### PR TITLE
Fix: Simplificar shared/auth.py para confiar nos claims do API Gateway e corrigir empacotamento da Lambda Layer #120

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -140,16 +140,21 @@ env_vars = {
     "TOKENS_TABLE": tokens_table.name,
     "HISTORICO_TABLE": historico_table.name,
     "LOGS_TABLE": logs_table.name,
-    "USER_POOL_ID": user_pool.id,
-    "CLIENT_ID": user_pool_client.id,
 }
 
+# Lambda Layers extract to /opt/, but Python only adds /opt/python/ to sys.path.
+# AssetArchive places files at explicit paths so `from shared.X import Y` works.
 shared_layer = aws.lambda_.LayerVersion(
     "shared",
     layer_name="shared",
-    code=pulumi.FileArchive("./functions/shared"),
+    code=pulumi.AssetArchive({
+        "python/shared/__init__.py": pulumi.FileAsset("./functions/shared/__init__.py"),
+        "python/shared/auth.py":     pulumi.FileAsset("./functions/shared/auth.py"),
+        "python/shared/db.py":       pulumi.FileAsset("./functions/shared/db.py"),
+        "python/shared/response.py": pulumi.FileAsset("./functions/shared/response.py"),
+    }),
     compatible_runtimes=["python3.13"],
-    description="My shared utility functions",
+    description="shared utilities (db, auth, response)",
 )
 
 

--- a/__main__.py
+++ b/__main__.py
@@ -206,6 +206,7 @@ def create_route(path, method, lambda_func, auth_id=None):
         integration_type="AWS_PROXY",
         integration_method="POST",  # ATENÇÃO: a integração com Lambda proxy no AWS é sempre POST, não mude isso.
         integration_uri=lambda_func.invoke_arn,
