### PR TITLE
feat: implementar banco de dados DynamoDB

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1,0 +1,175 @@
+# Database Module (`db`)
+
+Shared DynamoDB abstraction layer packaged as a Lambda Layer. Any Lambda function in this project can import it.
+
+## Architecture
+
+```
+layer/python/db/        ← Lambda Layer source (auto-deployed by Pulumi)
+├── __init__.py         ← Re-exports all modules
+├── client.py           ← DynamoDB connection (local or AWS)
+├── auth.py             ← Password hashing (PBKDF2, no external deps)
+├── email_sub.py        ← Email ↔ Sub mapping
+├── users.py            ← User profiles & preferences
+├── tokens.py           ← Email verification & password reset tokens (TTL)
+├── history.py          ← Movie recommendation history
+└── logs.py             ← User action audit log
+```
+
+## Tables
+
+| Table      | Partition Key | Sort Key    | TTL         | Purpose                        |
+|------------|---------------|-------------|-------------|--------------------------------|
+| email-to-sub | `email` (S) | —           | —           | Lookup sub by email            |
+| users      | `sub` (S)     | —           | —           | User profile, preferences      |
+| tokens     | `token` (S)   | —           | `expiresAt` | Verify-email, reset-password   |
+| history    | `sub` (S)     | `timestamp` (S) | —       | Movie recommendation log       |
+| logs       | `sub` (S)     | `timestamp` (S) | —       | All user actions               |
+
+## Using in Your Lambda Function
+
+### 1. Add the layer and env vars in `__main__.py`
+
+The existing `fn` Lambda already has the layer attached. For **new** Lambda functions:
+
+```python
+my_fn = aws.lambda_.Function("my-fn",
+    runtime="python3.9",
+    handler="my_handler.handler",
+    role=role.arn,
+    code=pulumi.FileArchive("./my_function"),
+    layers=[db_layer.arn],                              # ← attach the layer
+    environment=aws.lambda_.FunctionEnvironmentArgs(
+        variables=db_table_names,                       # ← pass all table names
+    ),
+)
+```
+
+### 2. Import and use in your handler
+
+```python
+from db import users, email_sub, history, logs, tokens, auth
+
+def handler(event, context):
+    # Create a user
+    password_hash = auth.hash_password("s3cret")
+    users.create(sub="abc-123", email="user@example.com", password_hash=password_hash)
+
+    # Look up sub by email
+    sub = email_sub.get_sub("user@example.com")
+
+    # Record a recommendation
+    history.add(sub="abc-123", movie_title="Inception")
+
+    # Get watch history
+    items = history.get_all(sub="abc-123", limit=10)
+
+    # Log an action
+    logs.add(sub="abc-123", action="recommend", metadata={"movie": "Inception"})
+
+    # Update preferences
+    users.update_preferences(sub="abc-123", preferences={
+        "streamingServices": ["Netflix", "Prime"],
+        "mood": "happy",
+        "ageRating": "PG-13",
+    })
+
+    # Add to watch later
+    users.add_to_watch_later(sub="abc-123", movie="The Matrix")
+
+    # Verify a password
+    user = users.get(sub="abc-123")
+    if auth.verify_password("s3cret", user["passwordHash"]):
+        print("Authenticated!")
+
+    return {"statusCode": 200, "body": "ok"}
+```
+
+## Local Development
+
+### 1. Start DynamoDB Local
+
+```bash
+docker compose up -d
+```
+
+### 2. Create tables
+
+```bash
+pip install boto3
+python scripts/create_local_tables.py
+```
+
+### 3. Set environment variables
+
+```bash
+export DYNAMODB_ENDPOINT=http://localhost:8000
+export DB_TABLE_EMAIL_SUB=email-to-sub
+export DB_TABLE_USERS=users
+export DB_TABLE_TOKENS=tokens
+export DB_TABLE_HISTORY=history
+export DB_TABLE_LOGS=logs
+```
+
+### 4. Test your handler locally
+
+```python
+# test_local.py
+import os
+os.environ["DYNAMODB_ENDPOINT"] = "http://localhost:8000"
+os.environ["DB_TABLE_USERS"] = "users"
+# ... set all table env vars ...
+
+import sys
+sys.path.insert(0, "layer/python")  # so 'from db import ...' works locally
+
+from db import users, auth
+users.create("test-sub", "test@test.com", auth.hash_password("123"))
+print(users.get("test-sub"))
+```
+
+## API Reference
+
+### `db.auth`
+- `hash_password(password: str) -> str` — Returns `"salt:hash"` hex string
+- `verify_password(password: str, stored_hash: str) -> bool`
+
+### `db.email_sub`
+- `put(email, sub)` — Link email to sub
+- `get_sub(email) -> str | None` — Lookup sub by email
+- `delete(email)` — Remove mapping
+
+### `db.users`
+- `create(sub, email, password_hash)` — New user (fails if exists)
+- `get(sub) -> dict | None` — Get user profile
+- `update(sub, **fields)` — Update any fields
+- `delete(sub)` — Delete user
+- `update_preferences(sub, preferences: dict)` — Replace preferences
+- `add_to_watch_later(sub, movie: str)` — Append to watch list
+- `remove_from_watch_later(sub, movie: str)` — Remove from watch list
+
+### `db.tokens`
+- `create(token, sub, token_type, expires_at)` — Create with TTL (epoch seconds)
+- `get(token) -> dict | None` — Get if not expired
+- `delete(token)` — Delete after use
+
+### `db.history`
+- `add(sub, movie_title, timestamp=None)` — Record recommendation
+- `get_all(sub, limit=None) -> list[dict]` — Newest first
+- `get_range(sub, start, end) -> list[dict]` — Between two ISO timestamps
+
+### `db.logs`
+- `add(sub, action, metadata=None, timestamp=None)` — Log an action
+- `get_all(sub, limit=None) -> list[dict]` — Newest first
+- `get_by_action(sub, action) -> list[dict]` — Filter by action type
+
+## Switching Local ↔ Production
+
+The **only** difference is the `DYNAMODB_ENDPOINT` environment variable:
+
+| Environment | `DYNAMODB_ENDPOINT`         | Table names                       |
+|-------------|----------------------------|-----------------------------------|
+| Local dev   | `http://localhost:8000`     | Fixed: `users`, `logs`, etc.      |
+| AWS (Pulumi)| *not set*                  | Pulumi-generated (auto via env vars) |
+
+When deployed via Pulumi, the table names are set automatically. Locally, you set them yourself to the plain names used in `create_local_tables.py`.

