### PR TITLE
feat: integrate OMDB API into /recommend endpoint

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -404,6 +404,7 @@ env_vars = {
     "HISTORICO_TABLE": historico_table.name,
     "LOGS_TABLE": logs_table.name,
     "DISABLE_AUTH": "0",
+    "OMDB_API_KEY": config.get("omdbApiKey") or "",
 }
 
 disable_auth = config.get_bool("disableAuth")

--- a/functions/recommend/recommend.py
+++ b/functions/recommend/recommend.py
@@ -140,22 +140,49 @@ def _omdb_to_movie(data: dict) -> dict:
         "runtime": _safe_int(data.get("Runtime")),
         "poster": data.get("Poster", ""),
         "imdbRating": _safe_float(data.get("imdbRating")),
+        # OMDB doesn't expose streaming providers; placeholder for a future
+        # JustWatch/etc. enrichment pass.
         "streaming-services": [],
     }
 
 
-def _omdb_random_movie() -> dict | None:
+def _omdb_random_movie(preferences: dict | None = None) -> dict | None:
+    """Randomly sample OMDB by IMDb ID until a movie matches preferences.
+
+    `type=movie` filters series/episodes server-side so we don't waste retries
+    on non-movie IDs. When `preferences.genres` is non-empty, results must
+    overlap at least one user genre; otherwise we re-roll within the same
+    5-retry budget. If preferences are too restrictive (no match in budget),
+    returns None and the caller falls back to the curated catalogue.
+    """
+    user_genres = {
+        g.strip().lower()
+        for g in ((preferences or {}).get("genres") or [])
+        if g
+    }
     for _ in range(5):
         imdb_id = f"tt{random.randint(1, _OMDB_MAX_IMDB_ID):07d}"
         try:
             resp = requests.get(
                 "https://www.omdbapi.com/",
-                params={"apikey": OMDB_API_KEY, "i": imdb_id},
+                params={
+                    "apikey": OMDB_API_KEY,
+                    "i": imdb_id,
+                    "type": "movie",
+                },
                 timeout=5,
             )
             data = resp.json()
-            if data.get("Response") == "True":
-                return _omdb_to_movie(data)
+            if data.get("Response") != "True":
+                continue
+            movie = _omdb_to_movie(data)
+            if user_genres:
+                movie_genres = {
+                    g.strip().lower() for g in (movie["genre"] or "").split(",") if g.strip()
+                }
+                if not (user_genres & movie_genres):
+                    continue
+            return movie
         except Exception:
             continue
     return None
@@ -167,7 +194,7 @@ def _omdb_random_movie() -> dict | None:
 
 def _pick_movie(preferences: dict) -> dict:
     if OMDB_API_KEY:
-        movie = _omdb_random_movie()
+        movie = _omdb_random_movie(preferences)
         if movie:
             return movie
 

--- a/functions/recommend/recommend.py
+++ b/functions/recommend/recommend.py
@@ -1,20 +1,20 @@
 """GET /recommend — auth optional (works for anonymous and logged-in users).
 
-Recommendation engine is MOCKED. Replace _omdb_lookup() with a real
-OMDB API call when OMDB_API_KEY is set — see inconsistencias.md.
-
 Authenticated users:
-  - recommendations filtered by their stored preferences
+  - recommendations filtered by their stored preferences (fallback only)
   - result saved to Historico table
 Anonymous users:
-  - random recommendation from the full catalogue
+  - random recommendation
 
 Environment variables:
-  OMDB_API_KEY (optional, for future OMDB integration), + shared db/auth vars
+  OMDB_API_KEY — when set, queries OMDB API instead of fallback catalogue
+  DISABLE_AUTH — skips auth checks in dev
 """
 import os
 import random
 from datetime import datetime, timezone
+
+import requests
 
 from shared.auth import get_sub
 from shared.db import get_user, historico, write_log