+        payload_format_version="2.0",  # default is 1.0; v2.0 puts JWT claims at event.requestContext.authorizer.jwt.claims
     )
 
     aws.lambda_.Permission(

--- a/functions/conftest.py
+++ b/functions/conftest.py
@@ -24,8 +24,6 @@ def pytest_ignore_collect(collection_path, config):
 
 
 # --- Env vars set before any shared module import ---
-os.environ["COGNITO_USER_POOL_ID"] = "test-pool-id"
-os.environ["COGNITO_CLIENT_ID"] = "test-client-id"
 os.environ["USERS_TABLE"] = "Users_test"
 os.environ["EMAIL_TO_SUB_TABLE"] = "EmailToSub_test"
 os.environ["TOKENS_TABLE"] = "Tokens_test"

--- a/functions/shared/auth.py
+++ b/functions/shared/auth.py
@@ -1,37 +1,22 @@
-import os
-import jwt
-from jwt import PyJWKClient, InvalidTokenError
+"""Read the validated `sub` claim from the API Gateway JWT authorizer.
 
-REGION        = os.environ.get("AWS_REGION", "sa-east-1")
-USER_POOL_ID  = os.environ.get("COGNITO_USER_POOL_ID", "")
-CLIENT_ID     = os.environ.get("COGNITO_CLIENT_ID", "")
+The HTTP API Gateway is configured with a JWT authorizer (see __main__.py)
+that validates signature, audience, issuer, and expiry **before** invoking
+the Lambda. The validated claims are passed to the Lambda via
+`event.requestContext.authorizer.jwt.claims`.
 
-JWKS_URL = (
-    f"https://cognito-idp.{REGION}.amazonaws.com/{USER_POOL_ID}/.well-known/jwks.json"
-)
-ISSUER = f"https://cognito-idp.{REGION}.amazonaws.com/{USER_POOL_ID}"
-
-# Client is instantiated once per Lambda container; cache_jwk_set avoids
-# an HTTP round-trip on every warm invocation.
-_jwks_client = PyJWKClient(JWKS_URL, cache_jwk_set=True, lifespan=3600)
+This module only extracts `sub` from that struct. No JWKS fetch, no
+in-Lambda signature verification — those would be redundant work.
+"""
 
 
 def get_sub(event: dict) -> str | None:
-    """Return the Cognito sub from a valid Bearer JWT, or None."""
-    headers = event.get("headers") or {}
-    auth = headers.get("Authorization") or headers.get("authorization", "")
-    if not auth.startswith("Bearer "):
-        return None
-    token = auth[7:]
-    try:
-        signing_key = _jwks_client.get_signing_key_from_jwt(token)
-        claims = jwt.decode(
-            token,
-            signing_key.key,
-            algorithms=["RS256"],
-            audience=CLIENT_ID,
-            issuer=ISSUER,
-        )
-        return claims.get("sub")
-    except (InvalidTokenError, Exception):
-        return None
+    claims = (
+        (event.get("requestContext") or {})
+        .get("authorizer", {})
+        .get("jwt", {})
+        .get("claims")
+        or {}
+    )
+    sub = claims.get("sub")
+    return sub if sub else None

--- a/functions/shared/auth.py
+++ b/functions/shared/auth.py
@@ -11,12 +11,9 @@ in-Lambda signature verification — those would be redundant work.
 
 
 def get_sub(event: dict) -> str | None:
-    claims = (
-        (event.get("requestContext") or {})
-        .get("authorizer", {})
-        .get("jwt", {})
-        .get("claims")
-        or {}
-    )
+    authorizer = (event.get("requestContext") or {}).get("authorizer") or {}
+    # HTTP API v2 payload (`payload_format_version=2.0`): claims under "jwt"
+    # HTTP API v1 / REST API payload: claims directly on the authorizer
+    claims = authorizer.get("jwt", {}).get("claims") or authorizer.get("claims") or {}
     sub = claims.get("sub")
     return sub if sub else None

--- a/functions/shared/test_auth.py
+++ b/functions/shared/test_auth.py
@@ -44,3 +44,13 @@ def test_empty_sub_returns_none():
 
 def test_null_request_context():
     assert get_sub({"requestContext": None}) is None
+
+
+def test_payload_format_v1_claims():
+    # HTTP API v1 / REST API payload: claims directly on authorizer (no jwt nesting)
+    event = {
+        "requestContext": {
+            "authorizer": {"claims": {"sub": "v1-style-sub"}}
+        }
+    }
+    assert get_sub(event) == "v1-style-sub"

--- a/functions/shared/test_auth.py
+++ b/functions/shared/test_auth.py
@@ -1,51 +1,46 @@
-from unittest.mock import MagicMock
-
-import jwt
-from cryptography.hazmat.primitives.asymmetric import rsa
-
 from shared.auth import get_sub
 
 
-def _make_rs256_token(
-    sub="test-sub",
-    issuer="https://cognito-idp.sa-east-1.amazonaws.com/test-pool-id",
-    audience="test-client-id",
-):
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    token = jwt.encode(
-        {"sub": sub, "iss": issuer, "aud": audience},
-        private_key,
-        algorithm="RS256",
-    )
-    return token, private_key
+def _event_with_sub(sub):
+    return {
+        "requestContext": {
+            "authorizer": {
+                "jwt": {
+                    "claims": {"sub": sub, "email": "u@example.com"}
+                }
+            }
+        }
+    }
 
 
-def test_valid_bearer_token(monkeypatch):
-    token, private_key = _make_rs256_token()
-    mock_key = MagicMock()
-    mock_key.key = private_key.public_key()
-    mock_client = MagicMock()
-    mock_client.get_signing_key_from_jwt.return_value = mock_key
-    monkeypatch.setattr("shared.auth._jwks_client", mock_client)
-
-    event = {"headers": {"Authorization": f"Bearer {token}"}}
-    assert get_sub(event) == "test-sub"
+def test_returns_sub_from_claims():
+    assert get_sub(_event_with_sub("abc-123")) == "abc-123"
 
 
-def test_missing_authorization_header():
-    assert get_sub({"headers": {}}) is None
+def test_missing_request_context():
     assert get_sub({}) is None
 
 
-def test_non_bearer_authorization():
-    event = {"headers": {"Authorization": "Basic xyz"}}
+def test_missing_authorizer():
+    assert get_sub({"requestContext": {}}) is None
+
+
+def test_missing_jwt():
+    assert get_sub({"requestContext": {"authorizer": {}}}) is None
+
+
+def test_missing_claims():
+    assert get_sub({"requestContext": {"authorizer": {"jwt": {}}}}) is None
+
+
+def test_missing_sub_claim():
+    event = {"requestContext": {"authorizer": {"jwt": {"claims": {"email": "u@e.com"}}}}}
     assert get_sub(event) is None
 
 
-def test_malformed_token(monkeypatch):
-    mock_client = MagicMock()
-    mock_client.get_signing_key_from_jwt.side_effect = Exception("JWKS fetch failed")
-    monkeypatch.setattr("shared.auth._jwks_client", mock_client)
+def test_empty_sub_returns_none():
+    assert get_sub(_event_with_sub("")) is None
 
-    event = {"headers": {"Authorization": "Bearer garbage-token"}}
-    assert get_sub(event) is None
+
+def test_null_request_context():
+    assert get_sub({"requestContext": None}) is None


### PR DESCRIPTION
This pull request refactors how authentication is handled in Lambda functions by simplifying the extraction of the authenticated user’s `sub` (subject) claim from JWTs provided by API Gateway. It removes in-Lambda JWT validation logic, relying instead on API Gateway’s JWT authorizer, and updates the shared Lambda layer packaging. Related tests are rewritten to match the new approach.

**Authentication logic simplification:**

* The `get_sub` function in `shared/auth.py` is rewritten to extract the `sub` claim directly from the event’s `requestContext.authorizer.jwt.claims` (for HTTP API v2) or `requestContext.authorizer.claims` (for v1/REST API). All code related to local JWT validation, JWKS fetching, and signature verification is removed, since API Gateway already handles this.
* The test suite for `get_sub` is rewritten to cover the new logic, removing tests for JWT signature validation and focusing on various event payload shapes and missing data scenarios.

**Infrastructure and packaging updates:**

* The shared Lambda layer is now packaged using `pulumi.AssetArchive` to ensure files are placed under `python/shared/`, which aligns with Lambda’s `/opt/python/` path for imports. The layer description is updated for clarity.
* The API Gateway integration is explicitly set to use `payload_format_version="2.0"`, ensuring JWT claims are available under `event.requestContext.authorizer.jwt.claims` in Lambda events.

**Test and environment variable cleanup:**

* Test environment variables for Cognito user pool and client ID are removed from `functions/conftest.py`, as they are no longer needed for the simplified authentication logic.