--- a/__main__.py
+++ b/__main__.py
@@ -3,8 +3,67 @@ import pulumi
 import pulumi_aws as aws
 import pulumi_aws_apigateway as apigateway
 
-# An execution role to use for the Lambda function
-role = aws.iam.Role("role", 
+# ---------------------------------------------------------------------------
+# DynamoDB Tables
+# ---------------------------------------------------------------------------
+
+email_sub_table = aws.dynamodb.Table("email-to-sub",
+    billing_mode="PAY_PER_REQUEST",
+    hash_key="email",
+    attributes=[aws.dynamodb.TableAttributeArgs(name="email", type="S")])
+
+users_table = aws.dynamodb.Table("users",
+    billing_mode="PAY_PER_REQUEST",
+    hash_key="sub",
+    attributes=[aws.dynamodb.TableAttributeArgs(name="sub", type="S")])
+
+tokens_table = aws.dynamodb.Table("tokens",
+    billing_mode="PAY_PER_REQUEST",
+    hash_key="token",
+    attributes=[aws.dynamodb.TableAttributeArgs(name="token", type="S")],
+    ttl=aws.dynamodb.TableTtlArgs(attribute_name="expiresAt", enabled=True))
+
+history_table = aws.dynamodb.Table("history",
+    billing_mode="PAY_PER_REQUEST",
+    hash_key="sub",
+    range_key="timestamp",
+    attributes=[
+        aws.dynamodb.TableAttributeArgs(name="sub", type="S"),
+        aws.dynamodb.TableAttributeArgs(name="timestamp", type="S"),
+    ])
+
+logs_table = aws.dynamodb.Table("logs",
+    billing_mode="PAY_PER_REQUEST",
+    hash_key="sub",
+    range_key="timestamp",
+    attributes=[
+        aws.dynamodb.TableAttributeArgs(name="sub", type="S"),
+        aws.dynamodb.TableAttributeArgs(name="timestamp", type="S"),
+    ])
+
+# Table name map — use this when setting Lambda environment variables
+db_table_names = {
+    "DB_TABLE_EMAIL_SUB": email_sub_table.name,
+    "DB_TABLE_USERS": users_table.name,
+    "DB_TABLE_TOKENS": tokens_table.name,
+    "DB_TABLE_HISTORY": history_table.name,
+    "DB_TABLE_LOGS": logs_table.name,
+}
+
+# ---------------------------------------------------------------------------
+# Lambda Layer (shared db module)
+# ---------------------------------------------------------------------------
+
+db_layer = aws.lambda_.LayerVersion("db-layer",
+    layer_name="db",
+    compatible_runtimes=["python3.9", "python3.10", "python3.11", "python3.12", "python3.13"],
+    code=pulumi.FileArchive("./layer"))
+
+# ---------------------------------------------------------------------------
+# IAM Role
+# ---------------------------------------------------------------------------
+
+role = aws.iam.Role("role",
     assume_role_policy=json.dumps({
         "Version": "2012-10-17",
         "Statement": [{
@@ -17,12 +76,42 @@ role = aws.iam.Role("role",
     }),
     managed_policy_arns=[aws.iam.ManagedPolicy.AWS_LAMBDA_BASIC_EXECUTION_ROLE])
 
-# A Lambda function to invoke
+# DynamoDB access policy for Lambda functions
+dynamodb_policy = aws.iam.RolePolicy("dynamodb-policy",
+    role=role.name,
+    policy=pulumi.Output.all(
+        email_sub_table.arn,
+        users_table.arn,
+        tokens_table.arn,
+        history_table.arn,
+        logs_table.arn,
+    ).apply(lambda arns: json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+            ],
+            "Resource": list(arns),
+        }],
+    })))
+
+# ---------------------------------------------------------------------------
+# Example Lambda function (existing)
+# ---------------------------------------------------------------------------
+
 fn = aws.lambda_.Function("fn",
     runtime="python3.9",
     handler="handler.handler",
     role=role.arn,
-    code=pulumi.FileArchive("./function"))
+    code=pulumi.FileArchive("./function"),
+    layers=[db_layer.arn],
+    environment=aws.lambda_.FunctionEnvironmentArgs(variables=db_table_names))
 
 # A REST API to route requests to HTML content and the Lambda function
 api = apigateway.RestAPI("api",
@@ -31,5 +120,14 @@ api = apigateway.RestAPI("api",
     apigateway.RouteArgs(path="/date", method=apigateway.Method.GET, event_handler=fn)
   ])
 