@@ -22,94 +22,183 @@ from shared.response import ok, unauthorized
 
 OMDB_API_KEY = os.environ.get("OMDB_API_KEY")
 
+_OMDB_MAX_IMDB_ID = 37_287_335
+
 # ---------------------------------------------------------------------------
-# Mock catalogue — replace with OMDB lookup in production
+# Fallback catalogue — used when OMDB_API_KEY is absent or all retries fail
 # ---------------------------------------------------------------------------
-_MOCK_CATALOGUE = [
+_FALLBACK_CATALOGUE = [
     {
         "movieId": "tt0133093",
-        "title":   "The Matrix",
-        "genre":   "action",
-        "streaming-services": [
-            {"name": "Netflix",
-             "image": "https://assets.nflxext.com/us/ffe/siteui/common/icons/nficon2016.ico",
-             "url":   "https://www.netflix.com/title/20557937"},
-        ],
+        "title": "The Matrix",
+        "year": 1999,
+        "rated": "R",
+        "genre": "action",
+        "director": "The Wachowskis",
+        "runtime": 136,
+        "poster": "",
+        "imdbRating": 8.7,
+        "streaming-services": [],
     },
     {
         "movieId": "tt0816692",
-        "title":   "Interstellar",
-        "genre":   "sci-fi",
-        "streaming-services": [
-            {"name": "Amazon Prime",
-             "image": "https://www.amazon.com/favicon.ico",
-             "url":   "https://www.amazon.com/dp/B00TU9UFTS"},
-        ],
+        "title": "Interstellar",
+        "year": 2014,
+        "rated": "PG-13",
+        "genre": "sci-fi",
+        "director": "Christopher Nolan",
+        "runtime": 169,
+        "poster": "",
+        "imdbRating": 8.7,
+        "streaming-services": [],
     },
     {
         "movieId": "tt1375666",
-        "title":   "Inception",
-        "genre":   "sci-fi",
-        "streaming-services": [
-            {"name": "Netflix",
-             "image": "https://assets.nflxext.com/us/ffe/siteui/common/icons/nficon2016.ico",
-             "url":   "https://www.netflix.com/title/70131314"},
-        ],
+        "title": "Inception",
+        "year": 2010,
+        "rated": "PG-13",
+        "genre": "sci-fi",
+        "director": "Christopher Nolan",
+        "runtime": 148,
+        "poster": "",
+        "imdbRating": 8.8,
+        "streaming-services": [],
     },
     {
         "movieId": "tt0468569",
-        "title":   "The Dark Knight",
-        "genre":   "action",
-        "streaming-services": [
-            {"name": "HBO Max",
-             "image": "https://www.max.com/favicon.ico",
-             "url":   "https://www.max.com/movies/dark-knight/07938dc1-3e25-4b2e-b01e-f23b7eed5977"},
-        ],
+        "title": "The Dark Knight",
+        "year": 2008,
+        "rated": "PG-13",
+        "genre": "action",
+        "director": "Christopher Nolan",
+        "runtime": 152,
+        "poster": "",
+        "imdbRating": 9.0,
+        "streaming-services": [],
     },
     {
         "movieId": "tt0110912",
-        "title":   "Pulp Fiction",
-        "genre":   "crime",
-        "streaming-services": [
-            {"name": "Amazon Prime",
-             "image": "https://www.amazon.com/favicon.ico",
-             "url":   "https://www.amazon.com/dp/B001CWSITY"},
-        ],
+        "title": "Pulp Fiction",
+        "year": 1994,
+        "rated": "R",
+        "genre": "crime",
+        "director": "Quentin Tarantino",
+        "runtime": 154,
+        "poster": "",
+        "imdbRating": 8.9,
+        "streaming-services": [],
     },
     {
         "movieId": "tt0245429",
-        "title":   "Spirited Away",
-        "genre":   "animation",
-        "streaming-services": [
-            {"name": "Netflix",
-             "image": "https://assets.nflxext.com/us/ffe/siteui/common/icons/nficon2016.ico",
-             "url":   "https://www.netflix.com/title/60023642"},
-        ],
+        "title": "Spirited Away",
+        "year": 2001,
+        "rated": "PG",
+        "genre": "animation",
+        "director": "Hayao Miyazaki",
+        "runtime": 125,
+        "poster": "",
+        "imdbRating": 8.6,
+        "streaming-services": [],
     },
 ]
 
 _GENRE_INDEX: dict[str, list[dict]] = {}
-for _m in _MOCK_CATALOGUE:
+for _m in _FALLBACK_CATALOGUE:
     _GENRE_INDEX.setdefault(_m["genre"], []).append(_m)
 
 
 def _resolve_movie(movie_id: str) -> dict | None:
-    """Return a catalogue entry by movieId, or None if not found."""
-    return next((m for m in _MOCK_CATALOGUE if m["movieId"] == movie_id), None)
+    return next((m for m in _FALLBACK_CATALOGUE if m["movieId"] == movie_id), None)
 
+
+# ---------------------------------------------------------------------------
+# OMDB API integration
+# ---------------------------------------------------------------------------
+
+def _safe_int(value, default=0):
+    try:
+        return int(str(value).split()[0])
+    except (ValueError, AttributeError):
+        return default
+
+
+def _safe_float(value, default=0.0):
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return default
+
+
+def _omdb_to_movie(data: dict) -> dict:
+    return {
+        "movieId": data.get("imdbID", ""),
+        "title": data.get("Title", ""),
+        "year": _safe_int(data.get("Year")),
+        "rated": data.get("Rated", ""),
+        "genre": data.get("Genre", ""),
+        "director": data.get("Director", ""),
+        "runtime": _safe_int(data.get("Runtime")),
+        "poster": data.get("Poster", ""),
+        "imdbRating": _safe_float(data.get("imdbRating")),
+        "streaming-services": [],
+    }
+
+
+def _omdb_random_movie() -> dict | None:
+    for _ in range(5):
+        imdb_id = f"tt{random.randint(1, _OMDB_MAX_IMDB_ID):07d}"
+        try:
+            resp = requests.get(
+                "https://www.omdbapi.com/",
+                params={"apikey": OMDB_API_KEY, "i": imdb_id},
+                timeout=5,
+            )
+            data = resp.json()
+            if data.get("Response") == "True":
+                return _omdb_to_movie(data)
+        except Exception:
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Recommendation engine
+# ---------------------------------------------------------------------------
 
 def _pick_movie(preferences: dict) -> dict:
-    """Return one movie matching user preferences, or a random one."""
+    if OMDB_API_KEY:
+        movie = _omdb_random_movie()
+        if movie:
+            return movie
+
     genres = [g.lower() for g in (preferences.get("genres") or [])]
     candidates: list[dict] = []
     for g in genres:
         candidates.extend(_GENRE_INDEX.get(g, []))
-    pool = candidates or _MOCK_CATALOGUE
+    pool = candidates or _FALLBACK_CATALOGUE
     return random.choice(pool)
 
 
+def _public_movie(movie: dict) -> dict:
+    return {
+        "title": movie["title"],
+        "year": movie["year"],
+        "rated": movie["rated"],
+        "genre": movie["genre"],
+        "director": movie["director"],
+        "runtime": movie["runtime"],
+        "poster": movie["poster"],
+        "imdbRating": movie["imdbRating"],
+        "streaming-services": movie["streaming-services"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Lambda handler
+# ---------------------------------------------------------------------------
+
 def handler(event, context):
-    sub = get_sub(event)  # may be None for anonymous requests
+    sub = get_sub(event)
 
     if sub:
         user = get_user(sub)
@@ -123,19 +212,15 @@ def handler(event, context):
     else:
         prefs = {}
 
-    movie   = _pick_movie(prefs)
+    movie = _pick_movie(prefs)
     now_iso = datetime.now(timezone.utc).isoformat()
 
     if sub:
         historico().put_item(Item={
-            "sub":        sub,
-            "timestamp":  now_iso,
+            "sub": sub,
+            "timestamp": now_iso,
             "movieTitle": movie["title"],
         })
         write_log(sub, now_iso, "RECOMMEND", {"movieId": movie["movieId"]})
 
-    return ok({
-        "title":              movie["title"],
-        "genre":              movie["genre"],
-        "streaming-services": movie["streaming-services"],
-    })
+    return ok(_public_movie(movie))

--- a/functions/recommend/requirements.txt
+++ b/functions/recommend/requirements.txt
@@ -1,2 +1,3 @@
 boto3
 pyjwt[crypto]>=2.8,<3
+requests

--- a/functions/recommend/test_recommend.py
+++ b/functions/recommend/test_recommend.py
@@ -7,6 +7,19 @@ from conftest import setup_dynamodb_tables
 from shared.db import users, historico, logs
 from recommend import handler
 
+_OMDB_MOCK_MOVIE = {
+    "movieId": "tt9999999",
+    "title": "Test Movie",
+    "year": 2020,
+    "rated": "PG",
+    "genre": "comedy",
+    "director": "Test Director",
+    "runtime": 120,
+    "poster": "https://example.com/poster.jpg",
+    "imdbRating": 7.5,
+    "streaming-services": [],
+}
+
 
 @mock_aws
 def test_recommend_anonymous(monkeypatch):
@@ -16,8 +29,15 @@ def test_recommend_anonymous(monkeypatch):
     assert resp["statusCode"] == 200
     body = json.loads(resp["body"])
     assert "title" in body
+    assert "year" in body
+    assert "rated" in body
     assert "genre" in body
-    assert "streaming-services" in body
+    assert "director" in body
+    assert "runtime" in body
+    assert "poster" in body
+    assert "imdbRating" in body
+    assert body["streaming-services"] == []
+    assert "movieId" not in body
 
 
 @mock_aws
@@ -46,6 +66,7 @@ def test_recommend_authenticated_no_prefs(monkeypatch):
     assert resp["statusCode"] == 200
     body = json.loads(resp["body"])
     assert "title" in body
+    assert "year" in body
 
 
 @mock_aws
@@ -104,3 +125,72 @@ def test_recommend_writes_audit_log(monkeypatch):
 
     log_items = logs().query(KeyConditionExpression=Key("sub").eq("user-4"))["Items"]
     assert any(item["action"] == "RECOMMEND" for item in log_items)
+
+
+# --- OMDB integration tests ---
+
+
+@mock_aws
+def test_recommend_omdb_fetch_success(monkeypatch):
+    setup_dynamodb_tables()
+    monkeypatch.setattr("recommend.recommend.OMDB_API_KEY", "test-key")
+    monkeypatch.setattr("recommend.recommend.get_sub", lambda event: "user-omdb")
+    monkeypatch.setattr(
+        "recommend.recommend._omdb_random_movie",
+        lambda: _OMDB_MOCK_MOVIE,
+    )
+    users().put_item(Item={"sub": "user-omdb", "email": "omdb@test.com"})
+
+    resp = handler({}, None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["title"] == "Test Movie"
+    assert body["year"] == 2020
+    assert body["rated"] == "PG"
+    assert body["genre"] == "comedy"
+    assert body["director"] == "Test Director"
+    assert body["runtime"] == 120
+    assert body["poster"] == "https://example.com/poster.jpg"
+    assert body["imdbRating"] == 7.5
+    assert body["streaming-services"] == []
+    assert "movieId" not in body
+
+
+@mock_aws
+def test_recommend_omdb_exhausted_retries_falls_back(monkeypatch):
+    setup_dynamodb_tables()
+    monkeypatch.setattr("recommend.recommend.OMDB_API_KEY", "test-key")
+    monkeypatch.setattr("recommend.recommend.get_sub", lambda event: "user-fallback")
+    monkeypatch.setattr(
+        "recommend.recommend._omdb_random_movie",
+        lambda: None,
+    )
+    users().put_item(Item={"sub": "user-fallback", "email": "fallback@test.com"})
+
+    resp = handler({}, None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert "title" in body
+    assert "year" in body
+    assert "rated" in body
+    assert "genre" in body
+    assert "director" in body
+    assert "runtime" in body
+    assert body["streaming-services"] == []
+
+
+@mock_aws
+def test_recommend_omdb_anonymous(monkeypatch):
+    setup_dynamodb_tables()
+    monkeypatch.setattr("recommend.recommend.OMDB_API_KEY", "test-key")
+    monkeypatch.setattr("recommend.recommend.get_sub", lambda event: None)
+    monkeypatch.setattr(
+        "recommend.recommend._omdb_random_movie",
+        lambda: _OMDB_MOCK_MOVIE,
+    )
+
+    resp = handler({}, None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["title"] == "Test Movie"
+    assert body["genre"] == "comedy"

--- a/functions/recommend/test_recommend.py
+++ b/functions/recommend/test_recommend.py
@@ -137,7 +137,7 @@ def test_recommend_omdb_fetch_success(monkeypatch):
     monkeypatch.setattr("recommend.recommend.get_sub", lambda event: "user-omdb")
     monkeypatch.setattr(
         "recommend.recommend._omdb_random_movie",
-        lambda: _OMDB_MOCK_MOVIE,
+        lambda preferences=None: _OMDB_MOCK_MOVIE,
     )
     users().put_item(Item={"sub": "user-omdb", "email": "omdb@test.com"})
 
@@ -163,7 +163,7 @@ def test_recommend_omdb_exhausted_retries_falls_back(monkeypatch):
     monkeypatch.setattr("recommend.recommend.get_sub", lambda event: "user-fallback")
     monkeypatch.setattr(
         "recommend.recommend._omdb_random_movie",
-        lambda: None,
+        lambda preferences=None: None,
     )
     users().put_item(Item={"sub": "user-fallback", "email": "fallback@test.com"})
 
@@ -186,7 +186,7 @@ def test_recommend_omdb_anonymous(monkeypatch):
     monkeypatch.setattr("recommend.recommend.get_sub", lambda event: None)
     monkeypatch.setattr(
         "recommend.recommend._omdb_random_movie",
-        lambda: _OMDB_MOCK_MOVIE,
+        lambda preferences=None: _OMDB_MOCK_MOVIE,
     )
 
     resp = handler({}, None)
@@ -194,3 +194,108 @@ def test_recommend_omdb_anonymous(monkeypatch):
     body = json.loads(resp["body"])
     assert body["title"] == "Test Movie"
     assert body["genre"] == "comedy"
+
+
+# --- OMDB genre-preference filtering ---
+
+
+def _make_omdb_response(response_value: str, **fields):
+    """Build a stub requests.Response with .json() returning OMDB-shaped data."""
+    payload = {"Response": response_value, **fields}
+
+    class _Resp:
+        def json(self):
+            return payload
+
+    return _Resp()
+
+
+@mock_aws
+def test_recommend_omdb_honors_genre_preferences(monkeypatch):
+    """OMDB result is accepted only when its Genre overlaps preferences.genres."""
+    import recommend.recommend as r
+
+    setup_dynamodb_tables()
+    monkeypatch.setattr(r, "OMDB_API_KEY", "test-key")
+    monkeypatch.setattr(r, "get_sub", lambda event: "user-genre-ok")
+    users().put_item(
+        Item={
+            "sub": "user-genre-ok",
+            "email": "g@h.com",
+            "preferences": {"genres": ["action"]},
+        }
+    )
+
+    # First OMDB call returns a comedy (rejected — no overlap with "action"),
+    # second returns an action movie (accepted).
+    responses = iter(
+        [
+            _make_omdb_response("True", imdbID="tt0000001", Title="Some Comedy",
+                                Genre="Comedy, Romance"),
+            _make_omdb_response("True", imdbID="tt0000002", Title="Some Action",
+                                Genre="Action, Thriller"),
+        ]
+    )
+    monkeypatch.setattr(r.requests, "get", lambda *a, **kw: next(responses))
+
+    resp = handler({}, None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["title"] == "Some Action"
+    assert "Action" in body["genre"]
+
+
+@mock_aws
+def test_recommend_omdb_genre_mismatch_falls_back(monkeypatch):
+    """If 5 OMDB retries all return non-matching genres, fall back to catalogue."""
+    import recommend.recommend as r
+
+    setup_dynamodb_tables()
+    monkeypatch.setattr(r, "OMDB_API_KEY", "test-key")
+    monkeypatch.setattr(r, "get_sub", lambda event: "user-genre-strict")
+    users().put_item(
+        Item={
+            "sub": "user-genre-strict",
+            "email": "g@h.com",
+            "preferences": {"genres": ["animation"]},
+        }
+    )
+
+    # Every OMDB roll returns "Horror" — never overlaps with "animation".
+    monkeypatch.setattr(
+        r.requests,
+        "get",
+        lambda *a, **kw: _make_omdb_response(
+            "True", imdbID="tt0000001", Title="Horror Film", Genre="Horror"
+        ),
+    )
+
+    resp = handler({}, None)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    # Fallback catalogue has "Spirited Away" tagged "animation".
+    assert body["title"] == "Spirited Away"
+
+
+@mock_aws
+def test_recommend_omdb_filters_non_movies(monkeypatch):
+    """type=movie query parameter is sent on every OMDB call."""
+    import recommend.recommend as r
+
+    setup_dynamodb_tables()
+    monkeypatch.setattr(r, "OMDB_API_KEY", "test-key")
+    monkeypatch.setattr(r, "get_sub", lambda event: None)
+
+    captured_params: list[dict] = []
+
+    def _fake_get(*args, **kwargs):
+        captured_params.append(kwargs.get("params", {}))
+        return _make_omdb_response(
+            "True", imdbID="tt0000001", Title="A Movie", Genre="Drama"
+        )
+
+    monkeypatch.setattr(r.requests, "get", _fake_get)
+
+    handler({}, None)
+    assert captured_params, "expected at least one OMDB call"
+    assert captured_params[0].get("type") == "movie"


### PR DESCRIPTION
## Summary
- Replaces hardcoded mock catalogue with live OMDB API lookups using random IMDb ID generation
- Falls back to enriched fallback catalogue when OMDB is unavailable or key is not configured

## Changes
- **`functions/recommend/recommend.py`** — rewrite: OMDB fetch (random IMDb IDs tt0000001–tt37287335, 5 retries), response mapping to OpenAPI spec fields, fallback catalogue with full fields, public/private movie separation
- **`functions/recommend/requirements.txt`** — add `requests` dependency
- **`functions/recommend/test_recommend.py`** — updated assertions for new OpenAPI fields, 4 new OMDB-specific tests (success, exhausted retries, anonymous, movieId exclusion)
- **`__main__.py`** — inject `OMDB_API_KEY` from Pulumi stack config into Lambda env vars

## How it works
1. When `OMDB_API_KEY` is configured → generates random IMDb IDs, queries OMDB, retries up to 5 times
2. When all retries fail or key is absent → picks from 6-movie fallback catalogue
3. Response matches `docs/openapi.yaml` `/recommend` contract (9 fields)
4. `streaming-services` returned as empty placeholder `[]`

## Setup
```bash
pulumi config set --secret isn20261:omdbApiKey "your-omdb-key"
pulumi up --stack dev
```

Closes #53