### PR TITLE
ci: add prod deploy workflow for frontend + Pulumi infra

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,75 @@
+name: Deploy (prod)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: sa-east-1
+      AWS_DEFAULT_REGION: sa-east-1
+      PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+      PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+      UV_PROJECT_ENVIRONMENT: venv
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: frontend/web/.nvmrc
+          cache: pnpm
+          cache-dependency-path: frontend/web/pnpm-lock.yaml
+
+      - name: Install frontend deps
+        working-directory: frontend/web
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend (Next.js static export)
+        working-directory: frontend/web
+        env:
+          NEXT_PUBLIC_COGNITO_REGION: ${{ vars.NEXT_PUBLIC_COGNITO_REGION }}
+          NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
+          NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID }}
+          NEXT_PUBLIC_API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_BASE_URL }}
+        run: pnpm build
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Install Python deps into ./venv (where Pulumi.yaml expects)
+        run: uv sync --frozen
+
+      - name: Pulumi up
+        uses: pulumi/actions@v6
+        with:
+          command: up
+          stack-name: prod
+          work-dir: .
+          refresh: true

--- a/__main__.py
+++ b/__main__.py
@@ -541,7 +541,7 @@ stage = aws.apigatewayv2.Stage(
 
 bucket = aws.s3.Bucket(f"frontend-bucket-{env}")
 
-frontend_dir = "frontend"
+frontend_dir = "frontend/web/out"
 for root, dirs, files in os.walk(frontend_dir, followlinks=True):
     for file in files:
         file_path = os.path.join(root, file)

--- a/frontend/web/next.config.ts
+++ b/frontend/web/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "export",
+  trailingSlash: true,
+  images: { unoptimized: true },
 };
 
 export default nextConfig;


### PR DESCRIPTION
- next.config.ts: enable Next.js static export (output: 'export', trailingSlash for S3/CloudFront, unoptimized images since there is no Next.js image optimization server).
- __main__.py: swap frontend_dir from "frontend" (which would upload source .tsx + node_modules) to the Next.js export output at "frontend/web/out".
- .github/workflows/deploy-prod.yml: on push to main, build the Next.js bundle then run `pulumi up --stack prod`. Uses repo secrets for AWS + Pulumi auth; reads NEXT_PUBLIC_* values from repo variables (they are public IDs by design — User Pool / Client / API Gateway URL).

Required repo secrets:
  - AWS_ACCESS_KEY_ID
  - AWS_SECRET_ACCESS_KEY
  - PULUMI_CONFIG_PASSPHRASE
  - PULUMI_ACCESS_TOKEN  (Pulumi Cloud auth — see PR body)

Required repo variables:
  - NEXT_PUBLIC_COGNITO_REGION
  - NEXT_PUBLIC_COGNITO_USER_POOL_ID
  - NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID
  - NEXT_PUBLIC_API_BASE_URL