-# The URL at which the REST API will be served.
+# ---------------------------------------------------------------------------
+# Exports
+# ---------------------------------------------------------------------------
+
 pulumi.export("url", api.url)
+pulumi.export("db_layer_arn", db_layer.arn)
+pulumi.export("db_table_email_sub", email_sub_table.name)
+pulumi.export("db_table_users", users_table.name)
+pulumi.export("db_table_tokens", tokens_table.name)
+pulumi.export("db_table_history", history_table.name)
+pulumi.export("db_table_logs", logs_table.name)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  dynamodb-local:
+    image: amazon/dynamodb-local:latest
+    container_name: dynamodb-local
+    ports:
+      - "8000:8000"
+    command: "-jar DynamoDBLocal.jar -sharedDb -inMemory"

--- a/layer/python/db/__init__.py
+++ b/layer/python/db/__init__.py
@@ -1,0 +1,18 @@
+"""
+Database abstraction module for the movie recommendation platform.
+
+Usage in Lambda functions:
+    from db import users, history, logs, tokens, email_sub, auth
+
+Environment variables (set via Lambda config):
+    DB_TABLE_EMAIL_SUB  - EmailToSub table name
+    DB_TABLE_USERS      - Users table name
+    DB_TABLE_TOKENS     - Tokens table name
+    DB_TABLE_HISTORY    - History table name
+    DB_TABLE_LOGS       - Logs table name
+    DYNAMODB_ENDPOINT   - (optional) Local DynamoDB endpoint, e.g. http://localhost:8000
+"""
+
+from db import auth, email_sub, history, logs, tokens, users
+
+__all__ = ["users", "email_sub", "tokens", "history", "logs", "auth"]

