### PR TITLE
feat: integrar front-end com Cognito (sign-up + confirm + login) #128

### DIFF
--- a/frontend/web/.env.example
+++ b/frontend/web/.env.example
@@ -1,1 +1,10 @@
-# Phase 1 ships zero env vars. Cognito / Lambda vars land in Phase 4+ when lib/api/ is filled.
+# Copy to .env.local and fill in from your Pulumi `dev` stack outputs.
+# Public on purpose — Cognito User Pool + Client IDs are not secrets;
+# the Pool's password policy + JWT-protected API enforce access.
+
+NEXT_PUBLIC_COGNITO_REGION=sa-east-1
+NEXT_PUBLIC_COGNITO_USER_POOL_ID=
+NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID=
+
+# API Gateway base URL (no trailing slash). Lambdas mount under /api/v1.
+NEXT_PUBLIC_API_BASE_URL=

--- a/frontend/web/app/(auth)/confirm/page.tsx
+++ b/frontend/web/app/(auth)/confirm/page.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+/**
+ * /confirm — email-code verification step for Cognito sign-up.
+ *
+ * Real Cognito sends a verification code to the email used at sign-up; the
+ * user is UNCONFIRMED until they enter it here. After confirmation the user
+ * still needs to sign in to obtain tokens, so this page funnels them to
+ * /login with a pre-filled email on success.
+ */
+
+import { Suspense, useState } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { ArrowRight, AlertCircle, CheckCircle2 } from "lucide-react";
+import { Field } from "@/components/Field";
+import {
+  CodeMismatchException,
+  confirmSignUp,
+  resendConfirmationCode,
+} from "@/lib/api/auth";
+
+export default function ConfirmPage() {
+  return (
+    <Suspense fallback={<div className="min-h-[400px]" aria-busy="true" />}>
+      <ConfirmForm />
+    </Suspense>
+  );
+}
+
+function ConfirmForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const initialEmail = searchParams.get("email") ?? "";
+  const from = searchParams.get("from");
+
+  const [email, setEmail] = useState(initialEmail);
+  const [code, setCode] = useState("");
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [resendNotice, setResendNotice] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (isSubmitting) return;
+
+    const errs: Record<string, string> = {};
+    if (!email.includes("@")) errs.email = "Enter a valid email";
+    if (code.trim().length < 4) errs.code = "Enter the code from your email";
+    setErrors(errs);
+    if (Object.keys(errs).length > 0) return;
+
+    setFormError(null);
+    setResendNotice(null);
+    setIsSubmitting(true);
+    try {
+      await confirmSignUp(email, code.trim());
+      const loginQuery = new URLSearchParams({ email, confirmed: "1" });
+      if (from) loginQuery.set("from", from);
+      router.push(`/login?${loginQuery.toString()}`);
+    } catch (err) {
+      if (err instanceof CodeMismatchException) {
+        setFormError("That code is invalid or expired. Try again or resend.");
+      } else {
+        setFormError("Could not confirm your account. Try again.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleResend() {
+    if (isResending) return;
+    if (!email.includes("@")) {
+      setErrors((prev) => ({ ...prev, email: "Enter a valid email" }));
+      return;
+    }
+    setFormError(null);
+    setResendNotice(null);
+    setIsResending(true);
+    try {
+      await resendConfirmationCode(email);
+      setResendNotice("We sent a fresh code to your email.");
+    } catch {
+      setFormError("Could not resend the code. Try again in a minute.");
+    } finally {
+      setIsResending(false);
+    }
+  }
+
+  return (
+    <>
+      {/* non-tokenized: text-[26px], tracking-[-0.02em], leading-[1.02] match the reference .display class — see UI-SPEC §Typography */}
+      <h1 className="font-display text-[26px] font-extrabold tracking-[-0.02em] leading-[1.02] text-center text-text-primary">
+        Check your email.
+      </h1>
+      {/* non-tokenized: text-[13px] is the auth-subtitle scale — see UI-SPEC §Typography */}
+      <p className="text-center text-text-secondary text-[13px] mt-1.5">
+        We sent a 6-digit code to confirm your address.
+      </p>
+
+      <form noValidate onSubmit={handleSubmit} className="flex flex-col gap-3.5 mt-6">
+        <Field
+          label="Email"
+          type="email"
+          name="email"
+          autoComplete="email"
+          value={email}
+          onChange={setEmail}
+          error={errors.email}
+          disabled={isSubmitting}
+        />
+        <Field
+          label="Verification code"
+          type="text"
+          name="code"
+          autoComplete="one-time-code"
+          value={code}
+          onChange={setCode}
+          error={errors.code}
+          hint="6 digits from your inbox"
+          disabled={isSubmitting}
+        />
+
+        {formError && (
+          <div
+            role="alert"
+            aria-live="polite"
+            className="flex items-center gap-2 bg-danger/10 border border-danger text-danger text-14 font-medium rounded-md px-3 py-2"
+          >
+            <AlertCircle size={16} />
+            <span>{formError}</span>
+          </div>
+        )}
+
+        {resendNotice && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex items-center gap-2 bg-accent/10 border border-accent text-accent text-14 font-medium rounded-md px-3 py-2"
+          >
+            <CheckCircle2 size={16} />
+            <span>{resendNotice}</span>
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          aria-busy={isSubmitting || undefined}
+          /* non-tokenized: tracking-[-0.005em] matches reference .btn class — see UI-SPEC §Typography */
+          className="h-14 flex items-center justify-center gap-2 bg-accent hover:bg-accent-hover text-on-accent text-16 font-semibold tracking-[-0.005em] rounded-md transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-90 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
+        >
+          {isSubmitting ? (
+            <>
+              Confirm
+              <span
+                className="w-4 h-4 rounded-full border-2 border-on-accent border-t-transparent animate-spin"
+                aria-hidden
+              />
+            </>
+          ) : (
+            <>
+              Confirm
+              <ArrowRight size={16} />
+            </>
+          )}
+        </button>
+      </form>
+
+      <div className="flex justify-between items-center mt-4 text-[13px]">
+        <button
+          type="button"
+          onClick={handleResend}
+          disabled={isResending}
+          className="text-accent font-semibold hover:underline focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2 rounded-sm disabled:opacity-60"
+        >
+          {isResending ? "Resending…" : "Resend code"}
+        </button>
+        <Link
+          href="/login"
+          className="text-text-secondary hover:text-text-primary transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2 rounded-sm"
+        >
+          Back to sign in
+        </Link>
+      </div>
+    </>
+  );
+}

--- a/frontend/web/app/(auth)/login/page.tsx
+++ b/frontend/web/app/(auth)/login/page.tsx
@@ -19,7 +19,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { ArrowRight, AlertCircle } from "lucide-react";
 import { Field } from "@/components/Field";
-import { NotAuthorizedException } from "@/lib/api/auth";
+import { NotAuthorizedException, UserNotConfirmedException } from "@/lib/api/auth";
 import { useAuth } from "@/lib/auth/AuthContext";
 
 const AUTH_PATHS = new Set(["/login", "/register", "/forgot"]);
@@ -48,11 +48,12 @@ function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { signIn } = useAuth();
-  const [email, setEmail] = useState("");
+  const [email, setEmail] = useState(searchParams.get("email") ?? "");
   const [password, setPassword] = useState("");
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [formError, setFormError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const justConfirmed = searchParams.get("confirmed") === "1";
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -71,8 +72,12 @@ function LoginForm() {
       await signIn({ email, password });
       router.push(safeReturnPath(searchParams.get("from")));
     } catch (err) {
-      // Collapse all unknown failures into the safe "Incorrect email or password."
-      // copy — never leak Cognito-internal messages (UI-SPEC §Interaction Contracts).
+      if (err instanceof UserNotConfirmedException) {
+        const from = searchParams.get("from");
+        const fromQuery = from ? `&from=${encodeURIComponent(from)}` : "";
+        router.push(`/confirm?email=${encodeURIComponent(email)}${fromQuery}`);
+        return;
+      }
       if (err instanceof NotAuthorizedException) {
         setFormError("Incorrect email or password.");
       } else {
@@ -124,6 +129,16 @@ function LoginForm() {
             Forgot password?
           </Link>
         </div>
+
+        {justConfirmed && !formError && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="text-accent text-12 font-medium text-center"
+          >
+            Your account is confirmed. Sign in to continue.
+          </div>
+        )}
 
         {formError && (
           <div

--- a/frontend/web/app/(auth)/register/page.tsx
+++ b/frontend/web/app/(auth)/register/page.tsx
@@ -21,7 +21,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { ArrowRight, AlertCircle } from "lucide-react";
 import { Field } from "@/components/Field";
-import { UsernameExistsException } from "@/lib/api/auth";
+import { InvalidPasswordException, UsernameExistsException } from "@/lib/api/auth";
 import { useAuth } from "@/lib/auth/AuthContext";
 
 const AUTH_PATHS = new Set(["/login", "/register", "/forgot"]);
@@ -71,15 +71,21 @@ function RegisterForm() {
     setFormError(null);
     setIsSubmitting(true);
     try {
-      await signUp({ email, password: pw1 });
-      router.push(safeReturnPath(searchParams.get("from")));
+      const result = await signUp({ email, password: pw1 });
+      const from = searchParams.get("from");
+      const fromQuery = from ? `&from=${encodeURIComponent(from)}` : "";
+      if (result.needsConfirmation) {
+        router.push(`/confirm?email=${encodeURIComponent(result.email)}${fromQuery}`);
+      } else {
+        router.push(safeReturnPath(from));
+      }
     } catch (err) {
-      // Collapse all unknown failures into the safe "An account with this email already exists."
-      // copy — never leak Cognito-internal messages (UI-SPEC §Interaction Contracts).
       if (err instanceof UsernameExistsException) {
         setFormError("An account with this email already exists.");
+      } else if (err instanceof InvalidPasswordException) {
+        setFormError(err.message || "Password does not meet the policy.");
       } else {
-        setFormError("An account with this email already exists.");
+        setFormError("Could not create your account. Try again.");
       }
     } finally {
       setIsSubmitting(false);

--- a/frontend/web/lib/api/auth.ts
+++ b/frontend/web/lib/api/auth.ts
@@ -1,24 +1,31 @@
 /**
- * Phase 4 (AUTH-04, AUTH-05, issue #93) — typed mock auth seam.
+ * Cognito-direct auth seam (Pattern B).
  *
- * Cognito-shaped surface that the real Cognito SDK will replace in v2 (INTG-01..04).
- * Persists registered users in `recommend-a.users` localStorage key (CONTEXT D-02);
- * persists the active session in `recommend-a.session` (CONTEXT D-04).
- * Throws Cognito-shaped error names: UsernameExistsException, NotAuthorizedException.
+ * Talks to the Cognito User Pool from the browser using amazon-cognito-identity-js.
+ * The SDK persists tokens in localStorage on its own keys
+ * (`CognitoIdentityServiceProvider.<clientId>.*`), so rehydrate is a matter of
+ * asking the pool for `getCurrentUser()` + `getSession()`.
  *
- * Module is import-safe (no top-level localStorage access — every read/write happens
- * inside an exported function). Tests may override MOCK_LATENCY_MS to [0, 0] (D-03).
+ * Public surface kept stable for the rest of the app:
+ *   - signUp / signIn / signOut / getSession
+ *   - confirmSignUp / resendConfirmationCode (new — real Cognito needs email verification)
+ *   - Session type
+ *   - UsernameExistsException / NotAuthorizedException / UserNotConfirmedException /
+ *     CodeMismatchException / InvalidPasswordException — typed error names so call
+ *     sites can branch without scraping message strings.
  *
- * Plain-text password storage in `recommend-a.users` is acceptable for this mock
- * (D-02): the real Cognito SDK in v2 will hold passwords server-side. This module
- * is the swap point — INTG-01 replaces these four exported functions one-for-one.
+ * getSession is now async because Cognito validates / refreshes tokens against the
+ * User Pool — that has always been an HTTP round-trip in disguise.
  */
 
-export const MOCK_LATENCY_MS = [400, 700] as const;
-export const SESSION_KEY = "recommend-a.session" as const;
-export const USERS_KEY = "recommend-a.users" as const;
-
-const ONE_HOUR_MS = 3_600_000;
+import {
+  AuthenticationDetails,
+  CognitoUser,
+  CognitoUserAttribute,
+  CognitoUserPool,
+  type CognitoUserSession,
+  type ISignUpResult,
+} from "amazon-cognito-identity-js";
 
 export type Session = {
   AccessToken: string;
@@ -30,135 +37,185 @@ export type Session = {
 
 type Credentials = { email: string; password: string };
 
-type UsersMap = Record<string, { password: string; sub: string }>;
-
 export class UsernameExistsException extends Error {
   override name = "UsernameExistsException" as const;
 }
-
 export class NotAuthorizedException extends Error {
   override name = "NotAuthorizedException" as const;
 }
-
-function delay(): Promise<void> {
-  const [min, max] = MOCK_LATENCY_MS;
-  if (max <= 0) return Promise.resolve();
-  const ms = Math.floor(min + Math.random() * (max - min));
-  return new Promise((resolve) => setTimeout(resolve, ms));
+export class UserNotConfirmedException extends Error {
+  override name = "UserNotConfirmedException" as const;
+}
+export class CodeMismatchException extends Error {
+  override name = "CodeMismatchException" as const;
+}
+export class InvalidPasswordException extends Error {
+  override name = "InvalidPasswordException" as const;
 }
 
-function readUsers(): UsersMap {
-  if (typeof window === "undefined") return {};
-  const raw = window.localStorage.getItem(USERS_KEY);
-  if (!raw) return {};
+let cachedPool: CognitoUserPool | null = null;
+function getPool(): CognitoUserPool {
+  if (cachedPool) return cachedPool;
+  const UserPoolId = process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID;
+  const ClientId = process.env.NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID;
+  if (!UserPoolId || !ClientId) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_COGNITO_USER_POOL_ID or NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID. Copy .env.example to .env.local.",
+    );
+  }
+  cachedPool = new CognitoUserPool({ UserPoolId, ClientId });
+  return cachedPool;
+}
+
+function translateError(err: unknown): Error {
+  const e = err as { name?: string; code?: string; message?: string };
+  const name = e?.name ?? e?.code ?? "";
+  const msg = e?.message ?? "Authentication failed.";
+  switch (name) {
+    case "UsernameExistsException":
+      return new UsernameExistsException(msg);
+    case "NotAuthorizedException":
+      return new NotAuthorizedException(msg);
+    case "UserNotConfirmedException":
+      return new UserNotConfirmedException(msg);
+    case "CodeMismatchException":
+    case "ExpiredCodeException":
+      return new CodeMismatchException(msg);
+    case "InvalidPasswordException":
+    case "InvalidParameterException":
+      return new InvalidPasswordException(msg);
+    default:
+      return err instanceof Error ? err : new Error(msg);
+  }
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  // ID/Access tokens are base64url-encoded JWTs; we only need the payload (claims).
+  // API Gateway already cryptographically validates this token before any Lambda
+  // sees it, so client-side we just read fields out of it.
+  const [, payload] = token.split(".");
+  if (!payload) return {};
+  const padded = payload.replace(/-/g, "+").replace(/_/g, "/");
   try {
-    const parsed = JSON.parse(raw);
-    // Defensive: reject non-object shapes (prototype-pollution / corruption guard).
-    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return {};
-    }
-    return parsed as UsersMap;
+    return JSON.parse(atob(padded));
   } catch {
     return {};
   }
 }
 
-function writeUsers(users: UsersMap): void {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(USERS_KEY, JSON.stringify(users));
-}
-
-function issueSession(email: string, sub: string): Session {
+function toSession(cognitoSession: CognitoUserSession): Session {
+  const idToken = cognitoSession.getIdToken().getJwtToken();
+  const accessToken = cognitoSession.getAccessToken().getJwtToken();
+  const refreshToken = cognitoSession.getRefreshToken().getToken();
+  const claims = decodeJwtPayload(idToken);
+  const expSeconds = typeof claims.exp === "number" ? claims.exp : 0;
   return {
-    AccessToken: crypto.randomUUID(),
-    IdToken: crypto.randomUUID(),
-    RefreshToken: crypto.randomUUID(),
-    ExpiresAt: Date.now() + ONE_HOUR_MS,
-    user: { email, sub },
+    AccessToken: accessToken,
+    IdToken: idToken,
+    RefreshToken: refreshToken,
+    ExpiresAt: expSeconds * 1000,
+    user: {
+      email: typeof claims.email === "string" ? claims.email : "",
+      sub: typeof claims.sub === "string" ? claims.sub : "",
+    },
   };
 }
 
-function writeSession(session: Session): void {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(SESSION_KEY, JSON.stringify(session));
-}
-
-export async function signUp({ email, password }: Credentials): Promise<Session> {
-  await delay();
-  const users = readUsers();
-  if (Object.prototype.hasOwnProperty.call(users, email)) {
-    throw new UsernameExistsException(
-      "An account with the given email already exists.",
+export function signUp({
+  email,
+  password,
+}: Credentials): Promise<{ email: string; needsConfirmation: boolean }> {
+  const pool = getPool();
+  const attrs = [new CognitoUserAttribute({ Name: "email", Value: email })];
+  return new Promise((resolve, reject) => {
+    pool.signUp(
+      email,
+      password,
+      attrs,
+      [],
+      (err: Error | undefined, result: ISignUpResult | undefined) => {
+        if (err || !result) {
+          reject(translateError(err));
+          return;
+        }
+        resolve({ email, needsConfirmation: !result.userConfirmed });
+      },
     );
-  }
-  const sub = crypto.randomUUID();
-  users[email] = { password, sub };
-  writeUsers(users);
-  const session = issueSession(email, sub);
-  writeSession(session);
-  return session;
+  });
 }
 
-export async function signIn({ email, password }: Credentials): Promise<Session> {
-  await delay();
-  const users = readUsers();
-  // Same error for unknown email AND wrong password — avoids user enumeration (D-02).
-  const record = Object.prototype.hasOwnProperty.call(users, email)
-    ? users[email]
-    : undefined;
-  if (!record || record.password !== password) {
-    throw new NotAuthorizedException("Incorrect email or password.");
-  }
-  const session = issueSession(email, record.sub);
-  writeSession(session);
-  return session;
+export function confirmSignUp(email: string, code: string): Promise<void> {
+  const user = new CognitoUser({ Username: email, Pool: getPool() });
+  return new Promise((resolve, reject) => {
+    user.confirmRegistration(code, false, (err) => {
+      if (err) {
+        reject(translateError(err));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export function resendConfirmationCode(email: string): Promise<void> {
+  const user = new CognitoUser({ Username: email, Pool: getPool() });
+  return new Promise((resolve, reject) => {
+    user.resendConfirmationCode((err) => {
+      if (err) {
+        reject(translateError(err));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export function signIn({ email, password }: Credentials): Promise<Session> {
+  const user = new CognitoUser({ Username: email, Pool: getPool() });
+  // The User Pool Client is created with ALLOW_USER_PASSWORD_AUTH only
+  // (see __main__.py: explicit_auth_flows). The SDK defaults to USER_SRP_AUTH,
+  // which the pool refuses with "USER_SRP_AUTH is not enabled for the client."
+  user.setAuthenticationFlowType("USER_PASSWORD_AUTH");
+  const auth = new AuthenticationDetails({ Username: email, Password: password });
+  return new Promise((resolve, reject) => {
+    user.authenticateUser(auth, {
+      onSuccess: (cognitoSession) => resolve(toSession(cognitoSession)),
+      onFailure: (err) => reject(translateError(err)),
+    });
+  });
 }
 
 export function signOut(): void {
   if (typeof window === "undefined") return;
-  // Removes session ONLY — recommend-a.users persists so a demo user can sign back in (D-04).
-  window.localStorage.removeItem(SESSION_KEY);
+  const user = getPool().getCurrentUser();
+  user?.signOut();
 }
 
-export function getSession(): Session | null {
-  if (typeof window === "undefined") return null;
-  const raw = window.localStorage.getItem(SESSION_KEY);
-  if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return null;
-    }
-    return parsed as Session;
-  } catch {
-    return null;
-  }
+export function getSession(): Promise<Session | null> {
+  if (typeof window === "undefined") return Promise.resolve(null);
+  const user = getPool().getCurrentUser();
+  if (!user) return Promise.resolve(null);
+  return new Promise((resolve) => {
+    user.getSession((err: Error | null, cognitoSession: CognitoUserSession | null) => {
+      if (err || !cognitoSession || !cognitoSession.isValid()) {
+        resolve(null);
+        return;
+      }
+      resolve(toSession(cognitoSession));
+    });
+  });
 }
 
 /**
- * AUTH-13 test hook (Phase 5) — backdates the persisted session's
- * ExpiresAt by 1s so the next AuthContext rehydrate detects expiry.
- * No-op when there's no session. Real Cognito (v2) replaces this with
- * refresh-token rotation; the rehydrate path doesn't change.
+ * Dev-only: signs the current user out so a reload exercises the logged-out
+ * rehydrate path. Real Cognito refreshes the IdToken automatically up to the
+ * refresh-token window, so backdating a timestamp the way the mock did would
+ * not force expiry — clearing the user is the closest equivalent test hook.
  */
 export function forceExpire(): void {
-  if (typeof window === "undefined") return;
-  const raw = window.localStorage.getItem(SESSION_KEY);
-  if (!raw) return;
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      parsed.ExpiresAt = Date.now() - 1000;
-      window.localStorage.setItem(SESSION_KEY, JSON.stringify(parsed));
-    }
-  } catch {
-    /* ignore */
-  }
+  signOut();
 }
 
-// Dev-only: expose forceExpire on window so manual smoke can run
-//   window.__authTest.forceExpire()
-// in devtools. Stripped from production bundles by NODE_ENV check.
 if (process.env.NODE_ENV !== "production" && typeof window !== "undefined") {
   (window as unknown as { __authTest?: { forceExpire: typeof forceExpire } }).__authTest = {
     forceExpire,

--- a/frontend/web/lib/auth/AuthContext.tsx
+++ b/frontend/web/lib/auth/AuthContext.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 /**
- * Phase 5 (AUTH-08, AUTH-10, AUTH-12, issue #94) — global auth context.
+ * Global auth context — wraps lib/api/auth (Cognito-direct seam) in a React
+ * context so chrome, pages, and protected routes can read auth state without
+ * prop-drilling.
  *
- * Wraps the typed mock seam (lib/api/auth.ts) in a React context so chrome,
- * pages, and protected routes can read auth state without prop-drilling.
- * The seam stays the swap point for v2 Cognito integration (INTG-01).
- *
- * Rehydrates from localStorage on mount; if the persisted session is past
- * its ExpiresAt timestamp, clears it and renders the logged-out tree.
+ * On mount: asks the Cognito SDK for the current user and validates/refreshes
+ * the session. signUp returns confirmation info instead of a session — the
+ * caller routes to /confirm and the session arrives via signIn after the user
+ * enters their email code.
  */
 
 import {
@@ -28,6 +28,7 @@ import {
 } from "@/lib/api/auth";
 
 type Credentials = { email: string; password: string };
+type SignUpResult = { email: string; needsConfirmation: boolean };
 
 type AuthContextValue = {
   session: Session | null;
@@ -35,7 +36,7 @@ type AuthContextValue = {
   isAuthenticated: boolean;
   user: { email: string; sub: string } | null;
   signIn: (creds: Credentials) => Promise<void>;
-  signUp: (creds: Credentials) => Promise<void>;
+  signUp: (creds: Credentials) => Promise<SignUpResult>;
   signOut: () => void;
 };
 
@@ -50,18 +51,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    // Rehydrate session from localStorage on mount. setState inside an effect
-    // is the documented pattern for syncing browser-only state into React —
-    // localStorage is unavailable during SSR.
-    /* eslint-disable react-hooks/set-state-in-effect */
-    const persisted = getSession();
-    if (persisted && persisted.ExpiresAt > Date.now()) {
-      setSession(persisted);
-    } else if (persisted) {
-      seamSignOut();
-    }
-    setIsLoading(false);
-    /* eslint-enable react-hooks/set-state-in-effect */
+    // Rehydrate session from Cognito on mount. The SDK validates / refreshes
+    // tokens against the User Pool, so this is async.
+    let cancelled = false;
+    getSession().then((persisted) => {
+      if (cancelled) return;
+      if (persisted) setSession(persisted);
+      setIsLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const signIn = useCallback(async (creds: Credentials) => {
@@ -69,10 +69,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setSession(next);
   }, []);
 
-  const signUp = useCallback(async (creds: Credentials) => {
-    const next = await seamSignUp(creds);
-    setSession(next);
-  }, []);
+  const signUp = useCallback(
+    async (creds: Credentials): Promise<SignUpResult> => seamSignUp(creds),
+    [],
+  );
 
   const signOut = useCallback(() => {
     seamSignOut();

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
+    "amazon-cognito-identity-js": "^6.3.16",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",

--- a/frontend/web/pnpm-lock.yaml
+++ b/frontend/web/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.4.1
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      amazon-cognito-identity-js:
+        specifier: ^6.3.16
+        version: 6.3.16
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -75,6 +78,19 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@aws-crypto/sha256-js@1.2.2':
+    resolution: {integrity: sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==}
+
+  '@aws-crypto/util@1.2.2':
+    resolution: {integrity: sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-utf8-browser@3.259.0':
+    resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -663,6 +679,10 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -987,6 +1007,9 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  amazon-cognito-identity-js@6.3.16:
+    resolution: {integrity: sha512-HPGSBGD6Q36t99puWh0LnptxO/4icnk2kqIQ9cTJ2tFQo5NMUnWQIgtrTAk8nm+caqUbjDzXzG56GBjI2tS6jQ==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1068,6 +1091,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.27:
     resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
     engines: {node: '>=6.0.0'}
@@ -1092,6 +1118,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@4.9.2:
+    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -1550,6 +1579,9 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  fast-base64-decode@1.0.0:
+    resolution: {integrity: sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1789,6 +1821,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1986,6 +2021,9 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -1995,6 +2033,9 @@ packages:
   isexe@3.1.5:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
+
+  isomorphic-unfetch@3.1.0:
+    resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
 
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
@@ -2006,6 +2047,9 @@ packages:
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-cookie@2.2.1:
+    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2290,6 +2334,15 @@ packages:
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
@@ -2867,6 +2920,9 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -2882,6 +2938,9 @@ packages:
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2936,6 +2995,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unfetch@4.2.0:
+    resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -2982,6 +3044,12 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3071,6 +3139,27 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@aws-crypto/sha256-js@1.2.2':
+    dependencies:
+      '@aws-crypto/util': 1.2.2
+      '@aws-sdk/types': 3.973.8
+      tslib: 1.14.1
+
+  '@aws-crypto/util@1.2.2':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-utf8-browser': 3.259.0
+      tslib: 1.14.1
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-utf8-browser@3.259.0':
+    dependencies:
+      tslib: 2.8.1
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3649,6 +3738,10 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -3940,6 +4033,16 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  amazon-cognito-identity-js@6.3.16:
+    dependencies:
+      '@aws-crypto/sha256-js': 1.2.2
+      buffer: 4.9.2
+      fast-base64-decode: 1.0.0
+      isomorphic-unfetch: 3.1.0
+      js-cookie: 2.2.1
+    transitivePeerDependencies:
+      - encoding
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -4039,6 +4142,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.27: {}
 
   body-parser@2.2.2:
@@ -4075,6 +4180,12 @@ snapshots:
       electron-to-chromium: 1.5.350
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer@4.9.2:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+      isarray: 1.0.0
 
   bundle-name@4.1.0:
     dependencies:
@@ -4674,6 +4785,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-base64-decode@1.0.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -4915,6 +5028,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -5086,11 +5201,20 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
   isexe@3.1.5: {}
+
+  isomorphic-unfetch@3.1.0:
+    dependencies:
+      node-fetch: 2.7.0
+      unfetch: 4.2.0
+    transitivePeerDependencies:
+      - encoding
 
   iterator.prototype@1.1.5:
     dependencies:
@@ -5104,6 +5228,8 @@ snapshots:
   jiti@2.7.0: {}
 
   jose@6.2.3: {}
+
+  js-cookie@2.2.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -5345,6 +5471,10 @@ snapshots:
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-fetch@3.3.2:
     dependencies:
@@ -5991,6 +6121,8 @@ snapshots:
     dependencies:
       tldts: 7.0.30
 
+  tr46@0.0.3: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -6012,6 +6144,8 @@ snapshots:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 
@@ -6086,6 +6220,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unfetch@4.2.0: {}
+
   unicorn-magic@0.3.0: {}
 
   universalify@2.0.1: {}
@@ -6139,6 +6275,13 @@ snapshots:
   vary@1.1.2: {}
 
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
Closes #128. Sub-issue de #127.

## Resumo

Substitui o mock `localStorage` de `frontend/web/lib/api/auth.ts` pela integração direta com o Cognito User Pool via `amazon-cognito-identity-js` (Pattern B — front-end fala direto com Cognito, sem Lambdas no caminho).

Foi testado ponta-a-ponta contra o pool `app-users-dev` (`sa-east-1_tGXGJ9gZy`): sign-up → e-mail com código → /confirm → /login → `/` autenticado, com `post_confirm-dev` criando as linhas em `Users_dev` + `EmailToSub_dev` + `Logs_dev` no DynamoDB.

## Mudanças

- **`lib/api/auth.ts`** — reescrito contra `CognitoUserPool`. Exporta:
  - `signUp(creds): Promise<{ email, needsConfirmation }>`
  - `confirmSignUp(email, code): Promise<void>`
  - `resendConfirmationCode(email): Promise<void>`
  - `signIn(creds): Promise<Session>`
  - `signOut(): void`
  - `getSession(): Promise<Session | null>` — agora **async** porque o SDK valida/refresha tokens contra o pool.
  - Classes tipadas para os erros: `UsernameExistsException`, `NotAuthorizedException`, `UserNotConfirmedException`, `CodeMismatchException`, `InvalidPasswordException`.
  - `setAuthenticationFlowType("USER_PASSWORD_AUTH")` no `signIn` — o pool client está configurado com `ALLOW_USER_PASSWORD_AUTH` apenas (SDK default é SRP, que dá `InvalidParameterException`).
- **`lib/auth/AuthContext.tsx`** — rehidratação async no `useEffect`; `signUp` no contexto agora retorna `{ email, needsConfirmation }` em vez de gravar sessão.
- **`app/(auth)/confirm/page.tsx`** (novo) — tela do código de verificação por e-mail, com botão "Resend code" e link "Back to sign in". Mesmo padrão visual de `/login` e `/register`.
- **`app/(auth)/register/page.tsx`** — após sign-up, redireciona para `/confirm?email=…&from=…`; trata `InvalidPasswordException`.
- **`app/(auth)/login/page.tsx`** — em `UserNotConfirmedException` redireciona para `/confirm`; pré-preenche e-mail vindo de `?email=`; banner "Your account is confirmed" quando `?confirmed=1`.
- **`.env.example`** — `NEXT_PUBLIC_COGNITO_REGION`, `NEXT_PUBLIC_COGNITO_USER_POOL_ID`, `NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID`, `NEXT_PUBLIC_API_BASE_URL`. Cópia local em `.env.local` (gitignored).
- `package.json` / `pnpm-lock.yaml` — `amazon-cognito-identity-js@6.3.16`.

## Como testar

```bash
cd frontend/web
cp .env.example .env.local   # preencher com os IDs do pool dev
pnpm install
pnpm dev
```

Em `http://localhost:3000`:

1. `/register` com e-mail real + senha forte (8+, upper+lower+digit+symbol — policy do pool).
2. Vai pra `/confirm?email=…`; pegar o código no inbox; confirmar.
3. Cai em `/login?email=…&confirmed=1`; entrar.
4. Cai em `/` autenticado; reload mantém sessão.
5. Verificar `Users_dev` no DynamoDB:

   ```bash
   aws dynamodb scan --table-name Users_dev --profile recommend-a
   ```

## Fora do escopo (issues separadas, ver #127)

- Wrapper `fetch` com `IdToken` injection (próxima sub-issue).
- Validador de senha do `/register` casar com a policy do Cognito.
- Fluxo `/forgot` real (Cognito `forgotPassword`).
- Build do front-end + gate S3/CloudFront para prod only.

## Notas

- Nenhum segredo no `.env.example`/`.env.local`: User Pool ID + Client ID são públicos por design — o pool tem password policy + o API Gateway tem JWT authorizer pra controle de acesso.
- `forceExpire()` dev-hook reescrito pra chamar `signOut()` (Cognito refresha tokens automaticamente; backdating de timestamp como no mock não força expiry de verdade).