### PR TITLE
Feature/issue 98 history

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -25,7 +25,7 @@ Ten sequential phases that ship a polished, design-faithful Next.js 16 + TypeScr
 - [x] **Phase 5: Auth Context + Protected Routes** — Global auth context, `RequireAuth` wrapper, localStorage rehydration, expiry redirect (issue #94) — COMPLETED 2026-05-06
 - [x] **Phase 6: Home / Hero** — Home screen using one of the 3 backdrop variants, CTA wired to `/recommendation` (issue #95) — COMPLETED 2026-05-06 (gradient variant)
 - [x] **Phase 7: Recommendation Result** — Mocked recommendation result screen (poster, title, summary, metadata) (issue #96) — COMPLETED 2026-05-06
-- [ ] **Phase 8: Preferences** — Mocked, protected preferences screen (issue #97)
+- [x] **Phase 8: Preferences** — Mocked, protected preferences screen (issue #97) — COMPLETED 2026-05-06
 - [ ] **Phase 9: History** — Mocked, protected history screen (issue #98)
 - [ ] **Phase 10: Watch Later** — Mocked, protected watch-later screen (issue #99)
 
@@ -242,7 +242,7 @@ Phases execute in numeric order: 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 →
 | 5. Auth Context + Protected Routes | 2/2 | Complete | 2026-05-06 |
 | 6. Home / Hero | 1/1 | Complete | 2026-05-06 |
 | 7. Recommendation Result | 1/1 | Complete | 2026-05-06 |
-| 8. Preferences | 0/TBD | Not started | - |
+| 8. Preferences | 1/1 | Complete | 2026-05-06 |
 | 9. History | 0/TBD | Not started | - |
 | 10. Watch Later | 0/TBD | Not started | - |
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,14 +3,14 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: executing
-stopped_at: Phase 07 (recommendation result) merged into frontend — starting Phase 08 (preferences)
-last_updated: "2026-05-06T09:00:00.000Z"
-last_activity: 2026-05-06 -- Phase 7 approved + merged (3D push-down CTA, fade-up animation)
+stopped_at: Phase 08 (preferences) merged into frontend — starting Phase 09 (history)
+last_updated: "2026-05-06T10:00:00.000Z"
+last_activity: 2026-05-06 -- Phase 8 approved + merged
 progress:
   total_phases: 10
-  completed_phases: 7
-  total_plans: 21
-  completed_plans: 21
+  completed_phases: 8
+  total_plans: 22
+  completed_plans: 22
   percent: 100
 ---
 
@@ -26,12 +26,12 @@ See: .planning/ROADMAP.md (created 2026-05-04)
 
 ## Current Position
 
-Phase: 08 (preferences) — STARTING
+Phase: 09 (history) — STARTING
 Plan: TBD
-Status: Phase 7 merged into frontend; planning Phase 8
-Last activity: 2026-05-06 -- Phase 7 approved + merged
+Status: Phase 8 merged into frontend; planning Phase 9
+Last activity: 2026-05-06 -- Phase 8 approved + merged
 
-Overall: 7/10 phases complete
+Overall: 8/10 phases complete
 
 ## Performance Metrics
 

--- a/.planning/phases/09-history/09-01-history-screen-PLAN.md
+++ b/.planning/phases/09-history/09-01-history-screen-PLAN.md
@@ -1,0 +1,168 @@
+---
+phase: 09
+plan: 01
+type: execute
+depends_on: []
+files_modified:
+  - frontend/web/lib/api/history.ts                                       # NEW mock seam
+  - frontend/web/components/HistoryRow.tsx                                # NEW row primitive
+  - frontend/web/components/EmptyState.tsx                                # NEW shared (Phase 10 reuses)
+  - frontend/web/app/(app)/(protected)/history/page.tsx                   # NEW screen
+autonomous: true
+requirements: [HIST-01, HIST-02, HIST-03, HIST-04, HIST-05]
+---
+
+<objective>
+Ship the History screen at `/history` (inside `(app)/(protected)/`). Lists past recommendations grouped by time period (Today / Yesterday / Last week / Earlier). Each row shows poster thumb (60×90), title, when + mood + match%, and three actions (View, Bookmark, Delete). Mock seam (`lib/api/history.ts`) is shaped like a future Lambda response so v2 swap is one provider replacement.
+</objective>
+
+<context>
+@.planning/STATE.md
+@.planning/ROADMAP.md  §"Phase 9"
+@frontend/_design-reference/history-queue.jsx
+@frontend/web/lib/api/recommend.ts
+@frontend/web/app/(app)/(protected)/preferences/page.tsx
+</context>
+
+<tasks>
+
+<task name="1: Mock history module">
+Create `frontend/web/lib/api/history.ts`. Self-contained — does NOT import from auth. Imports `MOVIES`, `Movie` from `@/lib/api/recommend`.
+
+Exports:
+- `HistoryEntry` type:
+  ```ts
+  type HistoryEntry = {
+    id: string;          // unique entry ID (e.g. `${movieId}-${timestamp}`)
+    movie: Movie;        // denormalized for display; v2 backend may join
+    when: string;        // pre-formatted display label (e.g. "2h ago")
+    mood: string;        // mood active when recommended
+  };
+  ```
+- `HistoryGroup` type:
+  ```ts
+  type HistoryGroup = { label: string; entries: readonly HistoryEntry[] };
+  ```
+- `getHistory()`: async (~250ms latency), returns `readonly HistoryGroup[]`. 4 groups (Today / Yesterday / Last week / Earlier). 10 entries total. Uses `MOVIES.slice(...)` to seed. The display labels (when, mood) match the reference verbatim.
+
+Pure data + helpers. No localStorage. v2 swap point: replace getHistory with a real fetch.
+</task>
+
+<task name="2: HistoryRow primitive">
+Create `frontend/web/components/HistoryRow.tsx`. Client Component (uses local hover/state for delete).
+
+Props:
+- `entry: HistoryEntry`
+- `onDelete?: (id: string) => void` — optional; called on delete click
+- `onView?: () => void` — optional; called on poster/View click (defaults to navigate to /recommendation)
+
+Visual (from reference `history-queue.jsx:33-63`):
+- Outer: `flex items-center gap-4 p-3.5 rounded-xl bg-surface border border-border hover:border-border-strong transition-colors duration-150`
+- Poster: `w-15 h-[90px] rounded-md object-cover shrink-0 cursor-pointer` (60×90)
+- Middle column: `flex-1 min-w-0`
+  - Title: `text-15 font-semibold text-text-primary mb-1 truncate`
+  - Meta row: `text-12 text-text-muted flex flex-wrap gap-2.5 items-center`
+    - Clock icon + when
+    - 2px dot separator
+    - "Mood: {mood}"
+    - 2px dot separator
+    - Match%: `text-accent text-12`
+- Actions cluster: `flex gap-1.5 shrink-0`
+  - View: text button (ghost)
+  - Bookmark: 32×32 icon button (secondary)
+  - Trash: 32×32 icon button (ghost, text-text-muted)
+
+DSGN-06 escape hatches expected:
+- `w-15 h-[90px]` poster thumb size (60×90 is below the spacing scale's standard step 16/20/24)
+- 2×2px dot separators (`w-0.5 h-0.5 rounded-full bg-current`)
+- `text-15` body — between Phase 2 steps (14/16); could just use `text-14` to avoid the escape hatch
+- Action button widths `w-8` (32px) for icon-only buttons
+</task>
+
+<task name="3: EmptyState primitive">
+Create `frontend/web/components/EmptyState.tsx`. Server Component.
+
+Props:
+- `title: string`
+- `body: string`
+- `ctaLabel?: string`
+- `ctaHref?: string` (if both provided, renders a Link CTA)
+
+Visual:
+- Centered column inside a `bg-surface border border-border rounded-xl p-10 md:p-14 text-center`
+- Title (`font-display text-20 font-bold text-text-primary`)
+- Body (`text-14 text-text-secondary mt-2 max-w-[480px] mx-auto`)
+- CTA (if provided): primary-style Link, `mt-6 inline-flex items-center gap-2 px-5 h-12 rounded-md bg-accent hover:bg-accent-hover text-on-accent text-14 font-semibold`
+
+Reusable: Phase 10 (Watch Later) calls this with the queue-empty copy.
+</task>
+
+<task name="4: /history full screen">
+Create `frontend/web/app/(app)/(protected)/history/page.tsx`. Client Component (`useState` for the list, `useEffect` for the initial fetch, `useRouter` for view navigation).
+
+Layout (follows preferences page rhythm):
+```
+<div max-w-[920px] mx-auto px-6 md:px-10 py-10 md:py-14>
+  <p eyebrow>Library</p>
+  <h1 display>History</h1>
+  <p subhead>Every recommendation we've served you, with the mood and filters you had on.</p>
+
+  {loading ? <skeleton /> : groups.length === 0 ? <EmptyState ... /> : (
+    <div flex flex-col gap-8 mt-8>
+      {groups.map(g => (
+        <section key={g.label}>
+          <h2 group-label>{g.label}</h2>
+          <div flex flex-col gap-2>
+            {g.entries.map(e => <HistoryRow ... onDelete={...} onView={...} />)}
+          </div>
+        </section>
+      ))}
+    </div>
+  )}
+</div>
+```
+
+Group label visual:
+- `font-display font-bold text-14 text-text-secondary tracking-[0.02em] mb-3.5`
+- DSGN-06 note: tracking-[0.02em] is the reference recipe
+
+Behavior:
+- Fetch history via `getHistory()` on mount → set state
+- Local delete: filter the entry out of the in-memory state (visual feedback only; no persistence)
+- View: `router.push('/recommendation')` — re-rolls a new recommendation (Phase 7 doesn't take a movie ID; that's a v2 concern)
+- If after deletes all groups are empty, render the `<EmptyState>` with copy `"Your history is empty."` + body `"Recommendations you've gotten will show up here."` + CTA `"Pick a movie for me"` → href `/`
+
+Apply `animate-fade-up [animation-delay:60ms]` to the section list (Phase 7's animation utilities) for a small entrance polish.
+</task>
+
+</tasks>
+
+<verification>
+After all tasks ship:
+- `cd frontend/web && pnpm tsc --noEmit && pnpm lint && pnpm build` exit 0
+- `/history` route in static prerender list
+- Manual smoke (`pnpm dev`):
+  1. **HIST-02 (gate)**: visit `/history` while signed-out → redirected to `/login?from=%2Fhistory`
+  2. **HIST-01 (display)**: sign in → `/history` shows 4 groups (Today / Yesterday / Last week / Earlier) with 10 total rows, each with poster + title + meta strip + 3 action buttons
+  3. **HIST-03 (responsive)**: at 375 / 768 / 1440 — column max-w-920 centers, padding scales, meta row wraps cleanly, no horizontal scroll
+  4. **HIST-04 (tokens-only)**: `git grep -nE 'className=.*#[0-9a-fA-F]{3,6}' -- 'app/(app)/(protected)/history/' 'components/HistoryRow.tsx' 'components/EmptyState.tsx' 'lib/api/history.ts'` returns 0 hits
+  5. **HIST-05 (empty state)**: delete all 10 rows → EmptyState renders with the "Pick a movie for me" CTA → click navigates to /
+  6. Click View on any row → navigates to /recommendation (re-rolls)
+  7. Click Bookmark icon → no-op (visual placeholder, Phase 10 will wire if needed)
+</verification>
+
+<scope-cuts>
+- **Real "View" with movie ID**: Phase 7's /recommendation doesn't take an ID. Routing /recommendation/[id] is a v2 concern. Click navigates to /recommendation which re-rolls — acceptable for milestone.
+- **Bookmark persistence**: Phase 10 owns the watch-later list. The button is visual only here.
+- **Delete persistence**: local filter only, page reload restores the full list. Mock seam stays static.
+- **Filters / search**: not in the reference design. Skip.
+</scope-cuts>
+
+<success_criteria>
+1. /history renders the design-faithful screen with grouped rows.
+2. Phase 5 RequireAuth gate redirects unauth visitors.
+3. Empty state appears when all rows deleted.
+4. Theme tokens only.
+5. tsc / lint / build green.
+6. Responsive at 3 breakpoints.
+</success_criteria>

--- a/frontend/web/app/(app)/(protected)/history/page.tsx
+++ b/frontend/web/app/(app)/(protected)/history/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+/**
+ * Phase 9 (HIST-01..05, issue #98) — history screen.
+ *
+ * Lists past recommendations grouped by time period (Today / Yesterday /
+ * Last week / Earlier). Lives inside (app)/(protected)/ so the Phase 5
+ * RequireAuth gate covers HIST-02.
+ *
+ * Local-only delete: filters the entry from in-memory state. Persistence
+ * is a v2 concern (real backend writes through the recommend module).
+ *
+ * DSGN-06 escape hatches (each with // non-tokenized inline):
+ *   - max-w-[920px]              : column width primitive
+ *   - text-[36px]                : page title — between Phase 2 steps (28/40)
+ *   - tracking-[0.18em]          : eyebrow letter-spacing (already documented)
+ *   - tracking-[0.02em]          : group-label letter-spacing recipe
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { EmptyState } from "@/components/EmptyState";
+import { HistoryRow } from "@/components/HistoryRow";
+import { getHistory, type HistoryGroup } from "@/lib/api/history";
+
+const EYEBROW = "text-12 font-medium tracking-[0.18em] uppercase text-text-muted";
+
+export default function HistoryPage() {
+  const router = useRouter();
+  const [groups, setGroups] = useState<readonly HistoryGroup[] | null>(null);
+  const [removedIds, setRemovedIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const result = await getHistory();
+      if (!cancelled) setGroups(result);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const visibleGroups = useMemo(() => {
+    if (!groups) return [];
+    return groups
+      .map((g) => ({
+        label: g.label,
+        entries: g.entries.filter((e) => !removedIds.has(e.id)),
+      }))
+      .filter((g) => g.entries.length > 0);
+  }, [groups, removedIds]);
+
+  function handleDelete(id: string) {
+    setRemovedIds((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <div className="max-w-[920px] mx-auto px-6 md:px-10 py-10 md:py-14">
+      <p className={`${EYEBROW} mb-2`}>Library</p>
+      {/* non-tokenized: text-[36px] page title — between Phase 2 steps (28/40) */}
+      <h1 className="font-display text-[36px] font-extrabold tracking-[-0.02em] leading-[1.05] text-text-primary">
+        History
+      </h1>
+      <p className="text-text-secondary text-14 mt-2 mb-8">
+        Every recommendation we&apos;ve served you, with the mood and filters you
+        had on.
+      </p>
+
+      {groups === null ? (
+        <div className="flex flex-col gap-2 animate-pulse" aria-busy="true">
+          <div className="h-[118px] rounded-xl bg-surface" />
+          <div className="h-[118px] rounded-xl bg-surface" />
+          <div className="h-[118px] rounded-xl bg-surface" />
+        </div>
+      ) : visibleGroups.length === 0 ? (
+        <EmptyState
+          title="Your history is empty."
+          body="Recommendations you've gotten will show up here."
+          ctaLabel="Pick a movie for me"
+          ctaHref="/"
+        />
+      ) : (
+        <div className="flex flex-col gap-8 animate-fade-up [animation-delay:60ms]">
+          {visibleGroups.map((g) => (
+            <section key={g.label}>
+              {/* non-tokenized: tracking-[0.02em] is the reference group-label recipe */}
+              <h2 className="font-display font-bold text-14 text-text-secondary tracking-[0.02em] mb-3.5">
+                {g.label}
+              </h2>
+              <div className="flex flex-col gap-2">
+                {g.entries.map((e) => (
+                  <HistoryRow
+                    key={e.id}
+                    entry={e}
+                    onView={() => router.push("/recommendation")}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/web/components/EmptyState.tsx
+++ b/frontend/web/components/EmptyState.tsx
@@ -1,0 +1,36 @@
+/**
+ * Phase 9 (HIST-05, issue #98) — shared empty-state card.
+ *
+ * Server Component. Reused by Phase 10 (Watch Later) for the
+ * empty-queue card. Title + body + optional CTA Link.
+ */
+
+import Link from "next/link";
+
+type EmptyStateProps = {
+  title: string;
+  body: string;
+  ctaLabel?: string;
+  ctaHref?: string;
+};
+
+export function EmptyState({ title, body, ctaLabel, ctaHref }: EmptyStateProps) {
+  return (
+    <div className="bg-surface border border-border rounded-xl p-10 md:p-14 text-center">
+      <h2 className="font-display text-20 font-bold text-text-primary">
+        {title}
+      </h2>
+      <p className="text-text-secondary text-14 mt-2 max-w-[480px] mx-auto">
+        {body}
+      </p>
+      {ctaLabel && ctaHref && (
+        <Link
+          href={ctaHref}
+          className="inline-flex items-center justify-center mt-6 px-5 h-12 rounded-md bg-accent hover:bg-accent-hover text-on-accent text-14 font-semibold transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
+        >
+          {ctaLabel}
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/frontend/web/components/HistoryRow.tsx
+++ b/frontend/web/components/HistoryRow.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+/**
+ * Phase 9 (HIST-01, issue #98) — single history-list row.
+ *
+ * Poster thumb + title + meta strip (when / mood / match%) + 3 actions
+ * (View, Bookmark, Delete). Hover deepens the border.
+ *
+ * DSGN-06 escape hatches:
+ *   - h-[60px] / h-[90px]   : 60×90 poster thumb (below spacing scale)
+ *   - w-0.5 h-0.5           : 2×2 dot separator (already on the spacing scale)
+ *   - text-[15px]           : title body — between Phase 2 steps (14/16)
+ */
+
+import { Bookmark, Clock, Eye, Trash2 } from "lucide-react";
+import { posterUrl } from "@/lib/api/recommend";
+import type { HistoryEntry } from "@/lib/api/history";
+
+type HistoryRowProps = {
+  entry: HistoryEntry;
+  onView?: () => void;
+  onDelete?: (id: string) => void;
+};
+
+export function HistoryRow({ entry, onView, onDelete }: HistoryRowProps) {
+  const { movie, when, mood } = entry;
+
+  return (
+    <div className="flex items-center gap-4 p-3.5 rounded-xl bg-surface border border-border hover:border-border-strong transition-colors duration-150">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={posterUrl(movie, 120, 180)}
+        alt=""
+        loading="lazy"
+        onClick={onView}
+        /* non-tokenized: 60×90 poster thumb is below Phase 2 spacing scale */
+        className="w-[60px] h-[90px] rounded-md object-cover shrink-0 cursor-pointer bg-surface-2"
+      />
+
+      <div className="flex-1 min-w-0">
+        {/* non-tokenized: text-[15px] body — between Phase 2 steps (14/16) */}
+        <p className="text-[15px] font-semibold text-text-primary mb-1 truncate">
+          {movie.title}
+        </p>
+        <div className="text-12 text-text-muted flex flex-wrap gap-x-2.5 gap-y-1 items-center">
+          <span className="inline-flex items-center gap-1">
+            <Clock size={11} aria-hidden />
+            {when}
+          </span>
+          <span aria-hidden className="w-0.5 h-0.5 rounded-full bg-current" />
+          <span>Mood: {mood}</span>
+          <span aria-hidden className="w-0.5 h-0.5 rounded-full bg-current" />
+          <span className="text-accent">{movie.match}% match</span>
+        </div>
+      </div>
+
+      <div className="flex gap-1.5 shrink-0">
+        <button
+          type="button"
+          onClick={onView}
+          className="inline-flex items-center gap-1.5 px-3 h-9 rounded-md text-13 font-semibold text-text-secondary hover:text-text-primary transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
+        >
+          <Eye size={14} aria-hidden />
+          View
+        </button>
+        <button
+          type="button"
+          aria-label={`Save ${movie.title} to watch later`}
+          className="inline-flex items-center justify-center w-9 h-9 rounded-md bg-surface-2 border border-border hover:border-border-strong text-text-secondary hover:text-text-primary transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
+        >
+          <Bookmark size={14} aria-hidden />
+        </button>
+        <button
+          type="button"
+          onClick={() => onDelete?.(entry.id)}
+          aria-label={`Remove ${movie.title} from history`}
+          className="inline-flex items-center justify-center w-9 h-9 rounded-md text-text-muted hover:text-danger hover:bg-danger/10 transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
+        >
+          <Trash2 size={14} aria-hidden />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/web/lib/api/history.ts
+++ b/frontend/web/lib/api/history.ts
@@ -1,0 +1,77 @@
+/**
+ * Phase 9 (HIST-01..05, issue #98) — typed mock history seam.
+ *
+ * Self-contained module shaped like a future `getHistory` Lambda response.
+ * v2 (INTG-02) replaces `getHistory()` with a real fetch — every other
+ * consumer keeps working unchanged. Decoupled from `@/lib/api/auth` per
+ * ARCHITECTURE.md anti-pattern note.
+ *
+ * Display labels (when, mood) are pre-formatted in the mock; v2 will
+ * compute relative-time strings from real `recommendedAt` ISO timestamps.
+ */
+
+import { MOVIES, type Movie } from "@/lib/api/recommend";
+
+export type HistoryEntry = {
+  id: string;
+  movie: Movie;
+  when: string;
+  mood: string;
+};
+
+export type HistoryGroup = {
+  label: string;
+  entries: readonly HistoryEntry[];
+};
+
+const FETCH_LATENCY_MS = 250;
+
+function entry(movie: Movie | undefined, when: string, mood: string): HistoryEntry {
+  if (!movie) {
+    throw new Error("history seed references a movie outside MOVIES bounds");
+  }
+  return {
+    id: `${movie.id}-${when.replace(/\s+/g, "-").toLowerCase()}`,
+    movie,
+    when,
+    mood,
+  };
+}
+
+const GROUPS: readonly HistoryGroup[] = [
+  {
+    label: "Today",
+    entries: [
+      entry(MOVIES[0], "2h ago", "Thoughtful"),
+      entry(MOVIES[1], "8h ago", "Thoughtful"),
+    ],
+  },
+  {
+    label: "Yesterday",
+    entries: [
+      entry(MOVIES[2], "Sat 9:14 PM", "Chill"),
+      entry(MOVIES[3], "Sat 9:14 PM", "Funny"),
+    ],
+  },
+  {
+    label: "Last week",
+    entries: [
+      entry(MOVIES[4], "Tue", "Intense"),
+      entry(MOVIES[5], "Wed", "Romantic"),
+      entry(MOVIES[6], "Fri", "Adventurous"),
+    ],
+  },
+  {
+    label: "Earlier",
+    entries: [
+      entry(MOVIES[7], "Apr 2", "Nostalgic"),
+      entry(MOVIES[8], "Mar 28", "Thoughtful"),
+      entry(MOVIES[9], "Mar 17", "Scary"),
+    ],
+  },
+] as const;
+
+export async function getHistory(): Promise<readonly HistoryGroup[]> {
+  await new Promise((resolve) => setTimeout(resolve, FETCH_LATENCY_MS));
+  return GROUPS;
+}


### PR DESCRIPTION
This pull request implements Phase 9 of the project: the History screen, which allows users to view their past movie recommendations grouped by time period. It includes a new mock API seam, reusable UI primitives, and a fully responsive, design-faithful `/history` page. The roadmap and state documentation are also updated to reflect the completion of Phase 8 and the start of Phase 9.

**Phase 9: History Screen Implementation**

- **New History Screen and Supporting Components**
  - Added the `/history` page (`frontend/web/app/(app)/(protected)/history/page.tsx`), which displays past recommendations grouped by time period, supports local-only deletion, and uses animation for polish. Includes empty state handling when all entries are deleted.
  - Introduced the `HistoryRow` component (`frontend/web/components/HistoryRow.tsx`) to render each history entry with poster, title, meta info, and three actions (View, Bookmark, Delete).
  - Added a reusable `EmptyState` component (`frontend/web/components/EmptyState.tsx`) for empty queue scenarios, used here and in future phases.

- **Mock API and Data Layer**
  - Created a typed mock history API (`frontend/web/lib/api/history.ts`) that returns grouped history data, shaped for easy future backend integration.

**Project Management and Documentation**

- **Phase Progress Updates**
  - Updated `.planning/ROADMAP.md` and `.planning/STATE.md` to mark Phase 8 as complete and Phase 9 as started, incrementing plan/phase counts and updating progress metrics. [[1]](diffhunk://#diff-50b07cc2a4b37b50419fd3b063aea1f5d1fe2a2b90a47254943677108d0008bbL28-R28) [[2]](diffhunk://#diff-50b07cc2a4b37b50419fd3b063aea1f5d1fe2a2b90a47254943677108d0008bbL245-R245) [[3]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40L6-R13) [[4]](diffhunk://#diff-10c47d0e33270cc4a979d56198376cf3a9df6cc3a3c397ef7d5131afda869b40L29-R34)
  - Added a detailed plan file for Phase 9, outlining requirements, tasks, verification steps, and success criteria.