### PR TITLE
fix(frontend): call API on custom domain to avoid cross-origin CORS failures

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -959,7 +959,13 @@ frontend_build_env = {
     "NEXT_PUBLIC_COGNITO_REGION": region.region,
     "NEXT_PUBLIC_COGNITO_USER_POOL_ID": user_pool.id,
     "NEXT_PUBLIC_COGNITO_USER_POOL_CLIENT_ID": user_pool_client.id,
-    "NEXT_PUBLIC_API_BASE_URL": public_url,
+    # Public-facing URL (custom domain in prod), NOT the raw CloudFront domain.
+    # The site is served from https://cinedica.video, so calling the API at the
+    # cloudfront.net hostname is cross-origin and fails the CORS preflight (the
+    # API only allows the cinedica.video origin). final_public_url keeps the API
+    # call same-origin -> no preflight. Matches the dev workflow, which feeds the
+    # `public_url` stack output (= final_public_url) into this same var.
+    "NEXT_PUBLIC_API_BASE_URL": final_public_url,
 }
 if oauth_enabled:
     frontend_build_env["NEXT_PUBLIC_COGNITO_DOMAIN"] = pulumi.Output.concat(


### PR DESCRIPTION
## Problem

Once login works on prod, the first authenticated request fails:

```
Access to fetch at 'https://<id>.cloudfront.net/api/v1/recommend'
from origin 'https://cinedica.video' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

The site is served from `https://cinedica.video`, but the frontend was built with `NEXT_PUBLIC_API_BASE_URL` pointing at the **raw CloudFront domain** (`https://<id>.cloudfront.net`). That makes every `/api/v1/*` call **cross-origin**, triggering a CORS preflight. The API's CORS config only allows the `https://cinedica.video` origin, so the preflight fails.

## Root cause

`NEXT_PUBLIC_API_BASE_URL` was set to `public_url` (= `https://<cloudfront-domain>`) instead of `final_public_url` (= the custom domain in prod). Pre-existing since the frontend build moved to `command.local.Command`; it only surfaced now because the `/login` 403 previously blocked anyone from logging in and making authenticated calls on prod.

## Fix

Build with `final_public_url`, so the prod bundle calls `https://cinedica.video/api/v1/...` — **same-origin as the page → no preflight → no CORS**. Still routes through the same CloudFront distribution to API Gateway. Matches what `deploy-dev-aluno.yml` already does (it feeds the `public_url` stack output, which is `final_public_url`, into this var).

One line + comment; no CORS/API/backend behavior changed.

## Test plan

- [ ] After deploy, log in on https://cinedica.video and confirm `/api/v1/recommend` succeeds (no CORS error in console)
- [ ] Network tab: the request goes to `https://cinedica.video/api/v1/...`, not the cloudfront.net host
- [ ] Allow a few minutes for CloudFront propagation after deploy