### PR TITLE
Feature/issue 97 preferences

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -24,7 +24,7 @@ Ten sequential phases that ship a polished, design-faithful Next.js 16 + TypeScr
 - [x] **Phase 4: Login + Register UI** — Design-faithful auth screens with validation and the mock `lib/api/auth` Cognito-shaped seam (issue #93) — COMPLETED 2026-05-06
 - [x] **Phase 5: Auth Context + Protected Routes** — Global auth context, `RequireAuth` wrapper, localStorage rehydration, expiry redirect (issue #94) — COMPLETED 2026-05-06
 - [x] **Phase 6: Home / Hero** — Home screen using one of the 3 backdrop variants, CTA wired to `/recommendation` (issue #95) — COMPLETED 2026-05-06 (gradient variant)
-- [ ] **Phase 7: Recommendation Result** — Mocked recommendation result screen (poster, title, summary, metadata) (issue #96)
+- [x] **Phase 7: Recommendation Result** — Mocked recommendation result screen (poster, title, summary, metadata) (issue #96) — COMPLETED 2026-05-06
 - [ ] **Phase 8: Preferences** — Mocked, protected preferences screen (issue #97)
 - [ ] **Phase 9: History** — Mocked, protected history screen (issue #98)
 - [ ] **Phase 10: Watch Later** — Mocked, protected watch-later screen (issue #99)
@@ -241,7 +241,7 @@ Phases execute in numeric order: 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 →
 | 4. Login + Register UI | 5/5 | Complete | 2026-05-06 |
 | 5. Auth Context + Protected Routes | 2/2 | Complete | 2026-05-06 |
 | 6. Home / Hero | 1/1 | Complete | 2026-05-06 |
-| 7. Recommendation Result | 0/TBD | Not started | - |
+| 7. Recommendation Result | 1/1 | Complete | 2026-05-06 |
 | 8. Preferences | 0/TBD | Not started | - |
 | 9. History | 0/TBD | Not started | - |
 | 10. Watch Later | 0/TBD | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,14 +3,14 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: executing
-stopped_at: Phase 06 (home/hero) merged into frontend — starting Phase 07 (recommendation result)
-last_updated: "2026-05-06T08:00:00.000Z"
-last_activity: 2026-05-06 -- Phase 6 approved + merged (gradient backdrop variant chosen)
+stopped_at: Phase 07 (recommendation result) merged into frontend — starting Phase 08 (preferences)
+last_updated: "2026-05-06T09:00:00.000Z"
+last_activity: 2026-05-06 -- Phase 7 approved + merged (3D push-down CTA, fade-up animation)
 progress:
   total_phases: 10
-  completed_phases: 6
-  total_plans: 20
-  completed_plans: 20
+  completed_phases: 7
+  total_plans: 21
+  completed_plans: 21
   percent: 100
 ---
 
@@ -26,12 +26,12 @@ See: .planning/ROADMAP.md (created 2026-05-04)
 
 ## Current Position
 
-Phase: 07 (recommendation result) — STARTING
+Phase: 08 (preferences) — STARTING
 Plan: TBD
-Status: Phase 6 merged into frontend; planning Phase 7
-Last activity: 2026-05-06 -- Phase 6 approved + merged
+Status: Phase 7 merged into frontend; planning Phase 8
+Last activity: 2026-05-06 -- Phase 7 approved + merged
 
-Overall: 6/10 phases complete
+Overall: 7/10 phases complete
 
 ## Performance Metrics
 

--- a/.planning/phases/08-preferences/08-01-preferences-screen-PLAN.md
+++ b/.planning/phases/08-preferences/08-01-preferences-screen-PLAN.md
@@ -1,0 +1,172 @@
+---
+phase: 08
+plan: 01
+type: execute
+depends_on: []
+files_modified:
+  - frontend/web/lib/api/recommend.ts                                    # add RATINGS export
+  - frontend/web/components/Chip.tsx                                     # NEW generic toggle chip
+  - frontend/web/components/SectionCard.tsx                              # NEW titled card with helper
+  - frontend/web/app/(app)/(protected)/preferences/page.tsx              # replace Phase 5 stub with full screen
+autonomous: true
+requirements: [PREF-01, PREF-02, PREF-03, PREF-04, PREF-05]
+---
+
+<objective>
+Replace the Phase 5 `/preferences` stub with the design-faithful preferences screen. Four titled cards: Streaming services (chips), Default mood (chips), Maximum age rating (chips), Account (email + password + sign-out rows). Lives inside `(app)/(protected)/` so the Phase 5 RequireAuth gate already covers PREF-02.
+
+Per ROADMAP §"Phase 8 Notes": **read-only display this milestone — toggling chips updates local React state for visual feedback only, no persistence.** v2 (INTG-02) wires real Cognito user attributes via the seam.
+</objective>
+
+<context>
+@.planning/STATE.md
+@.planning/ROADMAP.md  §"Phase 8"
+@.planning/codebase/ARCHITECTURE.md  §"preferences shape divergence" (genres / subscriptions / ageRating / humor)
+@frontend/_design-reference/preferences.jsx
+@frontend/_design-reference/data.jsx  §RATINGS
+@frontend/web/lib/api/recommend.ts
+@frontend/web/lib/auth/AuthContext.tsx
+@frontend/web/app/(app)/(protected)/preferences/page.tsx
+</context>
+
+<tasks>
+
+<task name="1: Add RATINGS to recommend module">
+Edit `frontend/web/lib/api/recommend.ts`. Add after the MOODS export:
+
+```ts
+export const RATINGS = ["G", "PG", "PG-13", "R", "NC-17"] as const;
+export type Rating = (typeof RATINGS)[number];
+```
+
+That's it — single addition, mirrors the reference `data.jsx:240`. Future filter UIs and the recommendation flow can both consume.
+</task>
+
+<task name="2: Generic Chip primitive">
+Create `frontend/web/components/Chip.tsx`. Client Component (interactive — pressable buttons).
+
+Props:
+- `active?: boolean` (default false)
+- `onClick?: () => void`
+- `children: React.ReactNode`
+- `aria-pressed` automatic from `active`
+
+Visual:
+- Inactive: `bg-surface border border-border text-text-secondary hover:border-border-strong hover:text-text-primary`
+- Active: `bg-accent-soft border border-accent text-text-primary`
+- Common: `inline-flex items-center gap-2 px-3 h-9 rounded-md text-13 font-medium transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2`
+
+Reusable for ServiceChip, MoodChip, RatingChip — they're all the same chip with different children. The page will compose them.
+
+No DSGN-06 violations — pure tokens.
+</task>
+
+<task name="3: SectionCard primitive">
+Create `frontend/web/components/SectionCard.tsx`. Server Component.
+
+```tsx
+type SectionCardProps = {
+  title: string;
+  helper?: string;
+  children: React.ReactNode;
+};
+```
+
+Visual: `bg-surface border border-border rounded-xl p-6` (24px padding from reference).
+- Title: `font-display font-bold text-[17px] text-text-primary` (text-[17px] is the existing Phase 6+ escape hatch)
+- Helper (if present): `text-13 text-text-secondary mt-1.5 mb-4`
+- Children container: `mt-3.5` (no helper) or unset (with helper — already spaced)
+
+DSGN-06 escape hatches:
+- `text-[17px]` for title (already on the documented list)
+</task>
+
+<task name="4: /preferences full screen">
+Replace `frontend/web/app/(app)/(protected)/preferences/page.tsx` entirely. Client Component (uses local state for chip toggles + `useAuth` for email/signOut).
+
+Structure:
+```
+<div max-w-[880px] mx-auto px-6 md:px-10 py-10 md:py-14>
+  <p eyebrow>Account</p>
+  <h1 display>Preferences</h1>
+  <p subhead>Tune the recommendations. Changes save automatically.</p>
+
+  <div flex flex-col gap-4 mt-8>
+    <SectionCard title="Streaming services" helper="Only suggest things on services you actually have.">
+      <div flex flex-wrap gap-2.5>
+        {STREAMING_SERVICES.map → <Chip active onClick toggle>...</Chip>}
+      </div>
+    </SectionCard>
+
+    <SectionCard title="Default mood" helper="What you usually want. You can override per recommendation.">
+      <div flex flex-wrap gap-2>
+        {MOODS.map → <Chip>{m.icon} {m.label}</Chip>}
+      </div>
+    </SectionCard>
+
+    <SectionCard title="Maximum age rating" helper="We won't go beyond this.">
+      <div flex flex-wrap gap-2>
+        {RATINGS.map → <Chip active={r === rating} onClick={() => setRating(r)}>{r}</Chip>}
+      </div>
+    </SectionCard>
+
+    <SectionCard title="Account">
+      {/* Three rows separated by border-b border-border */}
+      Email row:    label "Email" + email value + helper "Email changes require…" + Change button (right)
+      Password row: label "Password" + "Last changed N months ago" + Change button (right)
+      Sign out row: label "Sign out" + "You'll need to sign back in to see your queue." + Sign out button (right, danger style)
+    </SectionCard>
+  </div>
+</div>
+```
+
+Defaults (matching reference):
+- services: `["netflix", "prime", "mubi"]`
+- moods: `["thoughtful", "chill"]`
+- rating: `"R"`
+
+Sign out:
+- Calls `useAuth().signOut()` then `router.push("/login")`
+- Button visual: `text-danger border-danger/40 hover:bg-danger/10`
+
+Email row:
+- Email value: `useAuth().user?.email ?? "demo@example.com"` (the latter is just a fallback, but RequireAuth means user is always present)
+
+Change buttons: visual only — `disabled` or no-op handler. Real flows are out of scope.
+
+DSGN-06 escape hatches (each with `// non-tokenized` comment):
+- Title size if not on Phase 2 scale (use `text-[36px]` per reference, between 28 and 40 — note inline)
+- Eyebrow recipe (already documented)
+- max-w-[880px] (already documented)
+</task>
+
+</tasks>
+
+<verification>
+After all tasks ship:
+- `cd frontend/web && pnpm tsc --noEmit && pnpm lint && pnpm build` exit 0
+- `/preferences` route still in static prerender list
+- Manual smoke (boot `pnpm dev`):
+  1. **PREF-02**: visit `/preferences` while signed-out → redirected to `/login?from=%2Fpreferences` (Phase 5 RequireAuth gate)
+  2. **PREF-01**: sign in, then `/preferences` → see eyebrow "Account", title "Preferences", subhead, four titled cards with chips and account rows
+  3. **PREF-03**: at 375 / 768 / 1440 — content column max-w-880 centers, padding scales, chips wrap, no horizontal scroll
+  4. **PREF-04**: theme tokens only — `git grep -nE 'className=.*#[0-9a-fA-F]{3,6}' -- 'app/(app)/(protected)/preferences/' 'components/Chip.tsx' 'components/SectionCard.tsx'` returns 0 hits
+  5. **PREF-05**: defaults render selected (services Netflix/Prime/Mubi highlighted, moods Thoughtful/Chill highlighted, rating R highlighted)
+  6. Click a chip → visual toggle (no persistence; navigate away + back resets to defaults)
+  7. Click Sign out → redirects to /login, AccountMenu state cleared
+  8. Email value reflects the signed-in user's email-prefix (full email shown in the row)
+</verification>
+
+<scope-cuts>
+- **Persistence** of chip selections — explicitly out of scope per ROADMAP. The seam swap to Cognito user attributes is a v2 concern.
+- **Change Email / Change Password buttons** — visual only, no flow. The reference shows them but doesn't define their interaction.
+- **Genres / Humor sections** — ARCHITECTURE.md mentions these as backend-implementation fields but the design reference's `preferences.jsx` shows mood chips (which map to "humor" loosely) and doesn't show a genres section. Match the design, not the backend schema, this milestone.
+</scope-cuts>
+
+<success_criteria>
+1. /preferences renders the design-faithful screen with all four cards.
+2. Unauth visitors get redirected (Phase 5 gate validated on a real screen).
+3. Sign out from inside the page works and clears the session.
+4. Theme tokens only.
+5. tsc / lint / build green.
+</success_criteria>

--- a/frontend/web/app/(app)/(protected)/preferences/page.tsx
+++ b/frontend/web/app/(app)/(protected)/preferences/page.tsx
@@ -1,20 +1,187 @@
+"use client";
+
 /**
- * Phase 5 (AUTH-09 test target, issue #94) — /preferences stub.
+ * Phase 8 (PREF-01..05, issue #97) — preferences screen.
  *
- * Placeholder so RequireAuth has a real protected URL to test the
- * unauth → /login → ?from=/preferences → return-after-signin flow.
- * Phase 8 (PREF-01..05) replaces this in place with the real screen.
+ * Lives inside (app)/(protected)/ so the Phase 5 RequireAuth gate guards
+ * unauthenticated visitors (PREF-02). Client Component — local React
+ * state for chip toggles + useAuth() for the email/sign-out row.
+ *
+ * Per ROADMAP §"Phase 8 Notes": read-only display this milestone.
+ * Toggles update local state for visual feedback only; no persistence.
+ * v2 (INTG-02) wires real Cognito user attributes.
+ *
+ * DSGN-06 escape hatches (each with // non-tokenized inline):
+ *   - max-w-[880px]              : column width primitive (already documented)
+ *   - text-[36px]                : page title — between Phase 2 steps (28/40)
+ *   - tracking-[0.18em]          : eyebrow letter-spacing (already documented)
  */
 
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { LogOut } from "lucide-react";
+import { Chip } from "@/components/Chip";
+import { SectionCard } from "@/components/SectionCard";
+import {
+  MOODS,
+  RATINGS,
+  STREAMING_SERVICES,
+  type Rating,
+} from "@/lib/api/recommend";
+import { useAuth } from "@/lib/auth/AuthContext";
+
+const EYEBROW = "text-12 font-medium tracking-[0.18em] uppercase text-text-muted";
+
 export default function PreferencesPage() {
+  const router = useRouter();
+  const { user, signOut } = useAuth();
+  const [services, setServices] = useState<string[]>([
+    "netflix",
+    "prime",
+    "mubi",
+  ]);
+  const [moods, setMoods] = useState<string[]>(["thoughtful", "chill"]);
+  const [rating, setRating] = useState<Rating>("R");
+
+  function toggleSet(arr: string[], value: string): string[] {
+    return arr.includes(value)
+      ? arr.filter((v) => v !== value)
+      : [...arr, value];
+  }
+
+  function handleSignOut() {
+    signOut();
+    router.push("/login");
+  }
+
+  const email = user?.email ?? "";
   return (
-    <div className="p-10">
-      <h1 className="font-display text-28 font-semibold text-text-primary">
+    <div className="max-w-[880px] mx-auto px-6 md:px-10 py-10 md:py-14">
+      <p className={`${EYEBROW} mb-2`}>Account</p>
+      {/* non-tokenized: text-[36px] page title — between Phase 2 steps (28/40) */}
+      <h1 className="font-display text-[36px] font-extrabold tracking-[-0.02em] leading-[1.05] text-text-primary">
         Preferences
       </h1>
       <p className="text-text-secondary text-14 mt-2">
-        Phase 8 (PREF-01..05) will fill this page.
+        Tune the recommendations. Changes save automatically.
       </p>
+
+      <div className="flex flex-col gap-4 mt-8">
+        <SectionCard
+          title="Streaming services"
+          helper="Only suggest things on services you actually have."
+        >
+          <div className="flex flex-wrap gap-2.5">
+            {STREAMING_SERVICES.map((s) => (
+              <Chip
+                key={s.id}
+                active={services.includes(s.id)}
+                onClick={() => setServices(toggleSet(services, s.id))}
+              >
+                <span className="font-display font-extrabold text-11">
+                  {s.glyph}
+                </span>
+                <span>{s.name}</span>
+              </Chip>
+            ))}
+          </div>
+        </SectionCard>
+
+        <SectionCard
+          title="Default mood"
+          helper="What you usually want. You can override per recommendation."
+        >
+          <div className="flex flex-wrap gap-2">
+            {MOODS.map((m) => (
+              <Chip
+                key={m.id}
+                active={moods.includes(m.id)}
+                onClick={() => setMoods(toggleSet(moods, m.id))}
+              >
+                <span aria-hidden>{m.icon}</span>
+                <span>{m.label}</span>
+              </Chip>
+            ))}
+          </div>
+        </SectionCard>
+
+        <SectionCard
+          title="Maximum age rating"
+          helper="We won't go beyond this."
+        >
+          <div className="flex flex-wrap gap-2">
+            {RATINGS.map((r) => (
+              <Chip
+                key={r}
+                active={r === rating}
+                onClick={() => setRating(r)}
+                className="min-w-16"
+              >
+                {r}
+              </Chip>
+            ))}
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Account">
+          <div className="flex flex-col gap-3.5">
+            <div className="flex items-center justify-between gap-4 pb-3.5 border-b border-border">
+              <div>
+                <p className="text-13 font-semibold text-text-primary">Email</p>
+                <p className="text-12 text-text-secondary mt-0.5">{email}</p>
+                <p className="text-11 text-text-muted mt-1">
+                  Email changes require confirmation from both old and new
+                  addresses.
+                </p>
+              </div>
+              <button
+                type="button"
+                disabled
+                className="shrink-0 inline-flex items-center justify-center px-3.5 h-9 rounded-md bg-surface-2 border border-border text-13 font-semibold text-text-secondary disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Change
+              </button>
+            </div>
+
+            <div className="flex items-center justify-between gap-4 pb-3.5 border-b border-border">
+              <div>
+                <p className="text-13 font-semibold text-text-primary">
+                  Password
+                </p>
+                <p className="text-12 text-text-secondary mt-0.5">
+                  Last changed 4 months ago
+                </p>
+              </div>
+              <button
+                type="button"
+                disabled
+                className="shrink-0 inline-flex items-center justify-center px-3.5 h-9 rounded-md bg-surface-2 border border-border text-13 font-semibold text-text-secondary disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Change
+              </button>
+            </div>
+
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-13 font-semibold text-text-primary">
+                  Sign out
+                </p>
+                <p className="text-12 text-text-secondary mt-0.5">
+                  You&apos;ll need to sign back in to see your queue.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={handleSignOut}
+                className="shrink-0 inline-flex items-center justify-center gap-1.5 px-3.5 h-9 rounded-md bg-danger/10 border border-danger/40 hover:border-danger text-13 font-semibold text-danger transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
+              >
+                <LogOut size={14} aria-hidden />
+                Sign out
+              </button>
+            </div>
+          </div>
+        </SectionCard>
+      </div>
     </div>
   );
 }

--- a/frontend/web/components/Chip.tsx
+++ b/frontend/web/components/Chip.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ * Phase 8 (PREF-01, issue #97) — generic toggle chip.
+ *
+ * Used by Preferences (services, moods, ratings) and (future) home FilterBar.
+ * Inactive: bordered surface; active: amber-soft fill + accent border.
+ */
+
+import type { ReactNode } from "react";
+
+type ChipProps = {
+  active?: boolean;
+  onClick?: () => void;
+  children: ReactNode;
+  className?: string;
+};
+
+export function Chip({
+  active = false,
+  onClick,
+  children,
+  className = "",
+}: ChipProps) {
+  const isInteractive = typeof onClick === "function";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={isInteractive ? active : undefined}
+      className={`
+        inline-flex items-center justify-center gap-2 px-3 h-9 rounded-md
+        text-13 font-medium
+        transition-colors duration-150
+        focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2
+        ${
+          active
+            ? "bg-accent-soft border border-accent text-text-primary"
+            : "bg-surface border border-border text-text-secondary hover:border-border-strong hover:text-text-primary"
+        }
+        ${className}
+      `}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/web/components/SectionCard.tsx
+++ b/frontend/web/components/SectionCard.tsx
@@ -1,0 +1,32 @@
+/**
+ * Phase 8 (PREF-01, issue #97) — titled card with optional helper text.
+ *
+ * Server Component — pure JSX. Used by Preferences for each section
+ * (Streaming services / Default mood / Max age rating / Account).
+ *
+ * DSGN-06 escape hatch:
+ *   - text-[17px] for the title — between Phase 2 type-scale steps (16/20)
+ */
+
+import type { ReactNode } from "react";
+
+type SectionCardProps = {
+  title: string;
+  helper?: string;
+  children: ReactNode;
+};
+
+export function SectionCard({ title, helper, children }: SectionCardProps) {
+  return (
+    <section className="bg-surface border border-border rounded-xl p-6">
+      {/* non-tokenized: text-[17px] title size — between Phase 2 steps */}
+      <h3 className="font-display font-bold text-[17px] text-text-primary">
+        {title}
+      </h3>
+      {helper && (
+        <p className="text-13 text-text-secondary mt-1.5 mb-4">{helper}</p>
+      )}
+      <div className={helper ? "" : "mt-3.5"}>{children}</div>
+    </section>
+  );
+}

--- a/frontend/web/lib/api/recommend.ts
+++ b/frontend/web/lib/api/recommend.ts
@@ -278,6 +278,9 @@ export const MOODS = [
   { id: "nostalgic", label: "Nostalgic", icon: "◌" },
 ] as const;
 
+export const RATINGS = ["G", "PG", "PG-13", "R", "NC-17"] as const;
+export type Rating = (typeof RATINGS)[number];
+
 const PICK_LATENCY_MS = 250;
 
 export const posterUrl = (m: Movie, w = 360, h = 540): string =>


### PR DESCRIPTION
This pull request completes Phase 7 (Recommendation Result) and begins Phase 8 (Preferences), introducing the full, design-faithful `/preferences` screen. It also adds two new reusable UI components (`Chip` and `SectionCard`), and updates the planning and state documents to reflect the project's progress. The new preferences screen is interactive (local state only) and matches the design reference, with four titled sections and proper theme token usage.

**Major updates to planning and state:**

- **Phase 7 marked complete, Phase 8 started:** The roadmap and state documents now show Phase 7 (Recommendation Result) as finished and Phase 8 (Preferences) as the current focus. Progress metrics have been updated accordingly. [[1]](diffhunk://#diff-50b07cc2a4b37b50419fd3b063aea1f5d1fe2a2b90a47254943677108d0008bbL27-R27) [[2]](diffhunk://#diff-50b07cc2a4b37b50419fd3b063aea1f5d1fe2a2b90a47254943677108d0008bbL244-R244) [[3]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40L6-R13) [[4]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40L29-R34)

**Preferences screen implementation:**

- **Full `/preferences` page:** The stub is replaced with a complete, interactive preferences screen under `frontend/web/app/(app)/(protected)/preferences/page.tsx`. It includes sections for streaming services, default mood, maximum age rating, and account actions. Chips update local state for visual feedback only (no persistence yet). Sign-out is functional; change email/password buttons are visual only.
- **New `Chip` component:** Adds a generic, reusable toggle chip component (`frontend/web/components/Chip.tsx`) used for service, mood, and rating selections.
- **New `SectionCard` component:** Adds a titled card component (`frontend/web/components/SectionCard.tsx`) to structure each preferences section.
- **RATINGS export for age ratings:** Adds a `RATINGS` constant and `Rating` type to `frontend/web/lib/api/recommend.ts` for use in the preferences UI and future filters.

**Planning documentation:**

- **Phase 8 plan document:** Adds a detailed plan for implementing the preferences screen, including objectives, context, tasks, verification steps, and scope cuts.