### PR TITLE
fix(infra): quote CloudFront invalidation '/*' so the bare / cache actually clears

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1054,6 +1054,13 @@ uploads_marker = uploaded_files.apply(lambda objs: str(len(objs)))
 # 3. Invalidação do CloudFront (Apenas quando houver um novo build)
 # Como não usamos mais o sync, precisamos isolar a invalidação.
 #
+# IMPORTANTE: o path precisa ir ENTRE ASPAS SIMPLES (`'/*'`). Sem aspas, o shell
+# faz glob de `/*` contra o filesystem ANTES de chamar o `aws`, expandindo para
+# os diretórios da raiz (/bin /etc /home ...) — foi exatamente isso que gerou uma
+# invalidação com "Quantity": 27 (paths errados) em vez do curinga, deixando o
+# cache de `/` (index.html) sem ser limpo. Com aspas, o `aws` recebe `/*` literal
+# e invalida tudo.
+#
 # `create` E `update` apontam para o MESMO comando: hoje a invalidação roda a
 # cada deploy porque `triggers=[deploy_ts]` força a recriação do recurso (e o
 # `create` dispara). Mas se algum dia `deploy_ts` for estabilizado para parar o
@@ -1061,21 +1068,22 @@ uploads_marker = uploaded_files.apply(lambda objs: str(len(objs)))
 # `update` definido, a invalidação pararia de rodar silenciosamente. Definir os
 # dois mantém a garantia "invalida a cada deploy" independente dessa escolha.
 #
-# O comando referencia `uploads_marker` num comentário shell inócuo (`# uploads=N`)
-# só para criar a dependência de dados: como o `create`/`update` depende desse
-# Output, o Pulumi espera todos os BucketObjectv2 antes de invalidar.
-invalidate_cmd = pulumi.Output.all(distribution.id, uploads_marker).apply(
-    lambda args: (
-        f"aws cloudfront create-invalidation --distribution-id {args[0]} --paths /*"
-        f"  # uploads={args[1]}"
-    )
+# A dependência de dados que garante "uploads -> invalidação" vem de
+# `uploads_marker` nos `triggers` (o Pulumi resolve esse Output, esperando todos
+# os BucketObjectv2, antes de criar o recurso). NÃO costuramos o marker no
+# comando shell — fazer isso (ex.: `# uploads=N`) é frágil e foi o que mascarou
+# o bug do glob acima.
+invalidate_cmd = distribution.id.apply(
+    lambda dist_id: f"aws cloudfront create-invalidation --distribution-id {dist_id} --paths '/*'"
 )
 cloudfront_invalidation = command.local.Command(
     f"invalidate-cloudfront-{env}",
     create=invalidate_cmd,
     update=invalidate_cmd,
-    # `uploads_marker` também entra nos triggers para forçar re-execução quando o
-    # conjunto de arquivos muda, além do `deploy_ts` que muda a cada deploy.
+    # `uploads_marker` entra nos triggers para (a) forçar re-execução quando o
+    # conjunto de arquivos muda e (b) criar a dependência de dados que faz o
+    # Pulumi esperar todos os uploads antes de invalidar. `deploy_ts` muda a cada
+    # deploy, garantindo que a invalidação rode sempre.
     triggers=[deploy_ts, uploads_marker],
     opts=pulumi.ResourceOptions(
         depends_on=[frontend_build, distribution],


### PR DESCRIPTION
@
## What

Quote the CloudFront invalidation path as `'/*'` instead of bare `/*`.

## Why

Follow-up to #207. After that merged, prod still served a stale `index.html` at
`https://cinedica.video/` (old build, old API URL → CORS), even though the new
build was confirmed on S3.

Root cause: the invalidation ran `--paths /*` **unquoted**, so the Linux shell
glob-expanded `/*` against the filesystem root *before* `aws` ran. The deploy
log showed the invalidation with `"Quantity": 27` and bogus Items (`/bin`,
`/etc`, …) instead of the wildcard — so `/` (index.html) was never evicted.

Proof it was only invalidation coverage (not the build/upload):
- `curl https://cinedica.video/` → `Last-Modified: 01:31` (old build), `Age: 16901`, no `Cache-Control`
- `curl https://cinedica.video/?nocache=1` → `Last-Modified: 16:18` (new build), `Age: ~17`, `Cache-Control: no-cache`

The cache-busted URL hit origin and returned the correct fixed build, confirming
S3 + headers were fine and only the `/` cache key was stale.

## Change

- `--paths '/*'` (quoted) so `aws` receives the literal wildcard.
- Removed the fragile `# uploads=N` shell-comment data-dependency hack; the
  uploads→invalidate ordering is preserved by `uploads_marker` in `triggers`.

## After merge

Prod deploy runs the corrected `'/*'` invalidation → bare `/` is evicted →
all visitors get the fixed build. (Until then, `cinedica.video/` serves stale
until its TTL expires; cache-busted URLs already serve fresh.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@