### PR TITLE
Sugestão de retorno para o endpoint get recommend

### DIFF
--- a/docs/openAPI.yaml
+++ b/docs/openAPI.yaml
@@ -64,6 +64,35 @@ components:
         movieTitle:
           type: string
 
+    Movie:
+      type: object
+      properties:
+        title:
+          type: string
+          format: string
+        year:
+          type: integer
+          format: int32
+        rated:
+          type: string
+          format: string
+        runtime:
+          type: integer
+          format: int32
+        genre:
+          type: array
+          items:
+            type: string
+        director:
+          type: string
+          format: string
+        poster:
+          type: string
+          format: string
+        rating:
+          type: number
+          format: double
+
 security:
   - bearerAuth: []
 
@@ -261,13 +290,11 @@ paths:
       summary: Obtém recomendações para o usuário
       responses:
         '200':
-          description: Lista de filmes recomendados
+          description: Lista um filmes recomendado
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: string # Pode ser atualizado para um objeto Movie se necessário
+                $ref: '#/components/schemas/Movie'
 
   /history:
     get:

--- a/docs/openAPI.yaml
+++ b/docs/openAPI.yaml
@@ -207,27 +207,23 @@ paths:
             description: Token inválido ou expirado
 
   /verify-email:
-    post: # Mudado de GET para POST para proteger o token no body
-      tags:
-        - Usuários
-      summary: Verifica o e-mail do usuário
-      security: []
-      requestBody:
-        required: true
-        content:
-          application/json:
+      get:
+        tags:
+          - Usuários
+        summary: Verifica o e-mail do usuário
+        security: []
+        parameters:
+          - in: query
+            name: token
+            required: true
             schema:
-              type: object
-              required: [token]
-              properties:
-                token:
-                  type: string
-                  description: Token de verificação lido da URL pelo frontend
-      responses:
-        '200':
-          description: E-mail verificado com sucesso
-        '400':
-          description: Token inválido ou expirado
+              type: string
+            description: Token de verificação de e-mail (NÃO o token JWT)
+        responses:
+          '200':
+            description: E-mail verificado com sucesso
+          '400':
+            description: Token inválido ou expirado
 
   /preferences:
     get:

