### PR TITLE
fix(cloudfront): serve subdirectory index.html so deep links/refresh don't 403

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -835,6 +835,33 @@ api_origin_request_policy = aws.cloudfront.OriginRequestPolicy(
 
 # --- 2. Distribuição do CloudFront ---
 
+# CloudFront Function (viewer-request) that maps subdirectory requests to their
+# index.html. The frontend is a Next.js static export with trailingSlash, so a
+# route like /login lives at the S3 key `login/index.html`. CloudFront's
+# default_root_object only resolves `/` -> index.html, not subpaths, so a direct
+# load or refresh of /login/ hit a missing key and returned 403 AccessDenied
+# (the bucket is private via OAC). This rewrite fixes deep-links/refresh on every
+# sub-route. It is attached only to the S3 default behavior, never to /api/v1/*.
+spa_rewrite_function = aws.cloudfront.Function(
+    f"spa-rewrite-{env}",
+    runtime="cloudfront-js-2.0",
+    comment=f"Map subdirectory requests to index.html for the static export ({env})",
+    publish=True,
+    code="""function handler(event) {
+    var request = event.request;
+    var uri = request.uri;
+    if (uri.endsWith('/')) {
+        request.uri += 'index.html';
+    } else {
+        var lastSegment = uri.substring(uri.lastIndexOf('/') + 1);
+        if (lastSegment.indexOf('.') === -1) {
+            request.uri += '/index.html';
+        }
+    }
+    return request;
+}""",
+)
+
 distribution = aws.cloudfront.Distribution(
     f"cdn-{env}",
     enabled=True,
@@ -865,6 +892,12 @@ distribution = aws.cloudfront.Distribution(
         allowed_methods=["GET", "HEAD"],
         cached_methods=["GET", "HEAD"],
         cache_policy_id=s3_cache_policy.id,
+        function_associations=[
+            aws.cloudfront.DistributionDefaultCacheBehaviorFunctionAssociationArgs(
+                event_type="viewer-request",
+                function_arn=spa_rewrite_function.arn,
+            )
+        ],
     ),
     ordered_cache_behaviors=[
         aws.cloudfront.DistributionOrderedCacheBehaviorArgs(


### PR DESCRIPTION
## Problem

Direct loads and refreshes of sub-routes on prod return `403 AccessDenied`:

```xml
<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>
```

The frontend is a Next.js **static export** with `trailingSlash: true`, so `/login` lives at the S3 key `login/index.html`. CloudFront's `default_root_object` only resolves `/` → `index.html`, **not** subpaths. With the bucket private behind OAC, a request to `/login/` maps to the missing key `login/` and S3 returns 403.

In-app `<Link>` navigation worked (client-side render), which masked the bug until a hard load / refresh / bookmark / deep link.

## Fix

Add a viewer-request **CloudFront Function** that appends `index.html` to directory URIs:

| Request | Rewritten to |
|---|---|
| `/login/` | `/login/index.html` |
| `/login` | `/login/index.html` |
| `/` | `/index.html` |
| `/google.svg`, `/_next/static/*.js` | _unchanged (has a `.`)_ |

It is attached **only** to the S3 default cache behavior — the `/api/v1/*` behavior is untouched.

## Test plan

- [ ] After deploy, hard-refresh `https://cinedica.video/login/` → page renders instead of AccessDenied
- [ ] `https://cinedica.video/register/` direct load works
- [ ] Static assets (`/google.svg`) and `/api/v1/*` still resolve normally
- [ ] Allow a few minutes for CloudFront propagation after the deploy completes