### PR TITLE
fix(recommendation): guard initial fetch against Strict Mode double-effect

### DIFF
--- a/frontend/web/app/(app)/recommendation/page.tsx
+++ b/frontend/web/app/(app)/recommendation/page.tsx
@@ -58,6 +58,12 @@ export default function RecommendationPage() {
   const [saved, setSaved] = useState(false);
   const [saveError, setSaveError] = useState<ApiError | null>(null);
   const inFlight = useRef(false);
+  // React 18 Strict Mode runs effects setup→cleanup→setup in dev. The
+  // `cancelled` flag below only suppresses state updates from the first run;
+  // it does NOT cancel the in-flight network call, so /recommend would fire
+  // twice and the Lambda would record both in history. This ref persists
+  // across the simulated remount and short-circuits the second invocation.
+  const initialFetchFired = useRef(false);
 
   // Wires error-class-aware UX for both the recommendation fetch and the
   // watch-later save call (toast for network/server/forbidden, no-op for
@@ -66,6 +72,8 @@ export default function RecommendationPage() {
   useApiErrorUx(saveError);
 
   useEffect(() => {
+    if (initialFetchFired.current) return;
+    initialFetchFired.current = true;
     let cancelled = false;
     void (async () => {
       setStatus("loading");

--- a/frontend/web/app/(app)/recommendation/page.tsx
+++ b/frontend/web/app/(app)/recommendation/page.tsx
@@ -74,12 +74,10 @@ export default function RecommendationPage() {
   useEffect(() => {
     if (initialFetchFired.current) return;
     initialFetchFired.current = true;
-    let cancelled = false;
     void (async () => {
       setStatus("loading");
       setError(null);
       const res = await getRecommendationReal();
-      if (cancelled) return;
       if (!res.ok) {
         setError(res.error);
         setStatus("error");
@@ -97,9 +95,6 @@ export default function RecommendationPage() {
       setSaved(false);
       setStatus("ready");
     })();
-    return () => {
-      cancelled = true;
-    };
   }, []);
 
   async function handleAnother() {


### PR DESCRIPTION
## Summary

Discovered during Phase 15 (history) smoke: navigating to `/recommendation`
fires `GET /api/v1/recommend` twice. Only the second response renders on the
recommendation page, but the recommend Lambda writes to `Historico` on every
call — so `/history` shows both entries while the user only saw one. Confusing
during dev testing.

## Root cause

React 18 Strict Mode (Next.js dev default) runs effects setup → cleanup → setup
again to surface effect-cleanup bugs. The existing mount effect in
`recommendation/page.tsx`:

\`\`\`tsx
useEffect(() => {
  let cancelled = false;
  void (async () => {
    const res = await getRecommendationReal();   // ← fires twice in dev
    if (cancelled) return;                       // only suppresses state
    // ...                                          updates, not the call
  })();
  return () => { cancelled = true; };
}, []);
\`\`\`

The `cancelled` flag prevents the first invocation's state updates from
clobbering the second, but it does not abort the in-flight \`fetch\` —
both requests reach the backend.

## Fix

Add a \`useRef\` guard at the top of the effect. Refs persist across Strict
Mode's simulated remount, so the second effect invocation short-circuits
before calling \`getRecommendationReal()\`.

## Notes

- **No production behavior change.** Strict Mode is dev-only. In prod, the
  effect always ran exactly once. This fix only suppresses the duplicate
  call in dev so smoke testing against AWS matches what end users will see.
- \`handleAnother()\` (the manual "show another" button) was already
  correctly gated by user gesture, so no change there.
- The \`inFlight\` ref (used by the Save toggle in PR #155) is unrelated and
  unchanged.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] \`pnpm lint\` — clean
- [ ] In browser: home → "Pick a movie for me" → DevTools Network shows
      exactly one \`GET /api/v1/recommend\` request, exactly one new row in
      \`/history\` under Today

Refs #127