--- a/docs/openAPI.yaml
+++ b/docs/openAPI.yaml
@@ -1,0 +1,317 @@
+openapi: 3.0.3
+info:
+  title: API de Plataforma de Recomendação de Filmes
+  description: Especificação da API para o sistema de usuários, histórico e recomendações implantado na AWS.
+  version: 1.0.0
+servers:
+  - url: https://api.seusistema.com.br/v1
+    description: AWS API Gateway (Produção)
+  - url: http://localhost:8080
+    description: Ambiente de Desenvolvimento Local
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Token JWT retornado no endpoint de login.
+
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string
+
+    UserCredentials:
+      type: object
+      required:
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          format: password
+
+    Preferences:
+      type: object
+      additionalProperties: true
+      description: Mapa de preferências do usuário (ex. generos favoritos, idioma, etc.)
+      example:
+        idioma: "pt-BR"
+        autoplay: true
+
+    HistoryItem:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        movieTitle:
+          type: string
+          
+    WatchLaterItem:
+      type: object
+      required:
+        - movieTitle
+      properties:
+        movieTitle:
+          type: string
+
+security:
+  - bearerAuth: []
+
+paths:
+  # ==========================================
+  # Ações de Conta de Usuário
+  # ==========================================
+  /register:
+    post:
+      tags:
+        - Usuários
+      summary: Registra um novo usuário
+      security: [] # Endpoint público
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserCredentials'
+      responses:
+        '201':
+          description: Usuário criado com sucesso
+        '400':
+          description: Dados inválidos ou e-mail já existente
+
+  /login:
+    post:
+      tags:
+        - Usuários
+      summary: Autentica o usuário e retorna o token
+      security: [] # Endpoint público
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserCredentials'
+      responses:
+        '200':
+          description: Login bem-sucedido
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                  sub:
+                    type: string
+        '401':
+          description: Credenciais inválidas
+
+  /change-email:
+    post:
+      tags:
+        - Usuários
+      summary: Altera o e-mail do usuário autenticado
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [newEmail]
+              properties:
+                newEmail:
+                  type: string
+                  format: email
+      responses:
+        '200':
+          description: E-mail alterado com sucesso (pode requerer nova verificação)
+
+  /change-password:
+    post:
+      tags:
+        - Usuários
+      summary: Altera a senha do usuário autenticado
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [oldPassword, newPassword]
+              properties:
+                oldPassword:
+                  type: string
+                  format: password
+                newPassword:
+                  type: string
+                  format: password
+      responses:
+        '200':
+          description: Senha alterada com sucesso
+
+  /lost-password:
+    post:
+      tags:
+        - Usuários
+      summary: Solicita link de recuperação de senha
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email]
+              properties:
+                email:
+                  type: string
+                  format: email
+      responses:
+        '200':
+          description: E-mail de recuperação enviado (se o e-mail existir)
+
+  /reset-password:
+      post:
+        tags:
+          - Usuários
+        summary: Redefine a senha usando um token
+        security: []
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [token, newPassword]
+                properties:
+                  token:
+                    type: string
+                    description: Token lido da URL pelo frontend
+                  newPassword:
+                    type: string
+                    format: password
+        responses:
+          '200':
+            description: Senha redefinida com sucesso
+          '400':
+            description: Token inválido ou expirado
+
+  /verify-email:
+    post: # Mudado de GET para POST para proteger o token no body
+      tags:
+        - Usuários
+      summary: Verifica o e-mail do usuário
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [token]
+              properties:
+                token:
+                  type: string
+                  description: Token de verificação lido da URL pelo frontend
+      responses:
+        '200':
+          description: E-mail verificado com sucesso
+        '400':
+          description: Token inválido ou expirado
+
+  /preferences:
+    get:
+      tags:
+        - Usuários
+      summary: Obtém as preferências do usuário
+      responses:
+        '200':
+          description: Mapa de preferências
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Preferences'
+    post:
+      tags:
+        - Usuários
+      summary: Atualiza as preferências do usuário
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Preferences'
+      responses:
+        '200':
+          description: Preferências atualizadas com sucesso
+
+  # ==========================================
+  # Ações de Recomendações e Histórico
+  # ==========================================
+  /recommend:
+    get:
+      tags:
+        - Catálogo
+      summary: Obtém recomendações para o usuário
+      responses:
+        '200':
+          description: Lista de filmes recomendados
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string # Pode ser atualizado para um objeto Movie se necessário
+
+  /history:
+    get:
+      tags:
+        - Catálogo
+      summary: Retorna o histórico de filmes assistidos (tabela Historico)
+      responses:
+        '200':
+          description: Histórico do usuário
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HistoryItem'
+
+  /watch-later:
+    get:
+      tags:
+        - Catálogo
+      summary: Retorna a lista de assistir mais tarde
+      responses:
+        '200':
+          description: Lista "watchLater"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WatchLaterItem'
+    post:
+      tags:
+        - Catálogo
+      summary: Adiciona um filme à lista de assistir mais tarde
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WatchLaterItem'
+      responses:
+        '200':
+          description: Filme adicionado com sucesso


### PR DESCRIPTION
# Sugestão de retorno para o endpoint get recommend

Criei um schema para filme dessa forma:

```
Movie:
      type: object
      properties:
        title:
          type: string
          format: string
        year:
          type: integer
          format: int32
        rated:
          type: string
          format: string
        runtime:
          type: integer
          format: int32
        genre:
          type: array
          items:
            type: string
        director:
          type: string
          format: string
        poster:
          type: string
          format: string
        rating:
          type: number
          format: double
```

Uma coisa que reparei que talvez seja um problema é que a classificação indicativa **rated** é padrão americano, se a gente for realmente levar a classificação indicativa como um parametro na hora de recomendar um filme, a gente vai ter que vê como traduzir isso para o nosso padrão de classificação.

Outra coisa que alterei é que o get recommend só deve retornar UM filme, antes estava como array