--- a/layer/python/db/auth.py
+++ b/layer/python/db/auth.py
@@ -1,0 +1,25 @@
+"""Password hashing utilities using PBKDF2 (stdlib, no external deps)."""
+
+import hashlib
+import os
+import secrets
+
+
+def hash_password(password: str) -> str:
+    """Hash a password with a random salt. Returns 'salt:hash' hex string."""
+    salt = os.urandom(32)
+    key = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 100_000)
+    return salt.hex() + ":" + key.hex()
+
+
+def verify_password(password: str, stored_hash: str) -> bool:
+    """Verify a password against a stored 'salt:hash' string."""
+    try:
+        salt_hex, key_hex = stored_hash.split(":", 1)
+        salt = bytes.fromhex(salt_hex)
+        expected_key = bytes.fromhex(key_hex)
+    except (ValueError, AttributeError):
+        return False
+
+    key = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 100_000)
+    return secrets.compare_digest(key, expected_key)

--- a/layer/python/db/client.py
+++ b/layer/python/db/client.py
@@ -1,0 +1,31 @@
+"""
+DynamoDB client configuration.
+
+Set DYNAMODB_ENDPOINT to use DynamoDB Local (e.g. http://localhost:8000).
+When unset, uses the real AWS DynamoDB service.
+"""
+
+import os
+
+import boto3
+
+_ENDPOINT = os.environ.get("DYNAMODB_ENDPOINT")
+
+
+def _get_resource():
+    kwargs = {}
+    if _ENDPOINT:
+        kwargs["endpoint_url"] = _ENDPOINT
+        kwargs["region_name"] = os.environ.get("AWS_DEFAULT_REGION", "sa-east-1")
+    return boto3.resource("dynamodb", **kwargs)
+
+
+resource = _get_resource()
+
+
+def get_table(env_var: str):
+    """Get a DynamoDB Table object by its environment variable name."""
+    table_name = os.environ.get(env_var)
+    if not table_name:
+        raise RuntimeError(f"Environment variable {env_var} is not set")
+    return resource.Table(table_name)

--- a/layer/python/db/email_sub.py
+++ b/layer/python/db/email_sub.py
@@ -1,0 +1,26 @@
+"""EmailToSub table: maps email addresses to JWT sub identifiers."""
+
+from db.client import get_table
+
+TABLE_ENV = "DB_TABLE_EMAIL_SUB"
+
+
+def _table():
+    return get_table(TABLE_ENV)
+
+
+def put(email: str, sub: str):
+    """Link an email to a sub."""
+    _table().put_item(Item={"email": email, "sub": sub})
+
+
+def get_sub(email: str) -> str | None:
+    """Get the sub for an email. Returns None if not found."""
+    resp = _table().get_item(Key={"email": email})
+    item = resp.get("Item")
+    return item["sub"] if item else None
+
+
+def delete(email: str):
+    """Remove an email-to-sub mapping."""
+    _table().delete_item(Key={"email": email})

