### PR TITLE
feat(oauth): enable Google sign-in on the prod stack (cinedica.video)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -23,6 +23,12 @@ jobs:
       PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
       PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       UV_PROJECT_ENVIRONMENT: venv
+      # OAuth 2.0 / Google (issue #181). __main__.py reads these at `pulumi up`
+      # and injects them into the Cognito Google IdP (secret-marked in state).
+      # Required now that prod enables OAuth via Pulumi.prod.yaml — without them
+      # `config.require_secret("googleClientId")` would fail the prod deploy.
+      GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+      GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
 
     steps:
       - name: Checkout

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -9,3 +9,17 @@ config:
   # condition Cognito↔SES em __main__.py.
   isn20261:sesFromEmail: etorresini@ifsc.edu.br
   isn20261:sesFromName: Cine Dica
+  # OAuth 2.0 / Google Hosted UI (issue #181) for prod. Mirrors the dev setup
+  # in Pulumi.dev.yaml but with the production domain. The prefix must be
+  # globally unique within the region and differs from dev (`cinedica-dev`),
+  # so the prod Hosted UI lives at
+  # https://cinedica-prod.auth.sa-east-1.amazoncognito.com — that
+  # /oauth2/idpresponse URL must be registered in the Google OAuth client.
+  # googleClientId / googleClientSecret come from the GitHub Actions secrets
+  # GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET (see deploy-prod.yml),
+  # never committed here.
+  isn20261:cognitoDomainPrefix: cinedica-prod
+  isn20261:oauthCallbackUrls:
+    - https://cinedica.video/callback
+  isn20261:oauthLogoutUrls:
+    - https://cinedica.video/login

--- a/__main__.py
+++ b/__main__.py
@@ -932,17 +932,48 @@ if is_prod and domain_name:
 deploy_ts = str(int(time.time()))
 public_url = pulumi.Output.concat("https://", distribution.domain_name)
 
+
+def format_url(args):
+    dist_domain, prod_mode, custom_domain = args
+    if prod_mode and custom_domain:
+        return f"https://{custom_domain}"
+    return f"https://{dist_domain}"
+
+
+# Public-facing site URL — custom domain in prod, CloudFront otherwise. The
+# frontend's OAuth redirect_uri must equal this exactly; deriving it from the
+# CloudFront `public_url` would mismatch the Cognito callback URL on prod.
+# Computed here (not in the Outputs section) so the frontend build can consume
+# it below.
+final_public_url = pulumi.Output.all(
+    distribution.domain_name, is_prod, domain_name
+).apply(format_url)
+
+# Frontend build-time env. The OAuth vars are only injected when the stack
+# provisions the Hosted UI (oauth_enabled); without them signInWithGoogle
+# throws by design (frontend/web/lib/api/auth.ts). NEXT_PUBLIC_COGNITO_DOMAIN
+# mirrors the cognito_hosted_ui_domain output exactly.
+frontend_build_env = {
+    "NEXT_PUBLIC_COGNITO_REGION": region.region,
+    "NEXT_PUBLIC_COGNITO_USER_POOL_ID": user_pool.id,
+    "NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID": user_pool_client.id,
+    "NEXT_PUBLIC_API_BASE_URL": public_url,
+}
+if oauth_enabled:
+    frontend_build_env["NEXT_PUBLIC_COGNITO_DOMAIN"] = pulumi.Output.concat(
+        "https://", user_pool_domain.domain,
+        ".auth.", region.region, ".amazoncognito.com",
+    )
+    frontend_build_env["NEXT_PUBLIC_OAUTH_REDIRECT_URI"] = pulumi.Output.concat(
+        final_public_url, "/callback",
+    )
+
 frontend_build = command.local.Command(
     f"build-frontend-{env}",
     create="pnpm install --frozen-lockfile && pnpm build",
     update="pnpm install --frozen-lockfile && pnpm build",
     dir="./frontend/web",
-    environment={
-        "NEXT_PUBLIC_COGNITO_REGION": region.region,
-        "NEXT_PUBLIC_COGNITO_USER_POOL_ID": user_pool.id,
-        "NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID": user_pool_client.id,
-        "NEXT_PUBLIC_API_BASE_URL": public_url,
-    },
+    environment=frontend_build_env,
     triggers=[deploy_ts],
     opts=pulumi.ResourceOptions(
         depends_on=[user_pool, user_pool_client, distribution],
@@ -970,18 +1001,8 @@ frontend_deploy = command.local.Command(
 )
 
 # --- 8. Outputs ---
-
-
-def format_url(args):
-    dist_domain, prod_mode, custom_domain = args
-    if prod_mode and custom_domain:
-        return f"https://{custom_domain}"
-    return f"https://{dist_domain}"
-
-
-final_public_url = pulumi.Output.all(
-    distribution.domain_name, is_prod, domain_name
-).apply(format_url)
+# format_url / final_public_url are defined above (section 7a) so the frontend
+# build can consume the resolved public URL for the OAuth redirect_uri.
 
 pulumi.export("api_internal_url", api.api_endpoint)
 pulumi.export("public_url", final_public_url)


### PR DESCRIPTION
OAuth was only ever wired for dev. On prod, oauth_enabled was False (Pulumi.prod.yaml lacked cognitoDomainPrefix/oauthCallbackUrls), so no Cognito Hosted UI domain, Google IdP, or OAuth-enabled app client was provisioned — the frontend's Google button had no backend.

- Pulumi.prod.yaml: add cognitoDomainPrefix (cinedica-prod) + prod OAuth callback/logout URLs to flip oauth_enabled on for prod.
- deploy-prod.yml: pass GOOGLE_OAUTH_CLIENT_ID/SECRET so require_secret resolves at `pulumi up` (would otherwise fail the prod deploy).
- __main__.py: feed NEXT_PUBLIC_COGNITO_DOMAIN + NEXT_PUBLIC_OAUTH_REDIRECT_URI into the frontend build (required by signInWithGoogle). Move final_public_url above the build so the redirect_uri uses the custom domain, not CloudFront.

Out-of-band: register the prod Hosted UI callback
https://cinedica-prod.auth.sa-east-1.amazoncognito.com/oauth2/idpresponse in the Google OAuth client.