### PR TITLE
Implementacao endpoint (POST /register) #28

### DIFF
--- a/function/register.py
+++ b/function/register.py
@@ -1,0 +1,105 @@
+"""POST /register — public endpoint, no auth required.
+
+Required IAM permissions on Lambda role:
+  cognito-idp:AdminCreateUser
+  cognito-idp:AdminSetUserPassword
+
+Environment variables:
+  COGNITO_USER_POOL_ID, BASE_URL (optional), + shared db vars
+"""
+import json
+import os
+import secrets
+from datetime import datetime, timezone, timedelta
+
+import boto3
+from botocore.exceptions import ClientError
+
+from shared.db import email_to_sub, users, tokens, write_log
+from shared.response import ok, bad_request, forbidden, server_error
+
+cognito = boto3.client("cognito-idp")
+USER_POOL_ID = os.environ["COGNITO_USER_POOL_ID"]
+BASE_URL = os.environ.get("BASE_URL", "https://basic-movie-recommender.com/api/v1")
+
+
+def handler(event, context):
+    try:
+        body = json.loads(event.get("body") or "{}")
+    except json.JSONDecodeError:
+        return bad_request("Invalid JSON")
+
+    name     = (body.get("name") or "").strip()
+    email    = (body.get("email") or "").strip().lower()
+    password = body.get("password") or ""
+
+    if not name or len(name) < 3 or len(name) > 50:
+        return bad_request("name must be between 3 and 50 characters")
+    if not email or len(email) < 5 or len(email) > 255 or "@" not in email:
+        return bad_request("Invalid email")
+    if not password or len(password) < 6 or len(password) > 100:
+        return bad_request("password must be between 6 and 100 characters")
+
+    if email_to_sub().get_item(Key={"email": email}).get("Item"):
+        return forbidden("Email already registered")
+
+    try:
+        resp = cognito.admin_create_user(
+            UserPoolId=USER_POOL_ID,
+            Username=email,
+            UserAttributes=[
+                {"Name": "email",          "Value": email},
+                {"Name": "name",           "Value": name},
+                {"Name": "email_verified", "Value": "false"},
+            ],
+            MessageAction="SUPPRESS",
+        )
+        sub = next(
+            a["Value"]
+            for a in resp["User"]["Attributes"]
+            if a["Name"] == "sub"
+        )
+        cognito.admin_set_user_password(
+            UserPoolId=USER_POOL_ID,
+            Username=email,
+            Password=password,
+            Permanent=True,
+        )
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        if code == "UsernameExistsException":
+            return forbidden("Email already registered")
+        if code == "InvalidPasswordException":
+            return bad_request("Password does not meet requirements")
+        return server_error("Could not create user")
+
+    now = datetime.now(timezone.utc).isoformat()
+    expires_at = (datetime.now(timezone.utc) + timedelta(hours=24)).isoformat()
+    token_value = secrets.token_hex(32)  # 64 hex chars
+
+    users().put_item(Item={
+        "sub":           sub,
+        "email":         email,
+        "emailVerified": False,
+        "preferences": {
+            "genres":        [],
+            "subscriptions": [],
+            "ageRating":     None,
+            "humor":         None,
+        },
+        "watchLater": [],
+        "createdAt":  now,
+        "updatedAt":  now,
+    })
+    email_to_sub().put_item(Item={"email": email, "sub": sub})
+    tokens().put_item(Item={
+        "token":     token_value,
+        "sub":       sub,
+        "type":      "verify-email",
+        "expiresAt": expires_at,
+    })
+    write_log(sub, now, "REGISTER", {"email": email})
+
+    # TODO: send verification e-mail via SES instead of returning URL
+    verify_url = f"{BASE_URL}/verify-email?token={token_value}"
+    return ok({"verifyEmailUrl": verify_url})


### PR DESCRIPTION
## Summary
- Valida campos name, email e password
- Cria usuario no Cognito via admin_create_user + admin_set_user_password
- Grava registro em Users, EmailToSub e token de verificacao em Tokens (DynamoDB)
- Registra acao REGISTER nos Logs
- Retorna URL de verificacao de email (TODO: enviar via SES)

## Test plan
- [x] Campos faltando retornam 400
- [x] Email ja cadastrado retorna 403
- [x] Senha invalida no Cognito retorna 400
- [x] Registro valido cria usuario no Cognito e no DynamoDB e retorna 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)