--- a/layer/python/db/history.py
+++ b/layer/python/db/history.py
@@ -1,0 +1,49 @@
+"""History table: stores movie recommendation history per user."""
+
+from datetime import datetime, timezone
+
+from boto3.dynamodb.conditions import Key
+
+from db.client import get_table
+
+TABLE_ENV = "DB_TABLE_HISTORY"
+
+
+def _table():
+    return get_table(TABLE_ENV)
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def add(sub: str, movie_title: str, timestamp: str | None = None):
+    """Record a movie recommendation for a user."""
+    _table().put_item(
+        Item={
+            "sub": sub,
+            "timestamp": timestamp or _now(),
+            "movieTitle": movie_title,
+        }
+    )
+
+
+def get_all(sub: str, limit: int | None = None) -> list[dict]:
+    """Get recommendation history for a user, newest first."""
+    kwargs = {
+        "KeyConditionExpression": Key("sub").eq(sub),
+        "ScanIndexForward": False,
+    }
+    if limit:
+        kwargs["Limit"] = limit
+    resp = _table().query(**kwargs)
+    return resp.get("Items", [])
+
+
+def get_range(sub: str, start: str, end: str) -> list[dict]:
+    """Get history between two ISO timestamps (inclusive)."""
+    resp = _table().query(
+        KeyConditionExpression=Key("sub").eq(sub) & Key("timestamp").between(start, end),
+        ScanIndexForward=False,
+    )
+    return resp.get("Items", [])

--- a/layer/python/db/logs.py
+++ b/layer/python/db/logs.py
@@ -1,0 +1,61 @@
+"""Logs table: records all user actions on the platform."""
+
+import json
+from datetime import datetime, timezone
+
+from boto3.dynamodb.conditions import Key
+
+from db.client import get_table
+
+TABLE_ENV = "DB_TABLE_LOGS"
+
+
+def _table():
+    return get_table(TABLE_ENV)
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def add(sub: str, action: str, metadata: dict | None = None, timestamp: str | None = None):
+    """
+    Log a user action.
+
+    Args:
+        sub: The user identifier.
+        action: Action name (e.g. 'login', 'recommend', 'update-preferences').
+        metadata: Optional dict of extra data about the action.
+        timestamp: Optional ISO timestamp; defaults to now.
+    """
+    item = {
+        "sub": sub,
+        "timestamp": timestamp or _now(),
+        "action": action,
+    }
+    if metadata:
+        item["metadata"] = json.loads(json.dumps(metadata, default=str))
+    _table().put_item(Item=item)
+
+
+def get_all(sub: str, limit: int | None = None) -> list[dict]:
+    """Get logs for a user, newest first."""
+    kwargs = {
+        "KeyConditionExpression": Key("sub").eq(sub),
+        "ScanIndexForward": False,
+    }
+    if limit:
+        kwargs["Limit"] = limit
+    resp = _table().query(**kwargs)
+    return resp.get("Items", [])
+
+
+def get_by_action(sub: str, action: str) -> list[dict]:
+    """Get logs for a user filtered by action type."""
+    resp = _table().query(
+        KeyConditionExpression=Key("sub").eq(sub),
+        FilterExpression="action = :a",
+        ExpressionAttributeValues={":a": action},
+        ScanIndexForward=False,
+    )
+    return resp.get("Items", [])

--- a/layer/python/db/tokens.py
+++ b/layer/python/db/tokens.py
@@ -1,0 +1,48 @@
+"""Tokens table: stores verification and password-reset tokens with TTL."""
+
+import time
+
+from db.client import get_table
+
+TABLE_ENV = "DB_TABLE_TOKENS"
+
+
+def _table():
+    return get_table(TABLE_ENV)
+
+
+def create(token: str, sub: str, token_type: str, expires_at: int):
+    """
+    Create a token.
+
+    Args:
+        token: The token string (partition key).
+        sub: The user's sub.
+        token_type: 'verify-email' or 'reset-password'.
+        expires_at: Unix timestamp (epoch seconds) for TTL expiration.
+    """
+    _table().put_item(
+        Item={
+            "token": token,
+            "sub": sub,
+            "type": token_type,
+            "expiresAt": expires_at,
+        }
+    )
+
+
+def get(token: str) -> dict | None:
+    """Get a token. Returns None if not found or expired."""
+    resp = _table().get_item(Key={"token": token})
+    item = resp.get("Item")
+    if not item:
+        return None
+    # DynamoDB TTL deletion is eventual; check manually too
+    if item.get("expiresAt", 0) < int(time.time()):
+        return None
+    return item
+
+
+def delete(token: str):
+    """Delete a token (e.g. after use)."""
+    _table().delete_item(Key={"token": token})

--- a/layer/python/db/users.py
+++ b/layer/python/db/users.py
@@ -1,0 +1,99 @@
+"""Users table: stores user profiles and preferences."""
+
+from datetime import datetime, timezone
+
+from db.client import get_table
+
+TABLE_ENV = "DB_TABLE_USERS"
+
+
+def _table():
+    return get_table(TABLE_ENV)
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def create(sub: str, email: str, password_hash: str):
+    """Create a new user."""
+    now = _now()
+    _table().put_item(
+        Item={
+            "sub": sub,
+            "email": email,
+            "passwordHash": password_hash,
+            "emailVerified": False,
+            "preferences": {},
+            "watchLater": [],
+            "createdAt": now,
+            "updatedAt": now,
+        },
+        ConditionExpression="attribute_not_exists(#s)",
+        ExpressionAttributeNames={"#s": "sub"},
+    )
+
+
+def get(sub: str) -> dict | None:
+    """Get a user by sub. Returns None if not found."""
+    resp = _table().get_item(Key={"sub": sub})
+    return resp.get("Item")
+
+
+def update(sub: str, **fields):
+    """Update arbitrary fields on a user. Pass field=value pairs."""
+    if not fields:
+        return
+    fields["updatedAt"] = _now()
+
+    expr_parts = []
+    names = {}
+    values = {}
+    for i, (key, val) in enumerate(fields.items()):
+        alias = f"#k{i}"
+        placeholder = f":v{i}"
+        expr_parts.append(f"{alias} = {placeholder}")
+        names[alias] = key
+        values[placeholder] = val
+
+    _table().update_item(
+        Key={"sub": sub},
+        UpdateExpression="SET " + ", ".join(expr_parts),
+        ExpressionAttributeNames=names,
+        ExpressionAttributeValues=values,
+    )
+
+
+def delete(sub: str):
+    """Delete a user."""
+    _table().delete_item(Key={"sub": sub})
+
+
+def update_preferences(sub: str, preferences: dict):
+    """Replace the user's preferences map."""
+    update(sub, preferences=preferences)
+
+
+def add_to_watch_later(sub: str, movie: str):
+    """Append a movie to the user's watch-later list."""
+    _table().update_item(
+        Key={"sub": sub},
+        UpdateExpression="SET #wl = list_append(if_not_exists(#wl, :empty), :movie), #u = :now",
+        ExpressionAttributeNames={"#wl": "watchLater", "#u": "updatedAt"},
+        ExpressionAttributeValues={
+            ":movie": [movie],
+            ":empty": [],
+            ":now": _now(),
+        },
+    )
+
+
+def remove_from_watch_later(sub: str, movie: str):
+    """Remove a movie from the watch-later list (by value)."""
+    user = get(sub)
+    if not user:
+        return
+    watch_later = user.get("watchLater", [])
+    if movie in watch_later:
+        watch_later.remove(movie)
+        update(sub, watchLater=watch_later)

--- a/scripts/create_local_tables.py
+++ b/scripts/create_local_tables.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Create DynamoDB tables on DynamoDB Local for development.
+
+Usage:
+    1. Start DynamoDB Local:  docker compose up -d
+    2. Run this script:       python scripts/create_local_tables.py
+    3. Set env vars and test your Lambda handlers locally.
+
+Environment variables used by the db module (set these for local dev):
+    export DYNAMODB_ENDPOINT=http://localhost:8000
+    export DB_TABLE_EMAIL_SUB=email-to-sub
+    export DB_TABLE_USERS=users
+    export DB_TABLE_TOKENS=tokens
+    export DB_TABLE_HISTORY=history
+    export DB_TABLE_LOGS=logs
+"""
+
+import boto3
+
+ENDPOINT = "http://localhost:8000"
+
+client = boto3.client("dynamodb", endpoint_url=ENDPOINT, region_name="sa-east-1")
+
+TABLES = [
+    {
+        "TableName": "email-to-sub",
+        "KeySchema": [{"AttributeName": "email", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "email", "AttributeType": "S"}],
+        "BillingMode": "PAY_PER_REQUEST",
+    },
+    {
+        "TableName": "users",
+        "KeySchema": [{"AttributeName": "sub", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "sub", "AttributeType": "S"}],
+        "BillingMode": "PAY_PER_REQUEST",
+    },
+    {
+        "TableName": "tokens",
+        "KeySchema": [{"AttributeName": "token", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "token", "AttributeType": "S"}],
+        "BillingMode": "PAY_PER_REQUEST",
+    },
+    {
+        "TableName": "history",
+        "KeySchema": [
+            {"AttributeName": "sub", "KeyType": "HASH"},
+            {"AttributeName": "timestamp", "KeyType": "RANGE"},
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "sub", "AttributeType": "S"},
+            {"AttributeName": "timestamp", "AttributeType": "S"},
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+    },
+    {
+        "TableName": "logs",
+        "KeySchema": [
+            {"AttributeName": "sub", "KeyType": "HASH"},
+            {"AttributeName": "timestamp", "KeyType": "RANGE"},
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "sub", "AttributeType": "S"},
+            {"AttributeName": "timestamp", "AttributeType": "S"},
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+    },
+]
+
+
+def main():
+    existing = client.list_tables()["TableNames"]
+    for table_def in TABLES:
+        name = table_def["TableName"]
+        if name in existing:
+            print(f"  Table '{name}' already exists, skipping.")
+        else:
+            client.create_table(**table_def)
+            print(f"  Created table '{name}'.")
+    print("\nAll tables ready. Set these env vars for local development:\n")
+    print("export DYNAMODB_ENDPOINT=http://localhost:8000")
+    print("export DB_TABLE_EMAIL_SUB=email-to-sub")
+    print("export DB_TABLE_USERS=users")
+    print("export DB_TABLE_TOKENS=tokens")
+    print("export DB_TABLE_HISTORY=history")
+    print("export DB_TABLE_LOGS=logs")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## O que foi feito

Implementação da camada de banco de dados do projeto usando DynamoDB, conforme o card do Kanban.

### Infraestrutura (Pulumi)

- 5 tabelas DynamoDB com billing PAY_PER_REQUEST (sem custo quando ocioso)
- Política IAM para que qualquer Lambda com o role do projeto acesse as tabelas
- Lambda Layer com módulo Python `db` para abstrair o acesso aos dados
- Nomes das tabelas exportados como outputs do Pulumi

### Tabelas

| Tabela | Chave primária | Sort key | Finalidade |
|--------|---------------|----------|------------|
| email-to-sub | `email` | — | Vincular email ao sub do JWT |
| users | `sub` | — | Perfil, preferências, assistir depois |
| tokens | `token` | — | Verificação de email e reset de senha (TTL) |
| history | `sub` | `timestamp` | Histórico de recomendações |
| logs | `sub` | `timestamp` | Registro de ações do usuário |

### Como usar na sua Lambda

**Python** — importar o módulo `db` do layer:
```python
from db import users, auth, history, logs