### PR TITLE
feat: rich recommendation screen (synopsis, cast, similar films) + poster-led layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ aws
 sam_installation/
 .claude/
 Pulumi.dev-test-combined.yaml
+.scratch/

--- a/frontend/web/app/(app)/recommendation/page.tsx
+++ b/frontend/web/app/(app)/recommendation/page.tsx
@@ -1,39 +1,40 @@
 "use client";
 
 /**
- * Phase 13 (INTG-RECO-01/02, issue #132) + Phase 16 (INTG-WTCL-02, issue #135).
+ * Phase 13 (INTG-RECO-01/02, issue #132) + Phase 16 (INTG-WTCL-02, issue #135)
+ * + recommend-rich-fields: poster-led layout fed by the enriched Lambda payload.
  *
- * Phase 13: fetches a real movie recommendation from `/api/v1/recommend`
- * (`getRecommendationReal()` → `Result<RecommendedMovie | null, ApiError>`),
- * 4-state machine (loading / ready / empty / error), `useApiErrorUx` for
- * toast UX, kebab→camel adapter inside `recommend.real.ts`. Phase 13 fields
- * the live Lambda doesn't return — year / runtime / rating / match /
- * director / cast / synopsis / mood — render conditionally.
+ * Fetches a real movie recommendation from `/api/v1/recommend` (auth) or
+ * `/api/v1/recommend_anon` (guest) via `getRecommendationReal/Anon()` →
+ * `Result<RecommendedMovie | null, ApiError>`. 4-state machine (loading /
+ * ready / empty / error), `useApiErrorUx` for toast UX, kebab→camel adapter in
+ * `recommend.real.ts`.
  *
- * Phase 16 (this rebase): rewire the Save button to consume the real
- * `/watch-later` Lambda via async `addWatchLater(movieId)`. The Lambda
- * has no PUT/DELETE (verified 2026-05-14) so the toggle becomes ADD-ONLY
- * — once clicked it stays in "Saved" state with no un-save. The previous
- * `isInWatchLater(localId)` membership pre-check is dropped because the
- * GET response strips movieIds (docs/inconsistencias.md §4). `localId =
- * live:${title}` is preserved as the per-recommendation save handle since
- * the live Lambda has no id.
+ * recommend-rich-fields: the Lambda now returns year / rated / director /
+ * runtime / imdbRating / synopsis / cast plus a lightweight `similar[]` array
+ * (genre-superset matches — see functions/recommend/recommend.py). Every field
+ * is still rendered conditionally so the screen degrades gracefully if any are
+ * absent. `match`/`mood` are no longer produced and were dropped from the UI.
  *
- * Layout: full-bleed backdrop region with two-axis legibility gradient + content
- * column padded to clear the rail. Responsive at 3 breakpoints — backdrop
- * height steps up (360→560), padding scales (px-6→px-14), metadata strip
- * wraps on narrow widths.
+ * Phase 16: the Save button consumes the real `/watch-later` Lambda via async
+ * `addWatchLater(movieId)`. The Lambda has no PUT/DELETE (verified 2026-05-14)
+ * so the toggle is ADD-ONLY — once clicked it stays "Saved". `localId =
+ * live:${title}` is the per-recommendation save handle (live Lambda has no id).
+ *
+ * Layout (Mock B): the poster is portrait, so instead of a cropped backdrop the
+ * sharp full poster sits in a right column (object-contain, sticky on md+) and
+ * a heavily blurred/darkened copy fills an ambient region behind the hero for
+ * mood. Below the hero, a horizontal "Filmes parecidos" rail. Responsive: hero
+ * is single-column on mobile (poster first via order-*), two-column on md+.
  *
  * DSGN-06 escape hatches (each marked with // non-tokenized inline):
- *   - h-[360px] / md:h-[560px]                : backdrop height primitives
- *   - pt-[220px] / md:pt-[280px]              : header padding-top primitives
- *   - max-w-[880px] / max-w-[640px]           : column width primitives
- *   - leading-[0.98]                          : display heading line-height
- *   - tracking-[-0.03em]                      : display heading letter-spacing
- *   - tracking-[0.18em] / tracking-[0.06em]   : eyebrow + small-label spacing
- *   - text-[17px], text-[15px]                : body sizes between Phase 2 steps
- *   - bg-[linear-gradient(...)] x2            : backdrop legibility scrims
- *   - rating chip: text-11 px-1.5 py-0.5      : compact pill primitive
+ *   - ambient: h-170 region, blur-[48px]/brightness-[.45]/scale-110, bg gradient
+ *   - hero: max-w-300 shell, md:grid-cols-[1fr_minmax(300px,360px)], md:pt-22
+ *   - poster: max-w-[320px] aspect-2/3 object-contain, md:top-22 sticky
+ *   - rail cards: w-37.5 aspect-2/3 poster primitives
+ *   - h-[360px] / h-[560px] (skeleton only), pt-[220px]/pt-[280px] (other states)
+ *   - leading-[0.98]/[1.55]/[1.6], tracking-[-0.03em], text-[15px]/[17px]
+ *   - rating chip: text-11 px-1.5 py-0.5 compact pill primitive
  */
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
@@ -45,6 +46,7 @@ import {
   getRecommendationReal,
   getRecommendationAnon,
   type RecommendedMovie,
+  type SimilarMovie,
 } from "@/lib/api/recommend.real";
 import { addWatchLater } from "@/lib/api/watch-later";
 import { useApiErrorUx } from "@/lib/api/useApiErrorUx";
@@ -228,7 +230,7 @@ export default function RecommendationPage() {
     // status === "ready" && movie !== null
     const primaryService = movie.streamingServices[0];
     const showMetaStrip =
-      movie.match !== undefined ||
+      movie.imdbRating !== undefined ||
       movie.year !== undefined ||
       movie.rating !== undefined ||
       movie.runtime !== undefined ||
@@ -239,148 +241,171 @@ export default function RecommendationPage() {
       key={movie.title}
       className="relative isolate w-full min-h-screen overflow-hidden bg-bg"
     >
-      {/* Backdrop — fades in on its own */}
-      <div
-        aria-hidden
-        className="absolute top-0 left-0 right-0 h-[360px] md:h-[560px] overflow-hidden animate-fade-in"
-      >
-        {movie.poster && (
+      {/* Ambient backdrop — the poster, heavily blurred + darkened, for mood
+          only. Posters are portrait, so this never crops meaningfully; the
+          sharp full poster lives in the right column below. */}
+      {movie.poster && (
+        <div
+          aria-hidden
+          /* non-tokenized: h-170 ambient region height primitive */
+          className="absolute top-0 left-0 right-0 h-170 overflow-hidden animate-fade-in"
+        >
+          {/* non-tokenized: blur-[48px] + brightness-[.45] + scale-110 ambient recipe (no token) */}
           <img
             src={movie.poster}
             alt=""
-            className="absolute inset-0 w-full h-full object-cover object-top"
+            className="absolute inset-0 w-full h-full object-cover blur-[48px] brightness-[.45] scale-110"
           />
-        )}
-        {/* non-tokenized: stacked top-down + left-right legibility scrims */}
-        <div className="absolute inset-0 bg-[linear-gradient(to_bottom,rgba(10,10,11,0.30)_0%,rgba(10,10,11,0.10)_30%,rgba(10,10,11,0.70)_70%,var(--color-bg)_100%)]" />
-        <div className="absolute inset-0 bg-[linear-gradient(to_right,rgba(10,10,11,0.85)_0%,rgba(10,10,11,0.20)_60%)]" />
-      </div>
+          {/* non-tokenized: top-down fade from the ambient image into the page bg */}
+          <div className="absolute inset-0 bg-[linear-gradient(to_bottom,rgba(10,10,11,0.55)_0%,rgba(10,10,11,0.35)_40%,var(--color-bg)_92%)]" />
+        </div>
+      )}
 
-      {/* Content column */}
-      <div className="relative z-10">
-        {/* Header */}
-        {/* non-tokenized: pt-[220px] mobile / pt-[280px] md+ — backdrop clearance primitives */}
-        {/* non-tokenized: max-w-[880px] — header column width primitive */}
-        <div className="pt-[220px] md:pt-[280px] px-6 md:px-14 max-w-[880px] animate-fade-up [animation-delay:60ms]">
-          <p className={`${EYEBROW} text-accent flex items-center gap-2 mb-3`}>
-            <span aria-hidden>✦</span>
-            <span>Achamos que você vai gostar deste</span>
-          </p>
-          {/* non-tokenized: leading-[0.98] tracking-[-0.03em] match the reference .display recipe */}
-          <h1 className="font-display text-40 md:text-64 font-extrabold tracking-[-0.03em] leading-[0.98] text-text-primary">
-            {movie.title}
-          </h1>
-
-          {showMetaStrip && (
-            <div className="flex items-center flex-wrap gap-x-3.5 gap-y-2 mt-4 text-13 text-text-secondary">
-              {movie.match !== undefined && (
-                <span className="text-accent text-14 font-semibold">
-                  {movie.match}% compatível
-                </span>
-              )}
-              {movie.year !== undefined && <span>{movie.year}</span>}
-              {movie.rating !== undefined && (
-                /* non-tokenized: rating chip primitive — text-11 + px-1.5 py-0.5 below Phase 2 scale */
-                <span className="border border-border-strong rounded-sm px-1.5 py-0.5 text-11 font-semibold text-text-primary">
-                  {movie.rating}
-                </span>
-              )}
-              {movie.runtime !== undefined && <span>{movie.runtime}</span>}
-              {movie.genre && movie.genre.length > 0 && (
-                <span className="text-text-muted capitalize">{movie.genre}</span>
-              )}
-            </div>
-          )}
-
-          {movie.synopsis && (
-            /* non-tokenized: text-[15px] / md:text-[17px] body size between Phase 2 steps; max-w-[640px] body width primitive */
-            <p className="mt-6 mb-7 text-text-primary text-[15px] md:text-[17px] leading-[1.55] max-w-[640px]">
-              {movie.synopsis}
+      {/* Content — centered max-width shell */}
+      {/* non-tokenized: max-w-300 page shell width primitive */}
+      <div className="relative z-10 mx-auto max-w-300 px-6 md:px-10">
+        {/* Hero: text column + full poster column */}
+        {/* non-tokenized: pt-[88px] md+ / pt-12 hero top offset; poster col fixed 300–360px track */}
+        <div className="grid grid-cols-1 gap-7 pt-12 md:grid-cols-[1fr_minmax(300px,360px)] md:gap-12 md:pt-22 md:items-start">
+          {/* LEFT: text — order-2 on mobile so the poster leads, natural on md+ */}
+          <div className="order-2 md:order-1 animate-fade-up [animation-delay:60ms]">
+            <p className={`${EYEBROW} text-accent flex items-center gap-2 mb-3`}>
+              <span aria-hidden>✦</span>
+              <span>Achamos que você vai gostar deste</span>
             </p>
-          )}
+            {/* non-tokenized: leading-none tracking-[-0.03em] display heading recipe */}
+            <h1 className="font-display text-40 md:text-56 font-extrabold tracking-[-0.03em] leading-none text-text-primary">
+              {movie.title}
+            </h1>
 
-          {/* Actions */}
-          <div className="flex flex-wrap gap-2.5 mb-8">
-            {primaryService && (
-              <a
-                href={primaryService.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 h-12 px-5 rounded-md bg-accent hover:bg-accent-hover text-on-accent text-14 font-semibold transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
-              >
-                <Play size={16} aria-hidden />
-                Assistir em {primaryService.name}
-              </a>
+            {showMetaStrip && (
+              <div className="flex items-center flex-wrap gap-x-3.5 gap-y-2 mt-4 text-13 text-text-secondary">
+                {movie.imdbRating !== undefined && (
+                  <span className="text-accent text-14 font-semibold">
+                    ★ {movie.imdbRating} IMDb
+                  </span>
+                )}
+                {movie.year !== undefined && <span>{movie.year}</span>}
+                {movie.rating !== undefined && (
+                  /* non-tokenized: rating chip primitive — text-11 + px-1.5 py-0.5 below Phase 2 scale */
+                  <span className="border border-border-strong rounded-sm px-1.5 py-0.5 text-11 font-semibold text-text-primary">
+                    {movie.rating}
+                  </span>
+                )}
+                {movie.runtime !== undefined && <span>{movie.runtime}</span>}
+                {movie.genre && movie.genre.length > 0 && (
+                  <span className="text-text-muted capitalize">{movie.genre}</span>
+                )}
+              </div>
             )}
-            {isAuthenticated && (
+
+            {movie.synopsis && (
+              /* non-tokenized: text-[15px] / md:text-[17px] body size between Phase 2 steps; max-w-150 body width primitive */
+              <p className="mt-5 mb-6 text-text-primary text-[15px] md:text-[17px] leading-[1.55] max-w-150">
+                {movie.synopsis}
+              </p>
+            )}
+
+            {/* Actions */}
+            <div className="flex flex-wrap gap-2.5 mb-7">
+              {primaryService && (
+                <a
+                  href={primaryService.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 h-12 px-5 rounded-md bg-accent hover:bg-accent-hover text-on-accent text-14 font-semibold transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
+                >
+                  <Play size={16} aria-hidden />
+                  Assistir em {primaryService.name}
+                </a>
+              )}
+              {isAuthenticated && (
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={saved}
+                  aria-pressed={saved}
+                  className="inline-flex items-center gap-2 h-12 px-5 rounded-md bg-surface-2 border border-border hover:border-border-strong text-text-primary text-14 font-semibold transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2 disabled:opacity-70 disabled:cursor-default disabled:hover:border-border"
+                >
+                  {saved ? (
+                    <BookmarkCheck size={16} aria-hidden />
+                  ) : (
+                    <Bookmark size={16} aria-hidden />
+                  )}
+                  {saved ? "Salvo" : "Salvar para assistir depois"}
+                </button>
+              )}
+              {/* Note: no disabled/aria-busy here — entering "loading" replaces the entire screen with the skeleton in the branch above, so the button is unmounted while a fetch is in flight. */}
               <button
                 type="button"
-                onClick={handleSave}
-                disabled={saved}
-                aria-pressed={saved}
-                className="inline-flex items-center gap-2 h-12 px-5 rounded-md bg-surface-2 border border-border hover:border-border-strong text-text-primary text-14 font-semibold transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2 disabled:opacity-70 disabled:cursor-default disabled:hover:border-border"
+                onClick={handleAnother}
+                className="inline-flex items-center gap-2 h-12 px-5 rounded-md text-text-secondary hover:text-text-primary text-14 font-semibold transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
               >
-                {saved ? (
-                  <BookmarkCheck size={16} aria-hidden />
-                ) : (
-                  <Bookmark size={16} aria-hidden />
-                )}
-                {saved ? "Salvo" : "Salvar para assistir depois"}
+                <RefreshCw size={16} aria-hidden />
+                Recomendar outro
               </button>
+            </div>
+
+            {/* Where to watch */}
+            {movie.streamingServices.length > 0 && (
+              <div className="mb-7">
+                <p className={`${EYEBROW} mb-2.5`}>Onde assistir</p>
+                <div className="flex flex-wrap gap-2.5">
+                  {movie.streamingServices.map((s) => (
+                    // non-tokenized: live data has no kind tier — default to "included" until issue #70 enriches with rent/buy info.
+                    <ServiceBadge
+                      key={s.name}
+                      service={{ name: s.name, kind: "included" }}
+                    />
+                  ))}
+                </div>
+              </div>
             )}
-            {/* Note: no disabled/aria-busy here — entering "loading" replaces the entire screen with the skeleton in the branch above, so the button is unmounted while a fetch is in flight. */}
-            <button
-              type="button"
-              onClick={handleAnother}
-              className="inline-flex items-center gap-2 h-12 px-5 rounded-md text-text-secondary hover:text-text-primary text-14 font-semibold transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
-            >
-              <RefreshCw size={16} aria-hidden />
-              Recomendar outro
-            </button>
+
+            {/* Cast / Director — omitted if neither field is present */}
+            {(movie.director || (movie.cast && movie.cast.length > 0)) && (
+              /* non-tokenized: 150px Director column primitive at sm+ */
+              <div className="grid grid-cols-1 sm:grid-cols-[150px_1fr] gap-5">
+                {movie.director && (
+                  <div>
+                    <p className={`${EYEBROW} mb-1.5`}>Diretor</p>
+                    <p className="text-14 font-semibold text-text-primary">
+                      {movie.director}
+                    </p>
+                  </div>
+                )}
+                {movie.cast && movie.cast.length > 0 && (
+                  <div>
+                    <p className={`${EYEBROW} mb-1.5`}>Elenco</p>
+                    {/* non-tokenized: leading-[1.6] cast list line-height */}
+                    <p className="text-14 text-text-secondary leading-[1.6]">
+                      {movie.cast.join(" · ")}
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
 
-          {/* Where to watch */}
-          {movie.streamingServices.length > 0 && (
-            <div className="mb-8">
-              <p className={`${EYEBROW} mb-2.5`}>Onde assistir</p>
-              <div className="flex flex-wrap gap-2.5">
-                {movie.streamingServices.map((s) => (
-                  // non-tokenized: live data has no kind tier — default to "included" until issue #70 enriches with rent/buy info.
-                  <ServiceBadge
-                    key={s.name}
-                    service={{ name: s.name, kind: "included" }}
-                  />
-                ))}
+          {/* RIGHT: full poster — never cropped (object-contain). Sticky on md+. */}
+          {movie.poster && (
+            <div className="order-1 md:order-2 md:sticky md:top-22 animate-fade-up [animation-delay:120ms]">
+              {/* non-tokenized: max-w-[320px] poster width + aspect-2/3 portrait ratio primitives */}
+              <div className="mx-auto w-full max-w-[320px] aspect-2/3 overflow-hidden rounded-lg bg-surface-2 border border-border-strong shadow-lg">
+                <img
+                  src={movie.poster}
+                  alt={`Pôster: ${movie.title}`}
+                  className="w-full h-full object-contain bg-black"
+                />
               </div>
             </div>
           )}
         </div>
 
-        {/* Cast / Director — entire grid is omitted if neither field is present */}
-        {(movie.director || (movie.cast && movie.cast.length > 0)) && (
-          /* non-tokenized: 160px Director column primitive at md+ */
-          <div className="px-6 md:px-14 mb-9 max-w-[880px] grid grid-cols-1 md:grid-cols-[160px_1fr] gap-6 animate-fade-up [animation-delay:220ms]">
-            {movie.director && (
-              <div>
-                <p className={`${EYEBROW} mb-1.5`}>Diretor</p>
-                <p className="text-14 font-semibold text-text-primary">
-                  {movie.director}
-                </p>
-              </div>
-            )}
-            {movie.cast && movie.cast.length > 0 && (
-              <div>
-                <p className={`${EYEBROW} mb-1.5`}>Elenco</p>
-                <p className="text-14 text-text-secondary leading-[1.6]">
-                  {movie.cast.join(" · ")}
-                </p>
-              </div>
-            )}
-          </div>
+        {/* Similar films rail */}
+        {movie.similar && movie.similar.length > 0 && (
+          <SimilarRail items={movie.similar} />
         )}
-
-        {/* TODO Phase 13+ (issue #70 enrichment OR dedicated /similar endpoint): similar-films rail hidden — live /recommend payload has no similar films, and the prior Phase 7 helper iterated the now-deleted MOCK dataset. */}
-        {/* <SimilarFilmsRail /> */}
       </div>
     </section>
     );
@@ -391,6 +416,50 @@ export default function RecommendationPage() {
       {body}
       <SnackRecipeModal recipe={recipe} isLoading={status === "loading"} />
     </>
+  );
+}
+
+/**
+ * "Filmes parecidos" rail — horizontal-scrolling row of lightweight similar
+ * movie cards (poster + title + ★rating · year). Driven by the live Lambda's
+ * `similar` array (genre-superset matches, see recommend.py:_pick_similar).
+ * Uses the real IMDb poster URL per card (not the Picsum MovieCard seam, which
+ * is bound to the legacy mock Movie type).
+ */
+function SimilarRail({ items }: { items: ReadonlyArray<SimilarMovie> }) {
+  return (
+    <div className="mt-12 mb-14 animate-fade-up [animation-delay:260ms]">
+      <h2 className="font-display text-20 font-bold text-text-primary mb-3.5">
+        Filmes parecidos
+      </h2>
+      <div className="flex gap-4 overflow-x-auto pb-2 no-scrollbar">
+        {items.map((m) => (
+          <article key={m.movieId} className="shrink-0 w-37.5">
+            {/* non-tokenized: aspect-2/3 portrait poster ratio primitive */}
+            <div className="w-37.5 aspect-2/3 overflow-hidden rounded-md bg-surface-2 border border-border">
+              {m.poster && (
+                <img
+                  src={m.poster}
+                  alt={`Pôster: ${m.title}`}
+                  loading="lazy"
+                  className="w-full h-full object-cover block"
+                />
+              )}
+            </div>
+            <p className="mt-2 text-13 font-semibold text-text-primary line-clamp-2 leading-tight">
+              {m.title}
+            </p>
+            <p className="mt-0.5 text-12 text-text-muted flex items-center gap-1.5">
+              {m.imdbRating !== undefined && (
+                <span className="text-accent">★ {m.imdbRating}</span>
+              )}
+              {m.imdbRating !== undefined && m.year !== undefined && <span>·</span>}
+              {m.year !== undefined && <span>{m.year}</span>}
+            </p>
+          </article>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/frontend/web/lib/api/recommend.real.ts
+++ b/frontend/web/lib/api/recommend.real.ts
@@ -51,11 +51,31 @@ export type RecommendationServiceWire = {
   readonly url: string;
 };
 
+// Lightweight similar-movie card returned in the `similar` array (rail).
+export type SimilarMovieWire = {
+  readonly movieId: string;
+  readonly title: string;
+  readonly year?: number | null;
+  readonly genre: string;
+  readonly poster?: string | null;
+  readonly imdbRating?: number | null;
+};
+
 export type RecommendationResponse = {
   readonly title: string;
   readonly genre: string;
-  readonly "streaming-services": ReadonlyArray<RecommendationServiceWire>;
+  readonly "streaming-services": ReadonlyArray<RecommendationServiceWire> | null;
   readonly poster?: string | null;
+  // Enriched fields the Lambda returns as of the recommend-rich-fields change.
+  // All optional/nullable — the adapter coerces absent values to `undefined`.
+  readonly year?: number | null;
+  readonly rated?: string | null;
+  readonly director?: string | null;
+  readonly runtime?: number | null;
+  readonly imdbRating?: number | null;
+  readonly synopsis?: string | null;
+  readonly cast?: ReadonlyArray<string> | null;
+  readonly similar?: ReadonlyArray<SimilarMovieWire> | null;
 };
 
 // -----------------------------------------------------------------------------
@@ -68,26 +88,57 @@ export type RecommendedService = {
   readonly url: string;
 };
 
+// Screen-facing similar-movie card (camelCase, the rail consumes this).
+export type SimilarMovie = {
+  readonly movieId: string;
+  readonly title: string;
+  readonly genre: string;
+  readonly year?: number;
+  readonly poster?: string;
+  readonly imdbRating?: number;
+};
+
 export type RecommendedMovie = {
   readonly title: string;
   readonly genre: string;
   readonly streamingServices: ReadonlyArray<RecommendedService>;
   readonly poster?: string;
-  // Optional fields — not returned by the current Lambda. Kept for
-  // forward-compat with issue #70 (OMDb + Streaming Availability enrichment).
+  // Enriched fields. As of the recommend-rich-fields change the live Lambda
+  // returns year / rated / director / runtime / imdbRating / synopsis / cast /
+  // similar. Still optional so the screen degrades gracefully if any are absent
+  // (older Lambda, partial data).
   readonly year?: number;
   readonly runtime?: string;
   readonly rating?: string;
+  readonly imdbRating?: number;
   readonly match?: number;
   readonly director?: string;
   readonly cast?: ReadonlyArray<string>;
   readonly synopsis?: string;
   readonly mood?: ReadonlyArray<string>;
+  readonly similar?: ReadonlyArray<SimilarMovie>;
 };
 
 // -----------------------------------------------------------------------------
 // Adapter — sole kebab→camel boundary in the frontend
 // -----------------------------------------------------------------------------
+
+// Coerce nullable wire values to `undefined` so optional screen fields stay off
+// when the backend omits them (null) rather than rendering empty UI.
+function opt<T>(v: T | null | undefined): T | undefined {
+  return v ?? undefined;
+}
+
+function adaptSimilar(wire: SimilarMovieWire): SimilarMovie {
+  return {
+    movieId: wire.movieId,
+    title: wire.title,
+    genre: wire.genre,
+    ...(wire.year != null ? { year: wire.year } : {}),
+    ...(wire.poster ? { poster: wire.poster } : {}),
+    ...(wire.imdbRating != null ? { imdbRating: wire.imdbRating } : {}),
+  };
+}
 
 function adaptResponse(wire: RecommendationResponse): RecommendedMovie {
   // The bracket-string access below is the ONE place in the frontend that
@@ -98,11 +149,29 @@ function adaptResponse(wire: RecommendationResponse): RecommendedMovie {
     image: s.image,
     url: s.url,
   }));
+  // runtime arrives as a number of minutes (e.g. 175); the screen renders a
+  // human string. rated (cert, e.g. "A") maps to the screen's `rating` slot.
+  const runtime =
+    wire.runtime != null ? `${wire.runtime} min` : undefined;
+  const cast =
+    wire.cast && wire.cast.length > 0 ? [...wire.cast] : undefined;
+  const similar =
+    wire.similar && wire.similar.length > 0
+      ? wire.similar.map(adaptSimilar)
+      : undefined;
   return {
     title: wire.title,
     genre: wire.genre,
     streamingServices,
     ...(wire.poster ? { poster: wire.poster } : {}),
+    ...(opt(wire.year) !== undefined ? { year: wire.year as number } : {}),
+    ...(runtime !== undefined ? { runtime } : {}),
+    ...(opt(wire.rated) !== undefined ? { rating: wire.rated as string } : {}),
+    ...(opt(wire.imdbRating) !== undefined ? { imdbRating: wire.imdbRating as number } : {}),
+    ...(opt(wire.director) !== undefined ? { director: wire.director as string } : {}),
+    ...(opt(wire.synopsis) !== undefined ? { synopsis: wire.synopsis as string } : {}),
+    ...(cast !== undefined ? { cast } : {}),
+    ...(similar !== undefined ? { similar } : {}),
   };
 }
 

--- a/functions/recommend/recommend.py
+++ b/functions/recommend/recommend.py
@@ -18,9 +18,15 @@ from shared.movies import get_all_movies
 from shared.response import ok, unauthorized, server_error
 
 
+SIMILAR_LIMIT = 12
+
+
+def _genre_set(movie_genre: str) -> set[str]:
+    return {g.strip() for g in (movie_genre or "").lower().split(",") if g.strip()}
+
+
 def _genre_matches(movie_genre: str, wanted: list[str]) -> bool:
-    movie_genres = {g.strip() for g in movie_genre.lower().split(",")}
-    return bool(movie_genres & set(wanted))
+    return bool(_genre_set(movie_genre) & set(wanted))
 
 
 def _pick_movie(preferences: dict) -> dict | None:
@@ -35,6 +41,53 @@ def _pick_movie(preferences: dict) -> dict | None:
     else:
         pool = all_movies
     return random.choice(pool)
+
+
+def _similar_card(movie: dict) -> dict:
+    """Lightweight shape for the 'similar films' rail (no synopsis/cast)."""
+    return {
+        "movieId":    movie["movieId"],
+        "title":      movie["title"],
+        "year":       movie.get("year"),
+        "genre":      movie["genre"],
+        "poster":     movie.get("poster"),
+        "imdbRating": movie.get("imdbRating"),
+    }
+
+
+def _pick_similar(target: dict) -> list[dict]:
+    """Up to SIMILAR_LIMIT movies similar to `target`, as lightweight cards.
+
+    Primary rule (strict): a similar movie's genre set must be a SUPERSET of the
+    target's — it contains ALL of the target's genres, and may have more
+    (e.g. target {crime, drama} -> only movies tagged with at least crime AND
+    drama). Falls back to "shares at least one genre" only when the strict rule
+    yields nothing (≈62/1000 movies have no strict superset peer). The target
+    itself is always excluded. Result is a random sample (up to the limit).
+    """
+    target_genres = _genre_set(target.get("genre", ""))
+    target_id = target.get("movieId")
+    if not target_genres:
+        return []
+
+    pool = [
+        m for m in get_all_movies()
+        if m.get("movieId") != target_id
+    ]
+
+    strict = [m for m in pool if target_genres.issubset(_genre_set(m.get("genre", "")))]
+    chosen = strict
+    if not chosen:
+        # Fallback: anything sharing at least one genre with the target.
+        chosen = [m for m in pool if target_genres & _genre_set(m.get("genre", ""))]
+
+    if len(chosen) > SIMILAR_LIMIT:
+        chosen = random.sample(chosen, SIMILAR_LIMIT)
+    else:
+        # Shuffle so a short list isn't always in catalogue order.
+        chosen = random.sample(chosen, len(chosen))
+
+    return [_similar_card(m) for m in chosen]
 
 
 def handler(event, context):
@@ -81,5 +134,8 @@ def handler(event, context):
         "runtime":            movie.get("runtime"),
         "poster":             movie.get("poster"),
         "imdbRating":         movie.get("imdbRating"),
+        "synopsis":           movie.get("synopsis"),
+        "cast":               movie.get("cast"),
+        "similar":            _pick_similar(movie),
         "streaming-services": movie.get("streamingServices"),
     })

--- a/functions/shared/movies_catalogue.json
+++ b/functions/shared/movies_catalogue.json
@@ -8,7 +8,14 @@
     "year": 1994,
     "runtime": 142,
     "imdbRating": 9.3,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.",
+    "cast": [
+      "Tim Robbins",
+      "Morgan Freeman",
+      "Bob Gunton",
+      "William Sadler"
+    ]
   },
   {
     "movieId": "the-godfather-1972",
@@ -19,7 +26,14 @@
     "year": 1972,
     "runtime": 175,
     "imdbRating": 9.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An organized crime dynasty's aging patriarch transfers control of his clandestine empire to his reluctant son.",
+    "cast": [
+      "Marlon Brando",
+      "Al Pacino",
+      "James Caan",
+      "Diane Keaton"
+    ]
   },
   {
     "movieId": "the-dark-knight-2008",
@@ -30,7 +44,14 @@
     "year": 2008,
     "runtime": 152,
     "imdbRating": 9.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, Batman must accept one of the greatest psychological and physical tests of his ability to fight injustice.",
+    "cast": [
+      "Christian Bale",
+      "Heath Ledger",
+      "Aaron Eckhart",
+      "Michael Caine"
+    ]
   },
   {
     "movieId": "the-godfather-part-ii-1974",
@@ -41,7 +62,14 @@
     "year": 1974,
     "runtime": 202,
     "imdbRating": 9.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The early life and career of Vito Corleone in 1920s New York City is portrayed, while his son, Michael, expands and tightens his grip on the family crime syndicate.",
+    "cast": [
+      "Al Pacino",
+      "Robert De Niro",
+      "Robert Duvall",
+      "Diane Keaton"
+    ]
   },
   {
     "movieId": "12-angry-men-1957",
@@ -52,7 +80,14 @@
     "year": 1957,
     "runtime": 96,
     "imdbRating": 9.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A jury holdout attempts to prevent a miscarriage of justice by forcing his colleagues to reconsider the evidence.",
+    "cast": [
+      "Henry Fonda",
+      "Lee J. Cobb",
+      "Martin Balsam",
+      "John Fiedler"
+    ]
   },
   {
     "movieId": "the-lord-of-the-rings-the-return-of-the-king-2003",
@@ -63,7 +98,14 @@
     "year": 2003,
     "runtime": 201,
     "imdbRating": 8.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Gandalf and Aragorn lead the World of Men against Sauron's army to draw his gaze from Frodo and Sam as they approach Mount Doom with the One Ring.",
+    "cast": [
+      "Elijah Wood",
+      "Viggo Mortensen",
+      "Ian McKellen",
+      "Orlando Bloom"
+    ]
   },
   {
     "movieId": "pulp-fiction-1994",
@@ -74,7 +116,14 @@
     "year": 1994,
     "runtime": 154,
     "imdbRating": 8.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The lives of two mob hitmen, a boxer, a gangster and his wife, and a pair of diner bandits intertwine in four tales of violence and redemption.",
+    "cast": [
+      "John Travolta",
+      "Uma Thurman",
+      "Samuel L. Jackson",
+      "Bruce Willis"
+    ]
   },
   {
     "movieId": "schindler-s-list-1993",
@@ -85,7 +134,14 @@
     "year": 1993,
     "runtime": 195,
     "imdbRating": 8.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In German-occupied Poland during World War II, industrialist Oskar Schindler gradually becomes concerned for his Jewish workforce after witnessing their persecution by the Nazis.",
+    "cast": [
+      "Liam Neeson",
+      "Ralph Fiennes",
+      "Ben Kingsley",
+      "Caroline Goodall"
+    ]
   },
   {
     "movieId": "inception-2010",
@@ -96,7 +152,14 @@
     "year": 2010,
     "runtime": 148,
     "imdbRating": 8.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A thief who steals corporate secrets through the use of dream-sharing technology is given the inverse task of planting an idea into the mind of a C.E.O.",
+    "cast": [
+      "Leonardo DiCaprio",
+      "Joseph Gordon-Levitt",
+      "Elliot Page",
+      "Ken Watanabe"
+    ]
   },
   {
     "movieId": "fight-club-1999",
@@ -107,7 +170,14 @@
     "year": 1999,
     "runtime": 139,
     "imdbRating": 8.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An insomniac office worker and a devil-may-care soapmaker form an underground fight club that evolves into something much, much more.",
+    "cast": [
+      "Brad Pitt",
+      "Edward Norton",
+      "Meat Loaf",
+      "Zach Grenier"
+    ]
   },
   {
     "movieId": "the-lord-of-the-rings-the-fellowship-of-the-ring-2001",
@@ -118,7 +188,14 @@
     "year": 2001,
     "runtime": 178,
     "imdbRating": 8.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A meek Hobbit from the Shire and eight companions set out on a journey to destroy the powerful One Ring and save Middle-earth from the Dark Lord Sauron.",
+    "cast": [
+      "Elijah Wood",
+      "Ian McKellen",
+      "Orlando Bloom",
+      "Sean Bean"
+    ]
   },
   {
     "movieId": "forrest-gump-1994",
@@ -129,7 +206,14 @@
     "year": 1994,
     "runtime": 142,
     "imdbRating": 8.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The presidencies of Kennedy and Johnson, the events of Vietnam, Watergate and other historical events unfold through the perspective of an Alabama man with an IQ of 75, whose only desire is to be reunited with his childhood sweetheart.",
+    "cast": [
+      "Tom Hanks",
+      "Robin Wright",
+      "Gary Sinise",
+      "Sally Field"
+    ]
   },
   {
     "movieId": "il-buono-il-brutto-il-cattivo-1966",
@@ -140,7 +224,14 @@
     "year": 1966,
     "runtime": 161,
     "imdbRating": 8.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A bounty hunting scam joins two men in an uneasy alliance against a third in a race to find a fortune in gold buried in a remote cemetery.",
+    "cast": [
+      "Clint Eastwood",
+      "Eli Wallach",
+      "Lee Van Cleef",
+      "Aldo Giuffrè"
+    ]
   },
   {
     "movieId": "the-lord-of-the-rings-the-two-towers-2002",
@@ -151,7 +242,14 @@
     "year": 2002,
     "runtime": 179,
     "imdbRating": 8.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "While Frodo and Sam edge closer to Mordor with the help of the shifty Gollum, the divided fellowship makes a stand against Sauron's new ally, Saruman, and his hordes of Isengard.",
+    "cast": [
+      "Elijah Wood",
+      "Ian McKellen",
+      "Viggo Mortensen",
+      "Orlando Bloom"
+    ]
   },
   {
     "movieId": "the-matrix-1999",
@@ -162,7 +260,14 @@
     "year": 1999,
     "runtime": 136,
     "imdbRating": 8.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "When a beautiful stranger leads computer hacker Neo to a forbidding underworld, he discovers the shocking truth--the life he knows is the elaborate deception of an evil cyber-intelligence.",
+    "cast": [
+      "Lilly Wachowski",
+      "Keanu Reeves",
+      "Laurence Fishburne",
+      "Carrie-Anne Moss"
+    ]
   },
   {
     "movieId": "goodfellas-1990",
@@ -173,7 +278,14 @@
     "year": 1990,
     "runtime": 146,
     "imdbRating": 8.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The story of Henry Hill and his life in the mob, covering his relationship with his wife Karen Hill and his mob partners Jimmy Conway and Tommy DeVito in the Italian-American crime syndicate.",
+    "cast": [
+      "Robert De Niro",
+      "Ray Liotta",
+      "Joe Pesci",
+      "Lorraine Bracco"
+    ]
   },
   {
     "movieId": "star-wars-episode-v-the-empire-strikes-back-1980",
@@ -184,7 +296,14 @@
     "year": 1980,
     "runtime": 124,
     "imdbRating": 8.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "After the Rebels are brutally overpowered by the Empire on the ice planet Hoth, Luke Skywalker begins Jedi training with Yoda, while his friends are pursued by Darth Vader and a bounty hunter named Boba Fett all over the galaxy.",
+    "cast": [
+      "Mark Hamill",
+      "Harrison Ford",
+      "Carrie Fisher",
+      "Billy Dee Williams"
+    ]
   },
   {
     "movieId": "one-flew-over-the-cuckoo-s-nest-1975",
@@ -195,7 +314,14 @@
     "year": 1975,
     "runtime": 133,
     "imdbRating": 8.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A criminal pleads insanity and is admitted to a mental institution, where he rebels against the oppressive nurse and rallies up the scared patients.",
+    "cast": [
+      "Jack Nicholson",
+      "Louise Fletcher",
+      "Michael Berryman",
+      "Peter Brocco"
+    ]
   },
   {
     "movieId": "hamilton-2020",
@@ -206,7 +332,14 @@
     "year": 2020,
     "runtime": 160,
     "imdbRating": 8.6,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "The real life of one of America's foremost founding fathers and first Secretary of the Treasury, Alexander Hamilton. Captured live on Broadway from the Richard Rodgers Theater with the original Broadway cast.",
+    "cast": [
+      "Lin-Manuel Miranda",
+      "Phillipa Soo",
+      "Leslie Odom Jr.",
+      "Renée Elise Goldsberry"
+    ]
   },
   {
     "movieId": "gisaengchung-2019",
@@ -217,7 +350,14 @@
     "year": 2019,
     "runtime": 132,
     "imdbRating": 8.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Greed and class discrimination threaten the newly formed symbiotic relationship between the wealthy Park family and the destitute Kim clan.",
+    "cast": [
+      "Kang-ho Song",
+      "Lee Sun-kyun",
+      "Cho Yeo-jeong",
+      "Choi Woo-sik"
+    ]
   },
   {
     "movieId": "soorarai-pottru-2020",
@@ -228,7 +368,14 @@
     "year": 2020,
     "runtime": 153,
     "imdbRating": 8.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Nedumaaran Rajangam \"Maara\" sets out to make the common man fly and in the process takes on the world's most capital intensive industry and several enemies who stand in his way.",
+    "cast": [
+      "Suriya",
+      "Madhavan",
+      "Paresh Rawal",
+      "Aparna Balamurali"
+    ]
   },
   {
     "movieId": "interstellar-2014",
@@ -239,7 +386,14 @@
     "year": 2014,
     "runtime": 169,
     "imdbRating": 8.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A team of explorers travel through a wormhole in space in an attempt to ensure humanity's survival.",
+    "cast": [
+      "Matthew McConaughey",
+      "Anne Hathaway",
+      "Jessica Chastain",
+      "Mackenzie Foy"
+    ]
   },
   {
     "movieId": "cidade-de-deus-2002",
@@ -250,7 +404,14 @@
     "year": 2002,
     "runtime": 130,
     "imdbRating": 8.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In the slums of Rio, two kids' paths diverge as one struggles to become a photographer and the other a kingpin.",
+    "cast": [
+      "Kátia Lund",
+      "Alexandre Rodrigues",
+      "Leandro Firmino",
+      "Matheus Nachtergaele"
+    ]
   },
   {
     "movieId": "sen-to-chihiro-no-kamikakushi-2001",
@@ -261,7 +422,14 @@
     "year": 2001,
     "runtime": 125,
     "imdbRating": 8.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "During her family's move to the suburbs, a sullen 10-year-old girl wanders into a world ruled by gods, witches, and spirits, and where humans are changed into beasts.",
+    "cast": [
+      "Daveigh Chase",
+      "Suzanne Pleshette",
+      "Miyu Irino",
+      "Rumi Hiiragi"
+    ]
   },
   {
     "movieId": "saving-private-ryan-1998",
@@ -272,7 +440,14 @@
     "year": 1998,
     "runtime": 169,
     "imdbRating": 8.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Following the Normandy Landings, a group of U.S. soldiers go behind enemy lines to retrieve a paratrooper whose brothers have been killed in action.",
+    "cast": [
+      "Tom Hanks",
+      "Matt Damon",
+      "Tom Sizemore",
+      "Edward Burns"
+    ]
   },
   {
     "movieId": "the-green-mile-1999",
@@ -283,7 +458,14 @@
     "year": 1999,
     "runtime": 189,
     "imdbRating": 8.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The lives of guards on Death Row are affected by one of their charges: a black man accused of child murder and rape, yet who has a mysterious gift.",
+    "cast": [
+      "Tom Hanks",
+      "Michael Clarke Duncan",
+      "David Morse",
+      "Bonnie Hunt"
+    ]
   },
   {
     "movieId": "la-vita-bella-1997",
@@ -294,7 +476,14 @@
     "year": 1997,
     "runtime": 116,
     "imdbRating": 8.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "When an open-minded Jewish librarian and his son become victims of the Holocaust, he uses a perfect mixture of will, humor, and imagination to protect his son from the dangers around their camp.",
+    "cast": [
+      "Roberto Benigni",
+      "Nicoletta Braschi",
+      "Giorgio Cantarini",
+      "Giustino Durano"
+    ]
   },
   {
     "movieId": "se7en-1995",
@@ -305,7 +494,14 @@
     "year": 1995,
     "runtime": 127,
     "imdbRating": 8.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Two detectives, a rookie and a veteran, hunt a serial killer who uses the seven deadly sins as his motives.",
+    "cast": [
+      "Morgan Freeman",
+      "Brad Pitt",
+      "Kevin Spacey",
+      "Andrew Kevin Walker"
+    ]
   },
   {
     "movieId": "the-silence-of-the-lambs-1991",
@@ -316,7 +512,14 @@
     "year": 1991,
     "runtime": 118,
     "imdbRating": 8.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A young F.B.I. cadet must receive the help of an incarcerated and manipulative cannibal killer to help catch another serial killer, a madman who skins his victims.",
+    "cast": [
+      "Jodie Foster",
+      "Anthony Hopkins",
+      "Lawrence A. Bonney",
+      "Kasi Lemmons"
+    ]
   },
   {
     "movieId": "star-wars-1977",
@@ -327,7 +530,14 @@
     "year": 1977,
     "runtime": 121,
     "imdbRating": 8.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Luke Skywalker joins forces with a Jedi Knight, a cocky pilot, a Wookiee and two droids to save the galaxy from the Empire's world-destroying battle station, while also attempting to rescue Princess Leia from the mysterious Darth Vader.",
+    "cast": [
+      "Mark Hamill",
+      "Harrison Ford",
+      "Carrie Fisher",
+      "Alec Guinness"
+    ]
   },
   {
     "movieId": "seppuku-1962",
@@ -337,7 +547,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYjBmYTQ1NjItZWU5MS00YjI0LTg2OTYtYmFkN2JkMmNiNWVkXkEyXkFqcGdeQXVyMTMxMTY0OTQ@._V1_SX4000.jpg",
     "year": 1962,
     "runtime": 133,
-    "imdbRating": 8.6
+    "imdbRating": 8.6,
+    "synopsis": "When a ronin requesting seppuku at a feudal lord's palace is told of the brutal suicide of another ronin who previously visited, he reveals how their pasts are intertwined - and in doing so challenges the clan's integrity.",
+    "cast": [
+      "Tatsuya Nakadai",
+      "Akira Ishihama",
+      "Shima Iwashita",
+      "Tetsurô Tanba"
+    ]
   },
   {
     "movieId": "shichinin-no-samurai-1954",
@@ -348,7 +565,14 @@
     "year": 1954,
     "runtime": 207,
     "imdbRating": 8.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A poor village under attack by bandits recruits seven unemployed samurai to help them defend themselves.",
+    "cast": [
+      "Toshirô Mifune",
+      "Takashi Shimura",
+      "Keiko Tsushima",
+      "Yukiko Shimazaki"
+    ]
   },
   {
     "movieId": "it-s-a-wonderful-life-1946",
@@ -359,7 +583,14 @@
     "year": 1946,
     "runtime": 130,
     "imdbRating": 8.6,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "An angel is sent from Heaven to help a desperately frustrated businessman by showing him what life would have been like if he had never existed.",
+    "cast": [
+      "James Stewart",
+      "Donna Reed",
+      "Lionel Barrymore",
+      "Thomas Mitchell"
+    ]
   },
   {
     "movieId": "joker-2019",
@@ -370,7 +601,14 @@
     "year": 2019,
     "runtime": 122,
     "imdbRating": 8.5,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In Gotham City, mentally troubled comedian Arthur Fleck is disregarded and mistreated by society. He then embarks on a downward spiral of revolution and bloody crime. This path brings him face-to-face with his alter-ego: the Joker.",
+    "cast": [
+      "Joaquin Phoenix",
+      "Robert De Niro",
+      "Zazie Beetz",
+      "Frances Conroy"
+    ]
   },
   {
     "movieId": "whiplash-2014",
@@ -381,7 +619,14 @@
     "year": 2014,
     "runtime": 106,
     "imdbRating": 8.5,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A promising young drummer enrolls at a cut-throat music conservatory where his dreams of greatness are mentored by an instructor who will stop at nothing to realize a student's potential.",
+    "cast": [
+      "Miles Teller",
+      "J.K. Simmons",
+      "Melissa Benoist",
+      "Paul Reiser"
+    ]
   },
   {
     "movieId": "the-intouchables-2011",
@@ -392,7 +637,14 @@
     "year": 2011,
     "runtime": 112,
     "imdbRating": 8.5,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "After he becomes a quadriplegic from a paragliding accident, an aristocrat hires a young man from the projects to be his caregiver.",
+    "cast": [
+      "Éric Toledano",
+      "François Cluzet",
+      "Omar Sy",
+      "Anne Le Ny"
+    ]
   },
   {
     "movieId": "the-prestige-2006",
@@ -403,7 +655,14 @@
     "year": 2006,
     "runtime": 130,
     "imdbRating": 8.5,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "After a tragic accident, two stage magicians engage in a battle to create the ultimate illusion while sacrificing everything they have to outwit each other.",
+    "cast": [
+      "Christian Bale",
+      "Hugh Jackman",
+      "Scarlett Johansson",
+      "Michael Caine"
+    ]
   },
   {
     "movieId": "the-departed-2006",
@@ -414,7 +673,14 @@
     "year": 2006,
     "runtime": 151,
     "imdbRating": 8.5,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An undercover cop and a mole in the police attempt to identify each other while infiltrating an Irish gang in South Boston.",
+    "cast": [
+      "Leonardo DiCaprio",
+      "Matt Damon",
+      "Jack Nicholson",
+      "Mark Wahlberg"
+    ]
   },
   {
     "movieId": "the-pianist-2002",
@@ -425,7 +691,14 @@
     "year": 2002,
     "runtime": 150,
     "imdbRating": 8.5,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A Polish Jewish musician struggles to survive the destruction of the Warsaw ghetto of World War II.",
+    "cast": [
+      "Adrien Brody",
+      "Thomas Kretschmann",
+      "Frank Finlay",
+      "Emilia Fox"
+    ]
   },
   {
     "movieId": "gladiator-2000",
@@ -436,7 +709,14 @@
     "year": 2000,
     "runtime": 155,
     "imdbRating": 8.5,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A former Roman General sets out to exact vengeance against the corrupt emperor who murdered his family and sent him into slavery.",
+    "cast": [
+      "Russell Crowe",
+      "Joaquin Phoenix",
+      "Connie Nielsen",
+      "Oliver Reed"
+    ]
   },
   {
     "movieId": "american-history-x-1998",
@@ -447,7 +727,14 @@
     "year": 1998,
     "runtime": 119,
     "imdbRating": 8.5,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A former neo-nazi skinhead tries to prevent his younger brother from going down the same wrong path that he did.",
+    "cast": [
+      "Edward Norton",
+      "Edward Furlong",
+      "Beverly D'Angelo",
+      "Jennifer Lien"
+    ]
   },
   {
     "movieId": "the-usual-suspects-1995",
@@ -458,7 +745,14 @@
     "year": 1995,
     "runtime": 106,
     "imdbRating": 8.5,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A sole survivor tells of the twisty events leading up to a horrific gun battle on a boat, which began when five criminals met at a seemingly random police lineup.",
+    "cast": [
+      "Kevin Spacey",
+      "Gabriel Byrne",
+      "Chazz Palminteri",
+      "Stephen Baldwin"
+    ]
   },
   {
     "movieId": "l-on-1994",
@@ -469,7 +763,14 @@
     "year": 1994,
     "runtime": 110,
     "imdbRating": 8.5,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Mathilda, a 12-year-old girl, is reluctantly taken in by Léon, a professional assassin, after her family is murdered. An unusual relationship forms as she becomes his protégée and learns the assassin's trade.",
+    "cast": [
+      "Jean Reno",
+      "Gary Oldman",
+      "Natalie Portman",
+      "Danny Aiello"
+    ]
   },
   {
     "movieId": "the-lion-king-1994",
@@ -480,7 +781,14 @@
     "year": 1994,
     "runtime": 88,
     "imdbRating": 8.5,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Lion prince Simba and his father are targeted by his bitter uncle, who wants to ascend the throne himself.",
+    "cast": [
+      "Rob Minkoff",
+      "Matthew Broderick",
+      "Jeremy Irons",
+      "James Earl Jones"
+    ]
   },
   {
     "movieId": "terminator-2-judgment-day-1991",
@@ -491,7 +799,14 @@
     "year": 1991,
     "runtime": 137,
     "imdbRating": 8.5,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A cyborg, identical to the one who failed to kill Sarah Connor, must now protect her teenage son, John Connor, from a more advanced and powerful cyborg.",
+    "cast": [
+      "Arnold Schwarzenegger",
+      "Linda Hamilton",
+      "Edward Furlong",
+      "Robert Patrick"
+    ]
   },
   {
     "movieId": "nuovo-cinema-paradiso-1988",
@@ -502,7 +817,14 @@
     "year": 1988,
     "runtime": 155,
     "imdbRating": 8.5,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A filmmaker recalls his childhood when falling in love with the pictures at the cinema of his home village and forms a deep friendship with the cinema's projectionist.",
+    "cast": [
+      "Philippe Noiret",
+      "Enzo Cannavale",
+      "Antonella Attili",
+      "Isa Danieli"
+    ]
   },
   {
     "movieId": "hotaru-no-haka-1988",
@@ -513,7 +835,14 @@
     "year": 1988,
     "runtime": 89,
     "imdbRating": 8.5,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A young boy and his little sister struggle to survive in Japan during World War II.",
+    "cast": [
+      "Tsutomu Tatsumi",
+      "Ayano Shiraishi",
+      "Akemi Yamaguchi",
+      "Yoshiko Shinohara"
+    ]
   },
   {
     "movieId": "back-to-the-future-1985",
@@ -524,7 +853,14 @@
     "year": 1985,
     "runtime": 116,
     "imdbRating": 8.5,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Marty McFly, a 17-year-old high school student, is accidentally sent thirty years into the past in a time-traveling DeLorean invented by his close friend, the eccentric scientist Doc Brown.",
+    "cast": [
+      "Michael J. Fox",
+      "Christopher Lloyd",
+      "Lea Thompson",
+      "Crispin Glover"
+    ]
   },
   {
     "movieId": "once-upon-a-time-in-the-west-1968",
@@ -535,7 +871,14 @@
     "year": 1968,
     "runtime": 165,
     "imdbRating": 8.5,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A mysterious stranger with a harmonica joins forces with a notorious desperado to protect a beautiful widow from a ruthless assassin working for the railroad.",
+    "cast": [
+      "Henry Fonda",
+      "Charles Bronson",
+      "Claudia Cardinale",
+      "Jason Robards"
+    ]
   },
   {
     "movieId": "psycho-1960",
@@ -546,7 +889,14 @@
     "year": 1960,
     "runtime": 109,
     "imdbRating": 8.5,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A Phoenix secretary embezzles $40,000 from her employer's client, goes on the run, and checks into a remote motel run by a young man under the domination of his mother.",
+    "cast": [
+      "Anthony Perkins",
+      "Janet Leigh",
+      "Vera Miles",
+      "John Gavin"
+    ]
   },
   {
     "movieId": "casablanca-1942",
@@ -557,7 +907,14 @@
     "year": 1942,
     "runtime": 102,
     "imdbRating": 8.5,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A cynical expatriate American cafe owner struggles to decide whether or not to help his former lover and her fugitive husband escape the Nazis in French Morocco.",
+    "cast": [
+      "Humphrey Bogart",
+      "Ingrid Bergman",
+      "Paul Henreid",
+      "Claude Rains"
+    ]
   },
   {
     "movieId": "modern-times-1936",
@@ -568,7 +925,14 @@
     "year": 1936,
     "runtime": 87,
     "imdbRating": 8.5,
-    "rated": "G"
+    "rated": "G",
+    "synopsis": "The Tramp struggles to live in modern industrial society with the help of a young homeless woman.",
+    "cast": [
+      "Charles Chaplin",
+      "Paulette Goddard",
+      "Henry Bergman",
+      "Tiny Sandford"
+    ]
   },
   {
     "movieId": "city-lights-1931",
@@ -579,7 +943,14 @@
     "year": 1931,
     "runtime": 87,
     "imdbRating": 8.5,
-    "rated": "G"
+    "rated": "G",
+    "synopsis": "With the aid of a wealthy erratic tippler, a dewy-eyed tramp who has fallen in love with a sightless flower girl accumulates money to be able to help her medically.",
+    "cast": [
+      "Charles Chaplin",
+      "Virginia Cherrill",
+      "Florence Lee",
+      "Harry Myers"
+    ]
   },
   {
     "movieId": "capharna-m-2018",
@@ -590,7 +961,14 @@
     "year": 2018,
     "runtime": 126,
     "imdbRating": 8.4,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "While serving a five-year sentence for a violent crime, a 12-year-old boy sues his parents for neglect.",
+    "cast": [
+      "Zain Al Rafeea",
+      "Yordanos Shiferaw",
+      "Boluwatife Treasure Bankole",
+      "Kawsar Al Haddad"
+    ]
   },
   {
     "movieId": "ayla-the-daughter-of-war-2017",
@@ -600,7 +978,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNWJhMDlmZGUtYzcxNS00NDRiLWIwNjktNDY1Mjg3ZjBkYzY0XkEyXkFqcGdeQXVyMTU4MjUwMjI@._V1_SX4000.jpg",
     "year": 2017,
     "runtime": 125,
-    "imdbRating": 8.4
+    "imdbRating": 8.4,
+    "synopsis": "In 1950, amid-st the ravages of the Korean War, Sergeant Süleyman stumbles upon a half-frozen little girl, with no parents and no help in sight. Frantic, scared and on the verge of death, ...                See full summary »",
+    "cast": [
+      "Erdem Can",
+      "Çetin Tekindor",
+      "Ismail Hacioglu",
+      "Kyung-jin Lee"
+    ]
   },
   {
     "movieId": "vikram-vedha-2017",
@@ -611,7 +996,14 @@
     "year": 2017,
     "runtime": 147,
     "imdbRating": 8.4,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Vikram, a no-nonsense police officer, accompanied by Simon, his partner, is on the hunt to capture Vedha, a smuggler and a murderer. Vedha tries to change Vikram's life, which leads to a conflict.",
+    "cast": [
+      "Pushkar",
+      "Madhavan",
+      "Vijay Sethupathi",
+      "Shraddha Srinath"
+    ]
   },
   {
     "movieId": "kimi-no-na-wa-2016",
@@ -622,7 +1014,14 @@
     "year": 2016,
     "runtime": 106,
     "imdbRating": 8.4,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Two strangers find themselves linked in a bizarre way. When a connection forms, will distance be the only thing to keep them apart?",
+    "cast": [
+      "Ryûnosuke Kamiki",
+      "Mone Kamishiraishi",
+      "Ryô Narita",
+      "Aoi Yûki"
+    ]
   },
   {
     "movieId": "dangal-2016",
@@ -633,7 +1032,14 @@
     "year": 2016,
     "runtime": 161,
     "imdbRating": 8.4,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Former wrestler Mahavir Singh Phogat and his two wrestler daughters struggle towards glory at the Commonwealth Games in the face of societal oppression.",
+    "cast": [
+      "Aamir Khan",
+      "Sakshi Tanwar",
+      "Fatima Sana Shaikh",
+      "Sanya Malhotra"
+    ]
   },
   {
     "movieId": "spider-man-into-the-spider-verse-2018",
@@ -644,7 +1050,14 @@
     "year": 2018,
     "runtime": 117,
     "imdbRating": 8.4,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Teen Miles Morales becomes the Spider-Man of his universe, and must join with five spider-powered individuals from other dimensions to stop a threat for all realities.",
+    "cast": [
+      "Peter Ramsey",
+      "Rodney Rothman",
+      "Shameik Moore",
+      "Jake Johnson"
+    ]
   },
   {
     "movieId": "avengers-endgame-2019",
@@ -655,7 +1068,14 @@
     "year": 2019,
     "runtime": 181,
     "imdbRating": 8.4,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "After the devastating events of Avengers: Infinity War (2018), the universe is in ruins. With the help of remaining allies, the Avengers assemble once more in order to reverse Thanos' actions and restore balance to the universe.",
+    "cast": [
+      "Joe Russo",
+      "Robert Downey Jr.",
+      "Chris Evans",
+      "Mark Ruffalo"
+    ]
   },
   {
     "movieId": "avengers-infinity-war-2018",
@@ -666,7 +1086,14 @@
     "year": 2018,
     "runtime": 149,
     "imdbRating": 8.4,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The Avengers and their allies must be willing to sacrifice all in an attempt to defeat the powerful Thanos before his blitz of devastation and ruin puts an end to the universe.",
+    "cast": [
+      "Joe Russo",
+      "Robert Downey Jr.",
+      "Chris Hemsworth",
+      "Mark Ruffalo"
+    ]
   },
   {
     "movieId": "coco-2017",
@@ -677,7 +1104,14 @@
     "year": 2017,
     "runtime": 105,
     "imdbRating": 8.4,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Aspiring musician Miguel, confronted with his family's ancestral ban on music, enters the Land of the Dead to find his great-great-grandfather, a legendary singer.",
+    "cast": [
+      "Adrian Molina",
+      "Anthony Gonzalez",
+      "Gael García Bernal",
+      "Benjamin Bratt"
+    ]
   },
   {
     "movieId": "django-unchained-2012",
@@ -688,7 +1122,14 @@
     "year": 2012,
     "runtime": 165,
     "imdbRating": 8.4,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "With the help of a German bounty hunter, a freed slave sets out to rescue his wife from a brutal Mississippi plantation owner.",
+    "cast": [
+      "Jamie Foxx",
+      "Christoph Waltz",
+      "Leonardo DiCaprio",
+      "Kerry Washington"
+    ]
   },
   {
     "movieId": "the-dark-knight-rises-2012",
@@ -699,7 +1140,14 @@
     "year": 2012,
     "runtime": 164,
     "imdbRating": 8.4,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Eight years after the Joker's reign of anarchy, Batman, with the help of the enigmatic Catwoman, is forced from his exile to save Gotham City from the brutal guerrilla terrorist Bane.",
+    "cast": [
+      "Christian Bale",
+      "Tom Hardy",
+      "Anne Hathaway",
+      "Gary Oldman"
+    ]
   },
   {
     "movieId": "3-idiots-2009",
@@ -710,7 +1158,14 @@
     "year": 2009,
     "runtime": 170,
     "imdbRating": 8.4,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Two friends are searching for their long lost companion. They revisit their college days and recall the memories of their friend who inspired them to think differently, even as the rest of the world called them \"idiots\".",
+    "cast": [
+      "Aamir Khan",
+      "Madhavan",
+      "Mona Singh",
+      "Sharman Joshi"
+    ]
   },
   {
     "movieId": "taare-zameen-par-2007",
@@ -721,7 +1176,14 @@
     "year": 2007,
     "runtime": 165,
     "imdbRating": 8.4,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "An eight-year-old boy is thought to be a lazy trouble-maker, until the new art teacher has the patience and compassion to discover the real problem behind his struggles in school.",
+    "cast": [
+      "Amole Gupte",
+      "Darsheel Safary",
+      "Aamir Khan",
+      "Tisca Chopra"
+    ]
   },
   {
     "movieId": "wall-e-2008",
@@ -732,7 +1194,14 @@
     "year": 2008,
     "runtime": 98,
     "imdbRating": 8.4,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In the distant future, a small waste-collecting robot inadvertently embarks on a space journey that will ultimately decide the fate of mankind.",
+    "cast": [
+      "Ben Burtt",
+      "Elissa Knight",
+      "Jeff Garlin",
+      "Fred Willard"
+    ]
   },
   {
     "movieId": "the-lives-of-others-2006",
@@ -743,7 +1212,14 @@
     "year": 2006,
     "runtime": 137,
     "imdbRating": 8.4,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In 1984 East Berlin, an agent of the secret police, conducting surveillance on a writer and his lover, finds himself becoming increasingly absorbed by their lives.",
+    "cast": [
+      "Ulrich Mühe",
+      "Martina Gedeck",
+      "Sebastian Koch",
+      "Ulrich Tukur"
+    ]
   },
   {
     "movieId": "oldeuboi-2003",
@@ -754,7 +1230,14 @@
     "year": 2003,
     "runtime": 101,
     "imdbRating": 8.4,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "After being kidnapped and imprisoned for fifteen years, Oh Dae-Su is released, only to find that he must find his captor in five days.",
+    "cast": [
+      "Choi Min-sik",
+      "Yoo Ji-Tae",
+      "Kang Hye-jeong",
+      "Kim Byeong-Ok"
+    ]
   },
   {
     "movieId": "memento-2000",
@@ -765,7 +1248,14 @@
     "year": 2000,
     "runtime": 113,
     "imdbRating": 8.4,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A man with short-term memory loss attempts to track down his wife's murderer.",
+    "cast": [
+      "Guy Pearce",
+      "Carrie-Anne Moss",
+      "Joe Pantoliano",
+      "Mark Boone Junior"
+    ]
   },
   {
     "movieId": "mononoke-hime-1997",
@@ -776,7 +1266,14 @@
     "year": 1997,
     "runtime": 134,
     "imdbRating": 8.4,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "On a journey to find the cure for a Tatarigami's curse, Ashitaka finds himself in the middle of a war between the forest gods and Tatara, a mining colony. In this quest he also meets San, the Mononoke Hime.",
+    "cast": [
+      "Yôji Matsuda",
+      "Yuriko Ishida",
+      "Yûko Tanaka",
+      "Billy Crudup"
+    ]
   },
   {
     "movieId": "once-upon-a-time-in-america-1984",
@@ -787,7 +1284,14 @@
     "year": 1984,
     "runtime": 229,
     "imdbRating": 8.4,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A former Prohibition-era Jewish gangster returns to the Lower East Side of Manhattan over thirty years later, where he once again must confront the ghosts and regrets of his old life.",
+    "cast": [
+      "Robert De Niro",
+      "James Woods",
+      "Elizabeth McGovern",
+      "Treat Williams"
+    ]
   },
   {
     "movieId": "raiders-of-the-lost-ark-1981",
@@ -798,7 +1302,14 @@
     "year": 1981,
     "runtime": 115,
     "imdbRating": 8.4,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In 1936, archaeologist and adventurer Indiana Jones is hired by the U.S. government to find the Ark of the Covenant before Adolf Hitler's Nazis can obtain its awesome powers.",
+    "cast": [
+      "Harrison Ford",
+      "Karen Allen",
+      "Paul Freeman",
+      "John Rhys-Davies"
+    ]
   },
   {
     "movieId": "the-shining-1980",
@@ -809,7 +1320,14 @@
     "year": 1980,
     "runtime": 146,
     "imdbRating": 8.4,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A family heads to an isolated hotel for the winter where a sinister presence influences the father into violence, while his psychic son sees horrific forebodings from both past and future.",
+    "cast": [
+      "Jack Nicholson",
+      "Shelley Duvall",
+      "Danny Lloyd",
+      "Scatman Crothers"
+    ]
   },
   {
     "movieId": "apocalypse-now-1979",
@@ -820,7 +1338,14 @@
     "year": 1979,
     "runtime": 147,
     "imdbRating": 8.4,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A U.S. Army officer serving in Vietnam is tasked with assassinating a renegade Special Forces Colonel who sees himself as a god.",
+    "cast": [
+      "Martin Sheen",
+      "Marlon Brando",
+      "Robert Duvall",
+      "Frederic Forrest"
+    ]
   },
   {
     "movieId": "alien-1979",
@@ -831,7 +1356,14 @@
     "year": 1979,
     "runtime": 117,
     "imdbRating": 8.4,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "After a space merchant vessel receives an unknown transmission as a distress call, one of the crew is attacked by a mysterious life form and they soon realize that its life cycle has merely begun.",
+    "cast": [
+      "Sigourney Weaver",
+      "Tom Skerritt",
+      "John Hurt",
+      "Veronica Cartwright"
+    ]
   },
   {
     "movieId": "anand-1971",
@@ -842,7 +1374,14 @@
     "year": 1971,
     "runtime": 122,
     "imdbRating": 8.4,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The story of a terminally ill man who wishes to live life to the fullest before the inevitable occurs, as told by his best friend.",
+    "cast": [
+      "Rajesh Khanna",
+      "Amitabh Bachchan",
+      "Sumita Sanyal",
+      "Ramesh Deo"
+    ]
   },
   {
     "movieId": "tengoku-to-jigoku-1963",
@@ -852,7 +1391,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BOTI4NTNhZDMtMWNkZi00MTRmLWJmZDQtMmJkMGVmZTEzODlhXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_SX4000.jpg",
     "year": 1963,
     "runtime": 143,
-    "imdbRating": 8.4
+    "imdbRating": 8.4,
+    "synopsis": "An executive of a shoe company becomes a victim of extortion when his chauffeur's son is kidnapped and held for ransom.",
+    "cast": [
+      "Toshirô Mifune",
+      "Yutaka Sada",
+      "Tatsuya Nakadai",
+      "Kyôko Kagawa"
+    ]
   },
   {
     "movieId": "dr-strangelove-or-how-i-learned-to-stop-worrying-and-love-the-bomb-1964",
@@ -863,7 +1409,14 @@
     "year": 1964,
     "runtime": 95,
     "imdbRating": 8.4,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An insane general triggers a path to nuclear holocaust that a War Room full of politicians and generals frantically tries to stop.",
+    "cast": [
+      "Peter Sellers",
+      "George C. Scott",
+      "Sterling Hayden",
+      "Keenan Wynn"
+    ]
   },
   {
     "movieId": "witness-for-the-prosecution-1957",
@@ -874,7 +1427,14 @@
     "year": 1957,
     "runtime": 116,
     "imdbRating": 8.4,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A veteran British barrister must defend his client in a murder trial that has surprise after surprise.",
+    "cast": [
+      "Tyrone Power",
+      "Marlene Dietrich",
+      "Charles Laughton",
+      "Elsa Lanchester"
+    ]
   },
   {
     "movieId": "paths-of-glory-1957",
@@ -885,7 +1445,14 @@
     "year": 1957,
     "runtime": 88,
     "imdbRating": 8.4,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "After refusing to attack an enemy position, a general accuses the soldiers of cowardice and their commanding officer must defend them.",
+    "cast": [
+      "Kirk Douglas",
+      "Ralph Meeker",
+      "Adolphe Menjou",
+      "George Macready"
+    ]
   },
   {
     "movieId": "rear-window-1954",
@@ -896,7 +1463,14 @@
     "year": 1954,
     "runtime": 112,
     "imdbRating": 8.4,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A wheelchair-bound photographer spies on his neighbors from his apartment window and becomes convinced one of them has committed murder.",
+    "cast": [
+      "James Stewart",
+      "Grace Kelly",
+      "Wendell Corey",
+      "Thelma Ritter"
+    ]
   },
   {
     "movieId": "sunset-blvd-1950",
@@ -907,7 +1481,14 @@
     "year": 1950,
     "runtime": 110,
     "imdbRating": 8.4,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A screenwriter develops a dangerous relationship with a faded film star determined to make a triumphant return.",
+    "cast": [
+      "William Holden",
+      "Gloria Swanson",
+      "Erich von Stroheim",
+      "Nancy Olson"
+    ]
   },
   {
     "movieId": "the-great-dictator-1940",
@@ -918,7 +1499,14 @@
     "year": 1940,
     "runtime": 125,
     "imdbRating": 8.4,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "Dictator Adenoid Hynkel tries to expand his empire while a poor Jewish barber tries to avoid persecution from Hynkel's regime.",
+    "cast": [
+      "Charles Chaplin",
+      "Paulette Goddard",
+      "Jack Oakie",
+      "Reginald Gardiner"
+    ]
   },
   {
     "movieId": "1917-2019",
@@ -929,7 +1517,14 @@
     "year": 2019,
     "runtime": 119,
     "imdbRating": 8.3,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "April 6th, 1917. As a regiment assembles to wage war deep in enemy territory, two soldiers are assigned to race against time and deliver a message that will stop 1,600 men from walking straight into a deadly trap.",
+    "cast": [
+      "Dean-Charles Chapman",
+      "George MacKay",
+      "Daniel Mays",
+      "Colin Firth"
+    ]
   },
   {
     "movieId": "tumbbad-2018",
@@ -940,7 +1535,14 @@
     "year": 2018,
     "runtime": 104,
     "imdbRating": 8.3,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A mythological story about a goddess who created the entire universe. The plot revolves around the consequences when humans build a temple for her first-born.",
+    "cast": [
+      "Anand Gandhi",
+      "Adesh Prasad",
+      "Sohum Shah",
+      "Jyoti Malshe"
+    ]
   },
   {
     "movieId": "andhadhun-2018",
@@ -951,7 +1553,14 @@
     "year": 2018,
     "runtime": 139,
     "imdbRating": 8.3,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A series of mysterious events change the life of a blind pianist, who must now report a crime that he should technically know nothing of.",
+    "cast": [
+      "Ayushmann Khurrana",
+      "Tabu",
+      "Radhika Apte",
+      "Anil Dhawan"
+    ]
   },
   {
     "movieId": "drishyam-2013",
@@ -962,7 +1571,14 @@
     "year": 2013,
     "runtime": 160,
     "imdbRating": 8.3,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Desperate measures are taken by a man who tries to save his family from the dark side of the law, after they commit an unexpected crime.",
+    "cast": [
+      "Ajay Devgn",
+      "Shriya Saran",
+      "Tabu",
+      "Rajat Kapoor"
+    ]
   },
   {
     "movieId": "jagten-2012",
@@ -973,7 +1589,14 @@
     "year": 2012,
     "runtime": 115,
     "imdbRating": 8.3,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A teacher lives a lonely life, all the while struggling over his son's custody. His life slowly gets better as he finds love and receives good news from his son, but his new luck is about to be brutally shattered by an innocent little lie.",
+    "cast": [
+      "Mads Mikkelsen",
+      "Thomas Bo Larsen",
+      "Annika Wedderkopp",
+      "Lasse Fogelstrøm"
+    ]
   },
   {
     "movieId": "jodaeiye-nader-az-simin-2011",
@@ -984,7 +1607,14 @@
     "year": 2011,
     "runtime": 123,
     "imdbRating": 8.3,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A married couple are faced with a difficult decision - to improve the life of their child by moving to another country or to stay in Iran and look after a deteriorating parent who has Alzheimer's disease.",
+    "cast": [
+      "Payman Maadi",
+      "Leila Hatami",
+      "Sareh Bayat",
+      "Shahab Hosseini"
+    ]
   },
   {
     "movieId": "incendies-2010",
@@ -995,7 +1625,14 @@
     "year": 2010,
     "runtime": 131,
     "imdbRating": 8.3,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Twins journey to the Middle East to discover their family history and fulfill their mother's last wishes.",
+    "cast": [
+      "Lubna Azabal",
+      "Mélissa Désormeaux-Poulin",
+      "Maxim Gaudette",
+      "Mustafa Kamel"
+    ]
   },
   {
     "movieId": "miracle-in-cell-no-7-2019",
@@ -1006,7 +1643,14 @@
     "year": 2019,
     "runtime": 132,
     "imdbRating": 8.3,
-    "rated": "TV-14"
+    "rated": "TV-14",
+    "synopsis": "A story of love between a mentally-ill father who was wrongly accused of murder and his lovely six years old daughter. The prison would be their home. Based on the 2013 Korean movie 7-beon-bang-ui seon-mul (2013).",
+    "cast": [
+      "Aras Bulut Iynemli",
+      "Nisa Sofiya Aksongur",
+      "Deniz Baysal",
+      "Celile Toyon Uysal"
+    ]
   },
   {
     "movieId": "babam-ve-oglum-2005",
@@ -1016,7 +1660,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNjAzMzEwYzctNjc1MC00Nzg5LWFmMGItMTgzYmMyNTY2OTQ4XkEyXkFqcGdeQXVyNjU0OTQ0OTY@._V1_SX4000.jpg",
     "year": 2005,
     "runtime": 112,
-    "imdbRating": 8.3
+    "imdbRating": 8.3,
+    "synopsis": "The family of a left-wing journalist is torn apart after the military coup of Turkey in 1980.",
+    "cast": [
+      "Çetin Tekindor",
+      "Fikret Kuskan",
+      "Hümeyra",
+      "Ege Tanman"
+    ]
   },
   {
     "movieId": "inglourious-basterds-2009",
@@ -1027,7 +1678,14 @@
     "year": 2009,
     "runtime": 153,
     "imdbRating": 8.3,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In Nazi-occupied France during World War II, a plan to assassinate Nazi leaders by a group of Jewish U.S. soldiers coincides with a theatre owner's vengeful plans for the same.",
+    "cast": [
+      "Brad Pitt",
+      "Diane Kruger",
+      "Eli Roth",
+      "Mélanie Laurent"
+    ]
   },
   {
     "movieId": "eternal-sunshine-of-the-spotless-mind-2004",
@@ -1038,7 +1696,14 @@
     "year": 2004,
     "runtime": 108,
     "imdbRating": 8.3,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "When their relationship turns sour, a couple undergoes a medical procedure to have each other erased from their memories.",
+    "cast": [
+      "Jim Carrey",
+      "Kate Winslet",
+      "Tom Wilkinson",
+      "Gerry Robert Byrne"
+    ]
   },
   {
     "movieId": "am-lie-2001",
@@ -1049,7 +1714,14 @@
     "year": 2001,
     "runtime": 122,
     "imdbRating": 8.3,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Amélie is an innocent and naive girl in Paris with her own sense of justice. She decides to help those around her and, along the way, discovers love.",
+    "cast": [
+      "Audrey Tautou",
+      "Mathieu Kassovitz",
+      "Rufus",
+      "Lorella Cravotta"
+    ]
   },
   {
     "movieId": "snatch-2000",
@@ -1060,7 +1732,14 @@
     "year": 2000,
     "runtime": 104,
     "imdbRating": 8.3,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Unscrupulous boxing promoters, violent bookmakers, a Russian gangster, incompetent amateur robbers and supposedly Jewish jewelers fight to track down a priceless stolen diamond.",
+    "cast": [
+      "Jason Statham",
+      "Brad Pitt",
+      "Benicio Del Toro",
+      "Dennis Farina"
+    ]
   },
   {
     "movieId": "requiem-for-a-dream-2000",
@@ -1071,7 +1750,14 @@
     "year": 2000,
     "runtime": 102,
     "imdbRating": 8.3,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The drug-induced utopias of four Coney Island people are shattered when their addictions run deep.",
+    "cast": [
+      "Ellen Burstyn",
+      "Jared Leto",
+      "Jennifer Connelly",
+      "Marlon Wayans"
+    ]
   },
   {
     "movieId": "american-beauty-1999",
@@ -1082,7 +1768,14 @@
     "year": 1999,
     "runtime": 122,
     "imdbRating": 8.3,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A sexually frustrated suburban father has a mid-life crisis after becoming infatuated with his daughter's best friend.",
+    "cast": [
+      "Kevin Spacey",
+      "Annette Bening",
+      "Thora Birch",
+      "Wes Bentley"
+    ]
   },
   {
     "movieId": "good-will-hunting-1997",
@@ -1093,7 +1786,14 @@
     "year": 1997,
     "runtime": 126,
     "imdbRating": 8.3,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Will Hunting, a janitor at M.I.T., has a gift for mathematics, but needs help from a psychologist to find direction in his life.",
+    "cast": [
+      "Robin Williams",
+      "Matt Damon",
+      "Ben Affleck",
+      "Stellan Skarsgård"
+    ]
   },
   {
     "movieId": "bacheha-ye-aseman-1997",
@@ -1104,7 +1804,14 @@
     "year": 1997,
     "runtime": 89,
     "imdbRating": 8.3,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "After a boy loses his sister's pair of shoes, he goes on a series of adventures in order to find them. When he can't, he tries a new way to \"win\" a new pair.",
+    "cast": [
+      "Mohammad Amir Naji",
+      "Amir Farrokh Hashemian",
+      "Bahare Seddiqi",
+      "Nafise Jafar-Mohammadi"
+    ]
   },
   {
     "movieId": "toy-story-1995",
@@ -1115,7 +1822,14 @@
     "year": 1995,
     "runtime": 81,
     "imdbRating": 8.3,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A cowboy doll is profoundly threatened and jealous when a new spaceman figure supplants him as top toy in a boy's room.",
+    "cast": [
+      "Tom Hanks",
+      "Tim Allen",
+      "Don Rickles",
+      "Jim Varney"
+    ]
   },
   {
     "movieId": "braveheart-1995",
@@ -1126,7 +1840,14 @@
     "year": 1995,
     "runtime": 178,
     "imdbRating": 8.3,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Scottish warrior William Wallace leads his countrymen in a rebellion to free his homeland from the tyranny of King Edward I of England.",
+    "cast": [
+      "Mel Gibson",
+      "Sophie Marceau",
+      "Patrick McGoohan",
+      "Angus Macfadyen"
+    ]
   },
   {
     "movieId": "reservoir-dogs-1992",
@@ -1137,7 +1858,14 @@
     "year": 1992,
     "runtime": 99,
     "imdbRating": 8.3,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "When a simple jewelry heist goes horribly wrong, the surviving criminals begin to suspect that one of them is a police informant.",
+    "cast": [
+      "Harvey Keitel",
+      "Tim Roth",
+      "Michael Madsen",
+      "Chris Penn"
+    ]
   },
   {
     "movieId": "full-metal-jacket-1987",
@@ -1148,7 +1876,14 @@
     "year": 1987,
     "runtime": 116,
     "imdbRating": 8.3,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A pragmatic U.S. Marine observes the dehumanizing effects the Vietnam War has on his fellow recruits from their brutal boot camp training to the bloody street fighting in Hue.",
+    "cast": [
+      "Matthew Modine",
+      "R. Lee Ermey",
+      "Vincent D'Onofrio",
+      "Adam Baldwin"
+    ]
   },
   {
     "movieId": "idi-i-smotri-1985",
@@ -1159,7 +1894,14 @@
     "year": 1985,
     "runtime": 142,
     "imdbRating": 8.3,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "After finding an old rifle, a young boy joins the Soviet resistance movement against ruthless German forces and experiences the horrors of World War II.",
+    "cast": [
+      "Aleksey Kravchenko",
+      "Olga Mironova",
+      "Liubomiras Laucevicius",
+      "Vladas Bagdonas"
+    ]
   },
   {
     "movieId": "aliens-1986",
@@ -1170,7 +1912,14 @@
     "year": 1986,
     "runtime": 137,
     "imdbRating": 8.3,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Fifty-seven years after surviving an apocalyptic attack aboard her space vessel by merciless space creatures, Officer Ripley awakens from hyper-sleep and tries to warn anyone who will listen about the predators.",
+    "cast": [
+      "Sigourney Weaver",
+      "Michael Biehn",
+      "Carrie Henn",
+      "Paul Reiser"
+    ]
   },
   {
     "movieId": "amadeus-1984",
@@ -1181,7 +1930,14 @@
     "year": 1984,
     "runtime": 160,
     "imdbRating": 8.3,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "The life, success and troubles of Wolfgang Amadeus Mozart, as told by Antonio Salieri, the contemporaneous composer who was insanely jealous of Mozart's talent and claimed to have murdered him.",
+    "cast": [
+      "F. Murray Abraham",
+      "Tom Hulce",
+      "Elizabeth Berridge",
+      "Roy Dotrice"
+    ]
   },
   {
     "movieId": "scarface-1983",
@@ -1192,7 +1948,14 @@
     "year": 1983,
     "runtime": 170,
     "imdbRating": 8.3,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In 1980 Miami, a determined Cuban immigrant takes over a drug cartel and succumbs to greed.",
+    "cast": [
+      "Al Pacino",
+      "Michelle Pfeiffer",
+      "Steven Bauer",
+      "Mary Elizabeth Mastrantonio"
+    ]
   },
   {
     "movieId": "star-wars-episode-vi-return-of-the-jedi-1983",
@@ -1203,7 +1966,14 @@
     "year": 1983,
     "runtime": 131,
     "imdbRating": 8.3,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "After a daring mission to rescue Han Solo from Jabba the Hutt, the Rebels dispatch to Endor to destroy the second Death Star. Meanwhile, Luke struggles to help Darth Vader back from the dark side without falling into the Emperor's trap.",
+    "cast": [
+      "Mark Hamill",
+      "Harrison Ford",
+      "Carrie Fisher",
+      "Billy Dee Williams"
+    ]
   },
   {
     "movieId": "das-boot-1981",
@@ -1214,7 +1984,14 @@
     "year": 1981,
     "runtime": 149,
     "imdbRating": 8.3,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "The claustrophobic world of a WWII German U-boat; boredom, filth and sheer terror.",
+    "cast": [
+      "Jürgen Prochnow",
+      "Herbert Grönemeyer",
+      "Klaus Wennemann",
+      "Hubertus Bengsch"
+    ]
   },
   {
     "movieId": "taxi-driver-1976",
@@ -1225,7 +2002,14 @@
     "year": 1976,
     "runtime": 114,
     "imdbRating": 8.3,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A mentally unstable veteran works as a nighttime taxi driver in New York City, where the perceived decadence and sleaze fuels his urge for violent action by attempting to liberate a presidential campaign worker and an underage prostitute.",
+    "cast": [
+      "Robert De Niro",
+      "Jodie Foster",
+      "Cybill Shepherd",
+      "Albert Brooks"
+    ]
   },
   {
     "movieId": "the-sting-1973",
@@ -1236,7 +2020,14 @@
     "year": 1973,
     "runtime": 129,
     "imdbRating": 8.3,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Two grifters team up to pull off the ultimate con.",
+    "cast": [
+      "Paul Newman",
+      "Robert Redford",
+      "Robert Shaw",
+      "Charles Durning"
+    ]
   },
   {
     "movieId": "a-clockwork-orange-1971",
@@ -1247,7 +2038,14 @@
     "year": 1971,
     "runtime": 136,
     "imdbRating": 8.3,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In the future, a sadistic gang leader is imprisoned and volunteers for a conduct-aversion experiment, but it doesn't go as planned.",
+    "cast": [
+      "Malcolm McDowell",
+      "Patrick Magee",
+      "Michael Bates",
+      "Warren Clarke"
+    ]
   },
   {
     "movieId": "2001-a-space-odyssey-1968",
@@ -1258,7 +2056,14 @@
     "year": 1968,
     "runtime": 149,
     "imdbRating": 8.3,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "After discovering a mysterious artifact buried beneath the Lunar surface, mankind sets off on a quest to find its origins with help from intelligent supercomputer H.A.L. 9000.",
+    "cast": [
+      "Keir Dullea",
+      "Gary Lockwood",
+      "William Sylvester",
+      "Daniel Richter"
+    ]
   },
   {
     "movieId": "per-qualche-dollaro-in-pi-1965",
@@ -1269,7 +2074,14 @@
     "year": 1965,
     "runtime": 132,
     "imdbRating": 8.3,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Two bounty hunters with the same intentions team up to track down a Western outlaw.",
+    "cast": [
+      "Clint Eastwood",
+      "Lee Van Cleef",
+      "Gian Maria Volontè",
+      "Mara Krupp"
+    ]
   },
   {
     "movieId": "lawrence-of-arabia-1962",
@@ -1280,7 +2092,14 @@
     "year": 1962,
     "runtime": 228,
     "imdbRating": 8.3,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The story of T.E. Lawrence, the English officer who successfully united and led the diverse, often warring, Arab tribes during World War I in order to fight the Turks.",
+    "cast": [
+      "Peter O'Toole",
+      "Alec Guinness",
+      "Anthony Quinn",
+      "Jack Hawkins"
+    ]
   },
   {
     "movieId": "the-apartment-1960",
@@ -1291,7 +2110,14 @@
     "year": 1960,
     "runtime": 125,
     "imdbRating": 8.3,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A man tries to rise in his company by letting its executives use his apartment for trysts, but complications and a romance of his own ensue.",
+    "cast": [
+      "Jack Lemmon",
+      "Shirley MacLaine",
+      "Fred MacMurray",
+      "Ray Walston"
+    ]
   },
   {
     "movieId": "north-by-northwest-1959",
@@ -1302,7 +2128,14 @@
     "year": 1959,
     "runtime": 136,
     "imdbRating": 8.3,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A New York City advertising executive goes on the run after being mistaken for a government agent by a group of foreign spies.",
+    "cast": [
+      "Cary Grant",
+      "Eva Marie Saint",
+      "James Mason",
+      "Jessie Royce Landis"
+    ]
   },
   {
     "movieId": "vertigo-1958",
@@ -1313,7 +2146,14 @@
     "year": 1958,
     "runtime": 128,
     "imdbRating": 8.3,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A former police detective juggles wrestling with his personal demons and becoming obsessed with a hauntingly beautiful woman.",
+    "cast": [
+      "James Stewart",
+      "Kim Novak",
+      "Barbara Bel Geddes",
+      "Tom Helmore"
+    ]
   },
   {
     "movieId": "singin-in-the-rain-1952",
@@ -1324,7 +2164,14 @@
     "year": 1952,
     "runtime": 103,
     "imdbRating": 8.3,
-    "rated": "G"
+    "rated": "G",
+    "synopsis": "A silent film production company and cast make a difficult transition to sound.",
+    "cast": [
+      "Gene Kelly",
+      "Gene Kelly",
+      "Donald O'Connor",
+      "Debbie Reynolds"
+    ]
   },
   {
     "movieId": "ikiru-1952",
@@ -1334,7 +2181,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BZmM0NGY3Y2MtMTA1YS00YmQzLTk2YTctYWFhMDkzMDRjZWQzXkEyXkFqcGdeQXVyNTA4NzY1MzY@._V1_SX4000.jpg",
     "year": 1952,
     "runtime": 143,
-    "imdbRating": 8.3
+    "imdbRating": 8.3,
+    "synopsis": "A bureaucrat tries to find a meaning in his life after he discovers he has terminal cancer.",
+    "cast": [
+      "Takashi Shimura",
+      "Nobuo Kaneko",
+      "Shin'ichi Himori",
+      "Haruo Tanaka"
+    ]
   },
   {
     "movieId": "ladri-di-biciclette-1948",
@@ -1344,7 +2198,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNmI1ODdjODctMDlmMC00ZWViLWI5MzYtYzRhNDdjYmM3MzFjXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_SX4000.jpg",
     "year": 1948,
     "runtime": 89,
-    "imdbRating": 8.3
+    "imdbRating": 8.3,
+    "synopsis": "In post-war Italy, a working-class man's bicycle is stolen. He and his son set out to find it.",
+    "cast": [
+      "Lamberto Maggiorani",
+      "Enzo Staiola",
+      "Lianella Carell",
+      "Elena Altieri"
+    ]
   },
   {
     "movieId": "double-indemnity-1944",
@@ -1355,7 +2216,14 @@
     "year": 1944,
     "runtime": 107,
     "imdbRating": 8.3,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "An insurance representative lets himself be talked by a seductive housewife into a murder/insurance fraud scheme that arouses the suspicion of an insurance investigator.",
+    "cast": [
+      "Fred MacMurray",
+      "Barbara Stanwyck",
+      "Edward G. Robinson",
+      "Byron Barr"
+    ]
   },
   {
     "movieId": "citizen-kane-1941",
@@ -1366,7 +2234,14 @@
     "year": 1941,
     "runtime": 119,
     "imdbRating": 8.3,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Following the death of publishing tycoon Charles Foster Kane, reporters scramble to uncover the meaning of his final utterance; 'Rosebud'.",
+    "cast": [
+      "Orson Welles",
+      "Joseph Cotten",
+      "Dorothy Comingore",
+      "Agnes Moorehead"
+    ]
   },
   {
     "movieId": "m-eine-stadt-sucht-einen-m-rder-1931",
@@ -1377,7 +2252,14 @@
     "year": 1931,
     "runtime": 117,
     "imdbRating": 8.3,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "When the police in a German city are unable to catch a child-murderer, other criminals join in the manhunt.",
+    "cast": [
+      "Peter Lorre",
+      "Ellen Widmann",
+      "Inge Landgut",
+      "Otto Wernicke"
+    ]
   },
   {
     "movieId": "metropolis-1927",
@@ -1387,7 +2269,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTg5YWIyMWUtZDY5My00Zjc1LTljOTctYmI0MWRmY2M2NmRkXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_SX4000.jpg",
     "year": 1927,
     "runtime": 153,
-    "imdbRating": 8.3
+    "imdbRating": 8.3,
+    "synopsis": "In a futuristic city sharply divided between the working class and the city planners, the son of the city's mastermind falls in love with a working-class prophet who predicts the coming of a savior to mediate their differences.",
+    "cast": [
+      "Brigitte Helm",
+      "Alfred Abel",
+      "Gustav Fröhlich",
+      "Rudolf Klein-Rogge"
+    ]
   },
   {
     "movieId": "the-kid-1921",
@@ -1398,7 +2287,14 @@
     "year": 1921,
     "runtime": 68,
     "imdbRating": 8.3,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "The Tramp cares for an abandoned child, but events put that relationship in jeopardy.",
+    "cast": [
+      "Charles Chaplin",
+      "Edna Purviance",
+      "Jackie Coogan",
+      "Carl Miller"
+    ]
   },
   {
     "movieId": "chhichhore-2019",
@@ -1409,7 +2305,14 @@
     "year": 2019,
     "runtime": 143,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A tragic incident forces Anirudh, a middle-aged man, to take a trip down memory lane and reminisce his college days along with his friends, who were labelled as losers.",
+    "cast": [
+      "Sushant Singh Rajput",
+      "Shraddha Kapoor",
+      "Varun Sharma",
+      "Prateik"
+    ]
   },
   {
     "movieId": "uri-the-surgical-strike-2018",
@@ -1420,7 +2323,14 @@
     "year": 2018,
     "runtime": 138,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Indian army special forces execute a covert operation, avenging the killing of fellow army men at their base by a terrorist group.",
+    "cast": [
+      "Vicky Kaushal",
+      "Paresh Rawal",
+      "Mohit Raina",
+      "Yami Gautam"
+    ]
   },
   {
     "movieId": "k-g-f-chapter-1-2018",
@@ -1431,7 +2341,14 @@
     "year": 2018,
     "runtime": 156,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "In the 1970s, a fierce rebel rises against brutal oppression and becomes the symbol of hope to legions of downtrodden people.",
+    "cast": [
+      "Yash",
+      "Srinidhi Shetty",
+      "Ramachandra Raju",
+      "Archana Jois"
+    ]
   },
   {
     "movieId": "green-book-2018",
@@ -1442,7 +2359,14 @@
     "year": 2018,
     "runtime": 130,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A working-class Italian-American bouncer becomes the driver of an African-American classical pianist on a tour of venues through the 1960s American South.",
+    "cast": [
+      "Viggo Mortensen",
+      "Mahershala Ali",
+      "Linda Cardellini",
+      "Sebastian Maniscalco"
+    ]
   },
   {
     "movieId": "three-billboards-outside-ebbing-missouri-2017",
@@ -1453,7 +2377,14 @@
     "year": 2017,
     "runtime": 115,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A mother personally challenges the local authorities to solve her daughter's murder when they fail to catch the culprit.",
+    "cast": [
+      "Frances McDormand",
+      "Woody Harrelson",
+      "Sam Rockwell",
+      "Caleb Landry Jones"
+    ]
   },
   {
     "movieId": "talvar-2015",
@@ -1464,7 +2395,14 @@
     "year": 2015,
     "runtime": 132,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "An experienced investigator confronts several conflicting theories about the perpetrators of a violent double homicide.",
+    "cast": [
+      "Irrfan Khan",
+      "Konkona Sen Sharma",
+      "Neeraj Kabi",
+      "Sohum Shah"
+    ]
   },
   {
     "movieId": "baahubali-2-the-conclusion-2017",
@@ -1475,7 +2413,14 @@
     "year": 2017,
     "runtime": 167,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "When Shiva, the son of Bahubali, learns about his heritage, he begins to look for answers. His story is juxtaposed with past events that unfolded in the Mahishmati Kingdom.",
+    "cast": [
+      "Prabhas",
+      "Rana Daggubati",
+      "Anushka Shetty",
+      "Tamannaah Bhatia"
+    ]
   },
   {
     "movieId": "klaus-2019",
@@ -1486,7 +2431,14 @@
     "year": 2019,
     "runtime": 96,
     "imdbRating": 8.2,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "A simple act of kindness always sparks another, even in a frozen, faraway place. When Smeerensburg's new postman, Jesper, befriends toymaker Klaus, their gifts melt an age-old feud and deliver a sleigh full of holiday traditions.",
+    "cast": [
+      "Carlos Martínez López",
+      "Jason Schwartzman",
+      "J.K. Simmons",
+      "Rashida Jones"
+    ]
   },
   {
     "movieId": "drishyam-2015",
@@ -1497,7 +2449,14 @@
     "year": 2015,
     "runtime": 163,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Desperate measures are taken by a man who tries to save his family from the dark side of the law, after they commit an unexpected crime.",
+    "cast": [
+      "Ajay Devgn",
+      "Shriya Saran",
+      "Tabu",
+      "Rajat Kapoor"
+    ]
   },
   {
     "movieId": "queen-2013",
@@ -1508,7 +2467,14 @@
     "year": 2013,
     "runtime": 146,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A Delhi girl from a traditional family sets out on a solo honeymoon after her marriage gets cancelled.",
+    "cast": [
+      "Kangana Ranaut",
+      "Rajkummar Rao",
+      "Lisa Haydon",
+      "Jeffrey Ho"
+    ]
   },
   {
     "movieId": "mandariinid-2013",
@@ -1518,7 +2484,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTgwNzA3MDQzOV5BMl5BanBnXkFtZTgwNTE5MDE5NDE@._V1_SX4000.jpg",
     "year": 2013,
     "runtime": 87,
-    "imdbRating": 8.2
+    "imdbRating": 8.2,
+    "synopsis": "In 1992, war rages in Abkhazia, a breakaway region of Georgia. An Estonian man Ivo has decided to stay behind and harvest his crops of tangerines. In a bloody conflict at his door, a wounded man is left behind, and Ivo takes him in.",
+    "cast": [
+      "Lembit Ulfsak",
+      "Elmo Nüganen",
+      "Giorgi Nakashidze",
+      "Misha Meskhi"
+    ]
   },
   {
     "movieId": "bhaag-milkha-bhaag-2013",
@@ -1529,7 +2502,14 @@
     "year": 2013,
     "runtime": 186,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The truth behind the ascension of Milkha Singh who was scarred because of the India-Pakistan partition.",
+    "cast": [
+      "Farhan Akhtar",
+      "Sonam Kapoor",
+      "Pawan Malhotra",
+      "Art Malik"
+    ]
   },
   {
     "movieId": "gangs-of-wasseypur-2012",
@@ -1540,7 +2520,14 @@
     "year": 2012,
     "runtime": 321,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A clash between Sultan and Shahid Khan leads to the expulsion of Khan from Wasseypur, and ignites a deadly blood feud spanning three generations.",
+    "cast": [
+      "Manoj Bajpayee",
+      "Richa Chadha",
+      "Nawazuddin Siddiqui",
+      "Tigmanshu Dhulia"
+    ]
   },
   {
     "movieId": "udaan-2010",
@@ -1551,7 +2538,14 @@
     "year": 2010,
     "runtime": 134,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Expelled from his school, a 16-year old boy returns home to his abusive and oppressive father.",
+    "cast": [
+      "Rajat Barmecha",
+      "Ronit Roy",
+      "Manjot Singh",
+      "Ram Kapoor"
+    ]
   },
   {
     "movieId": "paan-singh-tomar-2012",
@@ -1562,7 +2556,14 @@
     "year": 2012,
     "runtime": 135,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The story of Paan Singh Tomar, an Indian athlete and seven-time national steeplechase champion who becomes one of the most feared dacoits in Chambal Valley after his retirement.",
+    "cast": [
+      "Irrfan Khan",
+      "Mahie Gill",
+      "Rajesh Abhay",
+      "Hemendra Dandotiya"
+    ]
   },
   {
     "movieId": "el-secreto-de-sus-ojos-2009",
@@ -1573,7 +2574,14 @@
     "year": 2009,
     "runtime": 129,
     "imdbRating": 8.2,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A retired legal counselor writes a novel hoping to find closure for one of his past unresolved homicide cases and for his unreciprocated love with his superior - both of which still haunt him decades later.",
+    "cast": [
+      "Ricardo Darín",
+      "Soledad Villamil",
+      "Pablo Rago",
+      "Carla Quevedo"
+    ]
   },
   {
     "movieId": "warrior-2011",
@@ -1584,7 +2592,14 @@
     "year": 2011,
     "runtime": 140,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The youngest son of an alcoholic former boxer returns home, where he's trained by his father for competition in a mixed martial arts tournament - a path that puts the fighter on a collision course with his estranged, older brother.",
+    "cast": [
+      "Tom Hardy",
+      "Nick Nolte",
+      "Joel Edgerton",
+      "Jennifer Morrison"
+    ]
   },
   {
     "movieId": "shutter-island-2010",
@@ -1595,7 +2610,14 @@
     "year": 2010,
     "runtime": 138,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In 1954, a U.S. Marshal investigates the disappearance of a murderer who escaped from a hospital for the criminally insane.",
+    "cast": [
+      "Leonardo DiCaprio",
+      "Emily Mortimer",
+      "Mark Ruffalo",
+      "Ben Kingsley"
+    ]
   },
   {
     "movieId": "up-2009",
@@ -1606,7 +2628,14 @@
     "year": 2009,
     "runtime": 96,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "78-year-old Carl Fredricksen travels to Paradise Falls in his house equipped with balloons, inadvertently taking a young stowaway.",
+    "cast": [
+      "Bob Peterson",
+      "Edward Asner",
+      "Jordan Nagai",
+      "John Ratzenberger"
+    ]
   },
   {
     "movieId": "the-wolf-of-wall-street-2013",
@@ -1617,7 +2646,14 @@
     "year": 2013,
     "runtime": 180,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Based on the true story of Jordan Belfort, from his rise to a wealthy stock-broker living the high life to his fall involving crime, corruption and the federal government.",
+    "cast": [
+      "Leonardo DiCaprio",
+      "Jonah Hill",
+      "Margot Robbie",
+      "Matthew McConaughey"
+    ]
   },
   {
     "movieId": "chak-de-india-2007",
@@ -1628,7 +2664,14 @@
     "year": 2007,
     "runtime": 153,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Kabir Khan is the coach of the Indian Women's National Hockey Team and his dream is to make his all girls team emerge victorious against all odds.",
+    "cast": [
+      "Shah Rukh Khan",
+      "Vidya Malvade",
+      "Sagarika Ghatge",
+      "Shilpa Shukla"
+    ]
   },
   {
     "movieId": "there-will-be-blood-2007",
@@ -1639,7 +2682,14 @@
     "year": 2007,
     "runtime": 158,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A story of family, religion, hatred, oil and madness, focusing on a turn-of-the-century prospector in the early days of the business.",
+    "cast": [
+      "Daniel Day-Lewis",
+      "Paul Dano",
+      "Ciarán Hinds",
+      "Martin Stringer"
+    ]
   },
   {
     "movieId": "pan-s-labyrinth-2006",
@@ -1650,7 +2700,14 @@
     "year": 2006,
     "runtime": 118,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "In the Falangist Spain of 1944, the bookish young stepdaughter of a sadistic army officer escapes into an eerie but captivating fantasy world.",
+    "cast": [
+      "Ivana Baquero",
+      "Ariadna Gil",
+      "Sergi López",
+      "Maribel Verdú"
+    ]
   },
   {
     "movieId": "toy-story-3-2010",
@@ -1661,7 +2718,14 @@
     "year": 2010,
     "runtime": 103,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The toys are mistakenly delivered to a day-care center instead of the attic right before Andy leaves for college, and it's up to Woody to convince the other toys that they weren't abandoned and to return home.",
+    "cast": [
+      "Tom Hanks",
+      "Tim Allen",
+      "Joan Cusack",
+      "Ned Beatty"
+    ]
   },
   {
     "movieId": "v-for-vendetta-2005",
@@ -1672,7 +2736,14 @@
     "year": 2005,
     "runtime": 132,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In a future British tyranny, a shadowy freedom fighter, known only by the alias of \"V\", plots to overthrow it with the help of a young woman.",
+    "cast": [
+      "Hugo Weaving",
+      "Natalie Portman",
+      "Rupert Graves",
+      "Stephen Rea"
+    ]
   },
   {
     "movieId": "rang-de-basanti-2006",
@@ -1683,7 +2754,14 @@
     "year": 2006,
     "runtime": 167,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The story of six young Indians who assist an English woman to film a documentary on the freedom fighters from their past, and the events that lead them to relive the long-forgotten saga of freedom.",
+    "cast": [
+      "Aamir Khan",
+      "Soha Ali Khan",
+      "Siddharth",
+      "Sharman Joshi"
+    ]
   },
   {
     "movieId": "black-2005",
@@ -1694,7 +2772,14 @@
     "year": 2005,
     "runtime": 122,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The cathartic tale of a young woman who can't see, hear or talk and the teacher who brings a ray of light into her dark world.",
+    "cast": [
+      "Amitabh Bachchan",
+      "Rani Mukerji",
+      "Shernaz Patel",
+      "Ayesha Kapoor"
+    ]
   },
   {
     "movieId": "batman-begins-2005",
@@ -1705,7 +2790,14 @@
     "year": 2005,
     "runtime": 140,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "After training with his mentor, Batman begins his fight to free crime-ridden Gotham City from corruption.",
+    "cast": [
+      "Christian Bale",
+      "Michael Caine",
+      "Ken Watanabe",
+      "Liam Neeson"
+    ]
   },
   {
     "movieId": "swades-we-the-people-2004",
@@ -1716,7 +2808,14 @@
     "year": 2004,
     "runtime": 210,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A successful Indian scientist returns to an Indian village to take his nanny to America with him and in the process rediscovers his roots.",
+    "cast": [
+      "Shah Rukh Khan",
+      "Gayatri Joshi",
+      "Kishori Ballal",
+      "Smit Sheth"
+    ]
   },
   {
     "movieId": "der-untergang-2004",
@@ -1727,7 +2826,14 @@
     "year": 2004,
     "runtime": 156,
     "imdbRating": 8.2,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Traudl Junge, the final secretary for Adolf Hitler, tells of the Nazi dictator's final days in his Berlin bunker at the end of WWII.",
+    "cast": [
+      "Bruno Ganz",
+      "Alexandra Maria Lara",
+      "Ulrich Matthes",
+      "Juliane Köhler"
+    ]
   },
   {
     "movieId": "hauru-no-ugoku-shiro-2004",
@@ -1738,7 +2844,14 @@
     "year": 2004,
     "runtime": 119,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "When an unconfident young woman is cursed with an old body by a spiteful witch, her only chance of breaking the spell lies with a self-indulgent yet insecure young wizard and his companions in his legged, walking castle.",
+    "cast": [
+      "Chieko Baishô",
+      "Takuya Kimura",
+      "Tatsuya Gashûin",
+      "Akihiro Miwa"
+    ]
   },
   {
     "movieId": "a-beautiful-mind-2001",
@@ -1749,7 +2862,14 @@
     "year": 2001,
     "runtime": 135,
     "imdbRating": 8.2,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "After John Nash, a brilliant but asocial mathematician, accepts secret work in cryptography, his life takes a turn for the nightmarish.",
+    "cast": [
+      "Russell Crowe",
+      "Ed Harris",
+      "Jennifer Connelly",
+      "Christopher Plummer"
+    ]
   },
   {
     "movieId": "hera-pheri-2000",
@@ -1760,7 +2880,14 @@
     "year": 2000,
     "runtime": 156,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Three unemployed men look for answers to all their money problems - but when their opportunity arrives, will they know what to do with it?",
+    "cast": [
+      "Akshay Kumar",
+      "Sunil Shetty",
+      "Paresh Rawal",
+      "Tabu"
+    ]
   },
   {
     "movieId": "lock-stock-and-two-smoking-barrels-1998",
@@ -1771,7 +2898,14 @@
     "year": 1998,
     "runtime": 107,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A botched card game in London triggers four friends, thugs, weed-growers, hard gangsters, loan sharks and debt collectors to collide with each other in a series of unexpected events, all for the sake of weed, cash and two antique shotguns.",
+    "cast": [
+      "Jason Flemyng",
+      "Dexter Fletcher",
+      "Nick Moran",
+      "Jason Statham"
+    ]
   },
   {
     "movieId": "l-a-confidential-1997",
@@ -1782,7 +2916,14 @@
     "year": 1997,
     "runtime": 138,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "As corruption grows in 1950s Los Angeles, three policemen - one strait-laced, one brutal, and one sleazy - investigate a series of murders with their own brand of justice.",
+    "cast": [
+      "Kevin Spacey",
+      "Russell Crowe",
+      "Guy Pearce",
+      "Kim Basinger"
+    ]
   },
   {
     "movieId": "eskiya-1996",
@@ -1792,7 +2933,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BOGQ4ZjFmYjktOGNkNS00OWYyLWIyZjgtMGJjM2U1ZTA0ZTlhXkEyXkFqcGdeQXVyNTA4NzY1MzY@._V1_SX4000.jpg",
     "year": 1996,
     "runtime": 128,
-    "imdbRating": 8.2
+    "imdbRating": 8.2,
+    "synopsis": "Baran the Bandit, released from prison after 35 years, searches for vengeance and his lover.",
+    "cast": [
+      "Sener Sen",
+      "Ugur Yücel",
+      "Sermin Hürmeriç",
+      "Yesim Salkim"
+    ]
   },
   {
     "movieId": "heat-1995",
@@ -1803,7 +2951,14 @@
     "year": 1995,
     "runtime": 170,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A group of professional bank robbers start to feel the heat from police when they unknowingly leave a clue at their latest heist.",
+    "cast": [
+      "Al Pacino",
+      "Robert De Niro",
+      "Val Kilmer",
+      "Jon Voight"
+    ]
   },
   {
     "movieId": "casino-1995",
@@ -1814,7 +2969,14 @@
     "year": 1995,
     "runtime": 178,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A tale of greed, deception, money, power, and murder occur between two best friends: a mafia enforcer and a casino executive compete against each other over a gambling empire, and over a fast-living and fast-loving socialite.",
+    "cast": [
+      "Robert De Niro",
+      "Sharon Stone",
+      "Joe Pesci",
+      "James Woods"
+    ]
   },
   {
     "movieId": "andaz-apna-apna-1994",
@@ -1825,7 +2987,14 @@
     "year": 1994,
     "runtime": 160,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Two slackers competing for the affections of an heiress inadvertently become her protectors from an evil criminal.",
+    "cast": [
+      "Aamir Khan",
+      "Salman Khan",
+      "Raveena Tandon",
+      "Karisma Kapoor"
+    ]
   },
   {
     "movieId": "unforgiven-1992",
@@ -1836,7 +3005,14 @@
     "year": 1992,
     "runtime": 130,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Retired Old West gunslinger William Munny reluctantly takes on one last job, with the help of his old partner Ned Logan and a young man, The \"Schofield Kid.\"",
+    "cast": [
+      "Clint Eastwood",
+      "Gene Hackman",
+      "Morgan Freeman",
+      "Richard Harris"
+    ]
   },
   {
     "movieId": "indiana-jones-and-the-last-crusade-1989",
@@ -1847,7 +3023,14 @@
     "year": 1989,
     "runtime": 127,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In 1938, after his father Professor Henry Jones, Sr. goes missing while pursuing the Holy Grail, Professor Henry \"Indiana\" Jones, Jr. finds himself up against Adolf Hitler's Nazis again to stop them from obtaining its powers.",
+    "cast": [
+      "Harrison Ford",
+      "Sean Connery",
+      "Alison Doody",
+      "Denholm Elliott"
+    ]
   },
   {
     "movieId": "dom-za-vesanje-1988",
@@ -1858,7 +3041,14 @@
     "year": 1988,
     "runtime": 142,
     "imdbRating": 8.2,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "In this luminous tale set in the area around Sarajevo and in Italy, Perhan, an engaging young Romany (gypsy) with telekinetic powers, is seduced by the quick-cash world of petty crime, which threatens to destroy him and those he loves.",
+    "cast": [
+      "Davor Dujmovic",
+      "Bora Todorovic",
+      "Ljubica Adzovic",
+      "Husnija Hasimovic"
+    ]
   },
   {
     "movieId": "tonari-no-totoro-1988",
@@ -1869,7 +3059,14 @@
     "year": 1988,
     "runtime": 86,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "When two girls move to the country to be near their ailing mother, they have adventures with the wondrous forest spirits who live nearby.",
+    "cast": [
+      "Hitoshi Takagi",
+      "Noriko Hidaka",
+      "Chika Sakamoto",
+      "Shigesato Itoi"
+    ]
   },
   {
     "movieId": "die-hard-1988",
@@ -1880,7 +3077,14 @@
     "year": 1988,
     "runtime": 132,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An NYPD officer tries to save his wife and several others taken hostage by German terrorists during a Christmas party at the Nakatomi Plaza in Los Angeles.",
+    "cast": [
+      "Bruce Willis",
+      "Alan Rickman",
+      "Bonnie Bedelia",
+      "Reginald VelJohnson"
+    ]
   },
   {
     "movieId": "ran-1985",
@@ -1891,7 +3095,14 @@
     "year": 1985,
     "runtime": 162,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In Medieval Japan, an elderly warlord retires, handing over his empire to his three sons. However, he vastly underestimates how the new-found power will corrupt them and cause them to turn on each other...and him.",
+    "cast": [
+      "Tatsuya Nakadai",
+      "Akira Terao",
+      "Jinpachi Nezu",
+      "Daisuke Ryû"
+    ]
   },
   {
     "movieId": "raging-bull-1980",
@@ -1902,7 +3113,14 @@
     "year": 1980,
     "runtime": 129,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The life of boxer Jake LaMotta, whose violence and temper that led him to the top in the ring destroyed his life outside of it.",
+    "cast": [
+      "Robert De Niro",
+      "Cathy Moriarty",
+      "Joe Pesci",
+      "Frank Vincent"
+    ]
   },
   {
     "movieId": "stalker-1979",
@@ -1913,7 +3131,14 @@
     "year": 1979,
     "runtime": 162,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A guide leads two men through an area known as the Zone to find a room that grants wishes.",
+    "cast": [
+      "Alisa Freyndlikh",
+      "Aleksandr Kaydanovskiy",
+      "Anatoliy Solonitsyn",
+      "Nikolay Grinko"
+    ]
   },
   {
     "movieId": "h-stsonaten-1978",
@@ -1924,7 +3149,14 @@
     "year": 1978,
     "runtime": 99,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A married daughter who longs for her mother's love is visited by the latter, a successful concert pianist.",
+    "cast": [
+      "Ingrid Bergman",
+      "Liv Ullmann",
+      "Lena Nyman",
+      "Halvar Björk"
+    ]
   },
   {
     "movieId": "the-message-1976",
@@ -1935,7 +3167,14 @@
     "year": 1976,
     "runtime": 177,
     "imdbRating": 8.2,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "This epic historical drama chronicles the life and times of Prophet Muhammad and serves as an introduction to early Islamic history.",
+    "cast": [
+      "Anthony Quinn",
+      "Irene Papas",
+      "Michael Ansara",
+      "Johnny Sekka"
+    ]
   },
   {
     "movieId": "sholay-1975",
@@ -1946,7 +3185,14 @@
     "year": 1975,
     "runtime": 204,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "After his family is murdered by a notorious and ruthless bandit, a former police officer enlists the services of two outlaws to capture the bandit.",
+    "cast": [
+      "Sanjeev Kumar",
+      "Dharmendra",
+      "Amitabh Bachchan",
+      "Amjad Khan"
+    ]
   },
   {
     "movieId": "monty-python-and-the-holy-grail-1975",
@@ -1957,7 +3203,14 @@
     "year": 1975,
     "runtime": 91,
     "imdbRating": 8.2,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "King Arthur and his Knights of the Round Table embark on a surreal, low-budget search for the Holy Grail, encountering many, very silly obstacles.",
+    "cast": [
+      "Terry Jones",
+      "Graham Chapman",
+      "John Cleese",
+      "Eric Idle"
+    ]
   },
   {
     "movieId": "the-great-escape-1963",
@@ -1968,7 +3221,14 @@
     "year": 1963,
     "runtime": 172,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Allied prisoners of war plan for several hundred of their number to escape from a German camp during World War II.",
+    "cast": [
+      "Steve McQueen",
+      "James Garner",
+      "Richard Attenborough",
+      "Charles Bronson"
+    ]
   },
   {
     "movieId": "to-kill-a-mockingbird-1962",
@@ -1979,7 +3239,14 @@
     "year": 1962,
     "runtime": 129,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Atticus Finch, a lawyer in the Depression-era South, defends a black man against an undeserved rape charge, and his children against prejudice.",
+    "cast": [
+      "Gregory Peck",
+      "John Megna",
+      "Frank Overton",
+      "Rosemary Murphy"
+    ]
   },
   {
     "movieId": "y-jinb-1961",
@@ -1989,7 +3256,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BZThiZjAzZjgtNDU3MC00YThhLThjYWUtZGRkYjc2ZWZlOTVjXkEyXkFqcGdeQXVyNTA4NzY1MzY@._V1_SX4000.jpg",
     "year": 1961,
     "runtime": 110,
-    "imdbRating": 8.2
+    "imdbRating": 8.2,
+    "synopsis": "A crafty ronin comes to a town divided by two criminal gangs and decides to play them against each other to free the town.",
+    "cast": [
+      "Toshirô Mifune",
+      "Eijirô Tôno",
+      "Tatsuya Nakadai",
+      "Yôko Tsukasa"
+    ]
   },
   {
     "movieId": "judgment-at-nuremberg-1961",
@@ -2000,7 +3274,14 @@
     "year": 1961,
     "runtime": 179,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In 1948, an American court in occupied Germany tries four Nazis judged for war crimes.",
+    "cast": [
+      "Spencer Tracy",
+      "Burt Lancaster",
+      "Richard Widmark",
+      "Marlene Dietrich"
+    ]
   },
   {
     "movieId": "some-like-it-hot-1959",
@@ -2011,7 +3292,14 @@
     "year": 1959,
     "runtime": 121,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "After two male musicians witness a mob hit, they flee the state in an all-female band disguised as women, but further complications set in.",
+    "cast": [
+      "Marilyn Monroe",
+      "Tony Curtis",
+      "Jack Lemmon",
+      "George Raft"
+    ]
   },
   {
     "movieId": "smultronst-llet-1957",
@@ -2022,7 +3310,14 @@
     "year": 1957,
     "runtime": 91,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "After living a life marked by coldness, an aging professor is forced to confront the emptiness of his existence.",
+    "cast": [
+      "Victor Sjöström",
+      "Bibi Andersson",
+      "Ingrid Thulin",
+      "Gunnar Björnstrand"
+    ]
   },
   {
     "movieId": "det-sjunde-inseglet-1957",
@@ -2033,7 +3328,14 @@
     "year": 1957,
     "runtime": 96,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A man seeks answers about life, death, and the existence of God as he plays chess against the Grim Reaper during the Black Plague.",
+    "cast": [
+      "Max von Sydow",
+      "Gunnar Björnstrand",
+      "Bengt Ekerot",
+      "Nils Poppe"
+    ]
   },
   {
     "movieId": "du-rififi-chez-les-hommes-1955",
@@ -2043,7 +3345,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNjZmZGRiMDgtNDkwNi00OTZhLWFhZmMtYTdkYjgyNThhOWY3XkEyXkFqcGdeQXVyMTA1NTM1NDI2._V1_SX4000.jpg",
     "year": 1955,
     "runtime": 118,
-    "imdbRating": 8.2
+    "imdbRating": 8.2,
+    "synopsis": "Four men plan a technically perfect crime, but the human element intervenes...",
+    "cast": [
+      "Jean Servais",
+      "Carl Möhner",
+      "Robert Manuel",
+      "Janine Darcey"
+    ]
   },
   {
     "movieId": "dial-m-for-murder-1954",
@@ -2054,7 +3363,14 @@
     "year": 1954,
     "runtime": 105,
     "imdbRating": 8.2,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A former tennis player tries to arrange his wife's murder after learning of her affair.",
+    "cast": [
+      "Ray Milland",
+      "Grace Kelly",
+      "Robert Cummings",
+      "John Williams"
+    ]
   },
   {
     "movieId": "t-ky-monogatari-1953",
@@ -2065,7 +3381,14 @@
     "year": 1953,
     "runtime": 136,
     "imdbRating": 8.2,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "An old couple visit their children and grandchildren in the city, but receive little attention.",
+    "cast": [
+      "Chishû Ryû",
+      "Chieko Higashiyama",
+      "Sô Yamamura",
+      "Setsuko Hara"
+    ]
   },
   {
     "movieId": "rash-mon-1950",
@@ -2075,7 +3398,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMjEzMzA4NDE2OF5BMl5BanBnXkFtZTcwNTc5MDI2NQ@@._V1_SX4000.jpg",
     "year": 1950,
     "runtime": 88,
-    "imdbRating": 8.2
+    "imdbRating": 8.2,
+    "synopsis": "The rape of a bride and the murder of her samurai husband are recalled from the perspectives of a bandit, the bride, the samurai's ghost and a woodcutter.",
+    "cast": [
+      "Toshirô Mifune",
+      "Machiko Kyô",
+      "Masayuki Mori",
+      "Takashi Shimura"
+    ]
   },
   {
     "movieId": "all-about-eve-1950",
@@ -2086,7 +3416,14 @@
     "year": 1950,
     "runtime": 138,
     "imdbRating": 8.2,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A seemingly timid but secretly ruthless ingénue insinuates herself into the lives of an aging Broadway star and her circle of theater friends.",
+    "cast": [
+      "Bette Davis",
+      "Anne Baxter",
+      "George Sanders",
+      "Celeste Holm"
+    ]
   },
   {
     "movieId": "the-treasure-of-the-sierra-madre-1948",
@@ -2097,7 +3434,14 @@
     "year": 1948,
     "runtime": 126,
     "imdbRating": 8.2,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "Two Americans searching for work in Mexico convince an old prospector to help them mine for gold in the Sierra Madre Mountains.",
+    "cast": [
+      "Humphrey Bogart",
+      "Walter Huston",
+      "Tim Holt",
+      "Bruce Bennett"
+    ]
   },
   {
     "movieId": "to-be-or-not-to-be-1942",
@@ -2108,7 +3452,14 @@
     "year": 1942,
     "runtime": 99,
     "imdbRating": 8.2,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "During the Nazi occupation of Poland, an acting troupe becomes embroiled in a Polish soldier's efforts to track down a German spy.",
+    "cast": [
+      "Carole Lombard",
+      "Jack Benny",
+      "Robert Stack",
+      "Felix Bressart"
+    ]
   },
   {
     "movieId": "the-gold-rush-1925",
@@ -2119,7 +3470,14 @@
     "year": 1925,
     "runtime": 95,
     "imdbRating": 8.2,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A prospector goes to the Klondike in search of gold and finds it and more.",
+    "cast": [
+      "Charles Chaplin",
+      "Mack Swain",
+      "Tom Murray",
+      "Henry Bergman"
+    ]
   },
   {
     "movieId": "sherlock-jr-1924",
@@ -2130,7 +3488,14 @@
     "year": 1924,
     "runtime": 45,
     "imdbRating": 8.2,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A film projectionist longs to be a detective, and puts his meagre skills to work when he is framed by a rival for stealing his girlfriend's father's pocketwatch.",
+    "cast": [
+      "Buster Keaton",
+      "Kathryn McGuire",
+      "Joe Keaton",
+      "Erwin Connelly"
+    ]
   },
   {
     "movieId": "portrait-de-la-jeune-fille-en-feu-2019",
@@ -2141,7 +3506,14 @@
     "year": 2019,
     "runtime": 122,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "On an isolated island in Brittany at the end of the eighteenth century, a female painter is obliged to paint a wedding portrait of a young woman.",
+    "cast": [
+      "Noémie Merlant",
+      "Adèle Haenel",
+      "Luàna Bajrami",
+      "Valeria Golino"
+    ]
   },
   {
     "movieId": "pink-2016",
@@ -2152,7 +3524,14 @@
     "year": 2016,
     "runtime": 136,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "When three young women are implicated in a crime, a retired lawyer steps forward to help them clear their names.",
+    "cast": [
+      "Taapsee Pannu",
+      "Amitabh Bachchan",
+      "Kirti Kulhari",
+      "Andrea Tariang"
+    ]
   },
   {
     "movieId": "koe-no-katachi-2016",
@@ -2163,7 +3542,14 @@
     "year": 2016,
     "runtime": 130,
     "imdbRating": 8.1,
-    "rated": "16"
+    "rated": "16",
+    "synopsis": "A young man is ostracized by his classmates after he bullies a deaf girl to the point where she moves away. Years later, he sets off on a path for redemption.",
+    "cast": [
+      "Miyu Irino",
+      "Saori Hayami",
+      "Aoi Yûki",
+      "Kenshô Ono"
+    ]
   },
   {
     "movieId": "contratiempo-2016",
@@ -2174,7 +3560,14 @@
     "year": 2016,
     "runtime": 106,
     "imdbRating": 8.1,
-    "rated": "TV-MA"
+    "rated": "TV-MA",
+    "synopsis": "A successful entrepreneur accused of murder and a witness preparation expert have less than three hours to come up with an impregnable defense.",
+    "cast": [
+      "Mario Casas",
+      "Ana Wagener",
+      "Jose Coronado",
+      "Bárbara Lennie"
+    ]
   },
   {
     "movieId": "ah-ga-ssi-2016",
@@ -2185,7 +3578,14 @@
     "year": 2016,
     "runtime": 145,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A woman is hired as a handmaiden to a Japanese heiress, but secretly she is involved in a plot to defraud her.",
+    "cast": [
+      "Kim Min-hee",
+      "Jung-woo Ha",
+      "Cho Jin-woong",
+      "Moon So-Ri"
+    ]
   },
   {
     "movieId": "mommy-2014",
@@ -2196,7 +3596,14 @@
     "year": 2014,
     "runtime": 139,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A widowed single mother, raising her violent son alone, finds new hope when a mysterious neighbor inserts herself into their household.",
+    "cast": [
+      "Anne Dorval",
+      "Antoine Olivier Pilon",
+      "Suzanne Clément",
+      "Patrick Huard"
+    ]
   },
   {
     "movieId": "haider-2014",
@@ -2207,7 +3614,14 @@
     "year": 2014,
     "runtime": 160,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A young man returns to Kashmir after his father's disappearance to confront his uncle, whom he suspects of playing a role in his father's fate.",
+    "cast": [
+      "Shahid Kapoor",
+      "Tabu",
+      "Shraddha Kapoor",
+      "Kay Kay Menon"
+    ]
   },
   {
     "movieId": "logan-2017",
@@ -2218,7 +3632,14 @@
     "year": 2017,
     "runtime": 137,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In a future where mutants are nearly extinct, an elderly and weary Logan leads a quiet life. But when Laura, a mutant child pursued by scientists, comes to him for help, he must get her to safety.",
+    "cast": [
+      "Hugh Jackman",
+      "Patrick Stewart",
+      "Dafne Keen",
+      "Boyd Holbrook"
+    ]
   },
   {
     "movieId": "room-2015",
@@ -2229,7 +3650,14 @@
     "year": 2015,
     "runtime": 118,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Held captive for 7 years in an enclosed space, a woman and her young son finally gain their freedom, allowing the boy to experience the outside world for the first time.",
+    "cast": [
+      "Brie Larson",
+      "Jacob Tremblay",
+      "Sean Bridgers",
+      "Wendy Crewson"
+    ]
   },
   {
     "movieId": "relatos-salvajes-2014",
@@ -2240,7 +3668,14 @@
     "year": 2014,
     "runtime": 122,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Six short stories that explore the extremities of human behavior involving people in distress.",
+    "cast": [
+      "Darío Grandinetti",
+      "María Marull",
+      "Mónica Villa",
+      "Diego Starosta"
+    ]
   },
   {
     "movieId": "soul-2020",
@@ -2251,7 +3686,14 @@
     "year": 2020,
     "runtime": 100,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "After landing the gig of a lifetime, a New York jazz pianist suddenly finds himself trapped in a strange land between Earth and the afterlife.",
+    "cast": [
+      "Kemp Powers",
+      "Jamie Foxx",
+      "Tina Fey",
+      "Graham Norton"
+    ]
   },
   {
     "movieId": "kis-uykusu-2014",
@@ -2261,7 +3703,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYzE2MjEwMTQtOTQ2Mi00ZWExLTkyMjUtNmJjMjBlYWFjZDdlXkEyXkFqcGdeQXVyMTI3ODAyMzE2._V1_SX4000.jpg",
     "year": 2014,
     "runtime": 196,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "A hotel owner and landlord in a remote Turkish village deals with conflicts within his family and a tenant behind on his rent.",
+    "cast": [
+      "Haluk Bilginer",
+      "Melisa Sözen",
+      "Demet Akbag",
+      "Ayberk Pekcan"
+    ]
   },
   {
     "movieId": "pk-2014",
@@ -2272,7 +3721,14 @@
     "year": 2014,
     "runtime": 153,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "An alien on Earth loses the only device he can use to communicate with his spaceship. His innocent nature and child-like questions force the country to evaluate the impact of religion on its people.",
+    "cast": [
+      "Aamir Khan",
+      "Anushka Sharma",
+      "Sanjay Dutt",
+      "Boman Irani"
+    ]
   },
   {
     "movieId": "omg-oh-my-god-2012",
@@ -2283,7 +3739,14 @@
     "year": 2012,
     "runtime": 125,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A shopkeeper takes God to court when his shop is destroyed by an earthquake.",
+    "cast": [
+      "Paresh Rawal",
+      "Akshay Kumar",
+      "Mithun Chakraborty",
+      "Mahesh Manjrekar"
+    ]
   },
   {
     "movieId": "the-grand-budapest-hotel-2014",
@@ -2294,7 +3757,14 @@
     "year": 2014,
     "runtime": 99,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A writer encounters the owner of an aging high-class hotel, who tells him of his early years serving as a lobby boy in the hotel's glorious years under an exceptional concierge.",
+    "cast": [
+      "Ralph Fiennes",
+      "F. Murray Abraham",
+      "Mathieu Amalric",
+      "Adrien Brody"
+    ]
   },
   {
     "movieId": "gone-girl-2014",
@@ -2305,7 +3775,14 @@
     "year": 2014,
     "runtime": 149,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "With his wife's disappearance having become the focus of an intense media circus, a man sees the spotlight turned on him when it's suspected that he may not be innocent.",
+    "cast": [
+      "Ben Affleck",
+      "Rosamund Pike",
+      "Neil Patrick Harris",
+      "Tyler Perry"
+    ]
   },
   {
     "movieId": "kami-kodomo-no-ame-to-yuki-2012",
@@ -2316,7 +3793,14 @@
     "year": 2012,
     "runtime": 117,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "After her werewolf lover unexpectedly dies in an accident while hunting for food for their children, a young woman must find ways to raise the werewolf son and daughter that she had with him while keeping their trait hidden from society.",
+    "cast": [
+      "Aoi Miyazaki",
+      "Takao Osawa",
+      "Haru Kuroki",
+      "Yukito Nishii"
+    ]
   },
   {
     "movieId": "hacksaw-ridge-2016",
@@ -2327,7 +3811,14 @@
     "year": 2016,
     "runtime": 139,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "World War II American Army Medic Desmond T. Doss, who served during the Battle of Okinawa, refuses to kill people, and becomes the first man in American history to receive the Medal of Honor without firing a shot.",
+    "cast": [
+      "Andrew Garfield",
+      "Sam Worthington",
+      "Luke Bracey",
+      "Teresa Palmer"
+    ]
   },
   {
     "movieId": "inside-out-2015",
@@ -2338,7 +3829,14 @@
     "year": 2015,
     "runtime": 95,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "After young Riley is uprooted from her Midwest life and moved to San Francisco, her emotions - Joy, Fear, Anger, Disgust and Sadness - conflict on how best to navigate a new city, house, and school.",
+    "cast": [
+      "Ronnie Del Carmen",
+      "Amy Poehler",
+      "Bill Hader",
+      "Lewis Black"
+    ]
   },
   {
     "movieId": "barfi-2012",
@@ -2349,7 +3847,14 @@
     "year": 2012,
     "runtime": 151,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Three young people learn that love can neither be defined nor contained by society's definition of normal and abnormal.",
+    "cast": [
+      "Ranbir Kapoor",
+      "Priyanka Chopra",
+      "Ileana D'Cruz",
+      "Saurabh Shukla"
+    ]
   },
   {
     "movieId": "12-years-a-slave-2013",
@@ -2360,7 +3865,14 @@
     "year": 2013,
     "runtime": 134,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In the antebellum United States, Solomon Northup, a free black man from upstate New York, is abducted and sold into slavery.",
+    "cast": [
+      "Chiwetel Ejiofor",
+      "Michael Kenneth Williams",
+      "Michael Fassbender",
+      "Brad Pitt"
+    ]
   },
   {
     "movieId": "rush-2013",
@@ -2371,7 +3883,14 @@
     "year": 2013,
     "runtime": 123,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The merciless 1970s rivalry between Formula One rivals James Hunt and Niki Lauda.",
+    "cast": [
+      "Daniel Brühl",
+      "Chris Hemsworth",
+      "Olivia Wilde",
+      "Alexandra Maria Lara"
+    ]
   },
   {
     "movieId": "ford-v-ferrari-2019",
@@ -2382,7 +3901,14 @@
     "year": 2019,
     "runtime": 152,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "American car designer Carroll Shelby and driver Ken Miles battle corporate interference and the laws of physics to build a revolutionary race car for Ford in order to defeat Ferrari at the 24 Hours of Le Mans in 1966.",
+    "cast": [
+      "Matt Damon",
+      "Christian Bale",
+      "Jon Bernthal",
+      "Caitriona Balfe"
+    ]
   },
   {
     "movieId": "spotlight-2015",
@@ -2393,7 +3919,14 @@
     "year": 2015,
     "runtime": 129,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The true story of how the Boston Globe uncovered the massive scandal of child molestation and cover-up within the local Catholic Archdiocese, shaking the entire Catholic Church to its core.",
+    "cast": [
+      "Mark Ruffalo",
+      "Michael Keaton",
+      "Rachel McAdams",
+      "Liev Schreiber"
+    ]
   },
   {
     "movieId": "song-of-the-sea-2014",
@@ -2404,7 +3937,14 @@
     "year": 2014,
     "runtime": 93,
     "imdbRating": 8.1,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "Ben, a young Irish boy, and his little sister Saoirse, a girl who can turn into a seal, go on an adventure to free the fairies and save the spirit world.",
+    "cast": [
+      "David Rawle",
+      "Brendan Gleeson",
+      "Lisa Hannigan",
+      "Fionnula Flanagan"
+    ]
   },
   {
     "movieId": "kahaani-2012",
@@ -2415,7 +3955,14 @@
     "year": 2012,
     "runtime": 122,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A pregnant woman's search for her missing husband takes her from London to Kolkata, but everyone she questions denies having ever met him.",
+    "cast": [
+      "Vidya Balan",
+      "Parambrata Chattopadhyay",
+      "Indraneil Sengupta",
+      "Nawazuddin Siddiqui"
+    ]
   },
   {
     "movieId": "zindagi-na-milegi-dobara-2011",
@@ -2426,7 +3973,14 @@
     "year": 2011,
     "runtime": 155,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Three friends decide to turn their fantasy vacation into reality after one of their friends gets engaged.",
+    "cast": [
+      "Hrithik Roshan",
+      "Farhan Akhtar",
+      "Abhay Deol",
+      "Katrina Kaif"
+    ]
   },
   {
     "movieId": "prisoners-2013",
@@ -2437,7 +3991,14 @@
     "year": 2013,
     "runtime": 153,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "When Keller Dover's daughter and her friend go missing, he takes matters into his own hands as the police pursue multiple leads and the pressure mounts.",
+    "cast": [
+      "Hugh Jackman",
+      "Jake Gyllenhaal",
+      "Viola Davis",
+      "Melissa Leo"
+    ]
   },
   {
     "movieId": "mad-max-fury-road-2015",
@@ -2448,7 +4009,14 @@
     "year": 2015,
     "runtime": 120,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "In a post-apocalyptic wasteland, a woman rebels against a tyrannical ruler in search for her homeland with the aid of a group of female prisoners, a psychotic worshiper, and a drifter named Max.",
+    "cast": [
+      "Tom Hardy",
+      "Charlize Theron",
+      "Nicholas Hoult",
+      "Zoë Kravitz"
+    ]
   },
   {
     "movieId": "a-wednesday-2008",
@@ -2459,7 +4027,14 @@
     "year": 2008,
     "runtime": 104,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A retiring police officer reminisces about the most astounding day of his career. About a case that was never filed but continues to haunt him in his memories - the case of a man and a Wednesday.",
+    "cast": [
+      "Anupam Kher",
+      "Naseeruddin Shah",
+      "Jimmy Sheirgill",
+      "Aamir Bashir"
+    ]
   },
   {
     "movieId": "gran-torino-2008",
@@ -2470,7 +4045,14 @@
     "year": 2008,
     "runtime": 116,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Disgruntled Korean War veteran Walt Kowalski sets out to reform his neighbor, Thao Lor, a Hmong teenager who tried to steal Kowalski's prized possession: a 1972 Gran Torino.",
+    "cast": [
+      "Clint Eastwood",
+      "Bee Vang",
+      "Christopher Carley",
+      "Ahney Her"
+    ]
   },
   {
     "movieId": "harry-potter-and-the-deathly-hallows-part-2-2011",
@@ -2481,7 +4063,14 @@
     "year": 2011,
     "runtime": 130,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Harry, Ron, and Hermione search for Voldemort's remaining Horcruxes in their effort to destroy the Dark Lord as the final battle rages on at Hogwarts.",
+    "cast": [
+      "Daniel Radcliffe",
+      "Emma Watson",
+      "Rupert Grint",
+      "Michael Gambon"
+    ]
   },
   {
     "movieId": "okuribito-2008",
@@ -2492,7 +4081,14 @@
     "year": 2008,
     "runtime": 130,
     "imdbRating": 8.1,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A newly unemployed cellist takes a job preparing the dead for funerals.",
+    "cast": [
+      "Masahiro Motoki",
+      "Ryôko Hirosue",
+      "Tsutomu Yamazaki",
+      "Kazuko Yoshiyuki"
+    ]
   },
   {
     "movieId": "hachi-a-dog-s-tale-2009",
@@ -2503,7 +4099,14 @@
     "year": 2009,
     "runtime": 93,
     "imdbRating": 8.1,
-    "rated": "G"
+    "rated": "G",
+    "synopsis": "A college professor bonds with an abandoned dog he takes into his home.",
+    "cast": [
+      "Richard Gere",
+      "Joan Allen",
+      "Cary-Hiroyuki Tagawa",
+      "Sarah Roemer"
+    ]
   },
   {
     "movieId": "mary-and-max-2009",
@@ -2513,7 +4116,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMDgzYjQwMDMtNGUzYi00MTRmLWIyMGMtNjE1OGZkNzY2YWIzL2ltYWdlXkEyXkFqcGdeQXVyNjU0OTQ0OTY@._V1_SX4000.jpg",
     "year": 2009,
     "runtime": 92,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "A tale of friendship between two unlikely pen pals: Mary, a lonely, eight-year-old girl living in the suburbs of Melbourne, and Max, a forty-four-year old, severely obese man living in New York.",
+    "cast": [
+      "Toni Collette",
+      "Philip Seymour Hoffman",
+      "Eric Bana",
+      "Barry Humphries"
+    ]
   },
   {
     "movieId": "how-to-train-your-dragon-2010",
@@ -2524,7 +4134,14 @@
     "year": 2010,
     "runtime": 98,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A hapless young Viking who aspires to hunt dragons becomes the unlikely friend of a young dragon himself, and learns there may be more to the creatures than he assumed.",
+    "cast": [
+      "Chris Sanders",
+      "Jay Baruchel",
+      "Gerard Butler",
+      "Christopher Mintz-Plasse"
+    ]
   },
   {
     "movieId": "into-the-wild-2007",
@@ -2535,7 +4152,14 @@
     "year": 2007,
     "runtime": 148,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "After graduating from Emory University, top student and athlete Christopher McCandless abandons his possessions, gives his entire $24,000 savings account to charity and hitchhikes to Alaska to live in the wilderness. Along the way, Christopher encounters a series of characters that shape his life.",
+    "cast": [
+      "Emile Hirsch",
+      "Vince Vaughn",
+      "Catherine Keener",
+      "Marcia Gay Harden"
+    ]
   },
   {
     "movieId": "no-country-for-old-men-2007",
@@ -2546,7 +4170,14 @@
     "year": 2007,
     "runtime": 122,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Violence and mayhem ensue after a hunter stumbles upon a drug deal gone wrong and more than two million dollars in cash near the Rio Grande.",
+    "cast": [
+      "Joel Coen",
+      "Tommy Lee Jones",
+      "Javier Bardem",
+      "Josh Brolin"
+    ]
   },
   {
     "movieId": "lage-raho-munna-bhai-2006",
@@ -2557,7 +4188,14 @@
     "year": 2006,
     "runtime": 144,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Munna Bhai embarks on a journey with Mahatma Gandhi in order to fight against a corrupt property dealer.",
+    "cast": [
+      "Sanjay Dutt",
+      "Arshad Warsi",
+      "Vidya Balan",
+      "Boman Irani"
+    ]
   },
   {
     "movieId": "million-dollar-baby-2004",
@@ -2568,7 +4206,14 @@
     "year": 2004,
     "runtime": 132,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A determined woman works with a hardened boxing trainer to become a professional.",
+    "cast": [
+      "Hilary Swank",
+      "Clint Eastwood",
+      "Morgan Freeman",
+      "Jay Baruchel"
+    ]
   },
   {
     "movieId": "hotel-rwanda-2004",
@@ -2579,7 +4224,14 @@
     "year": 2004,
     "runtime": 121,
     "imdbRating": 8.1,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "Paul Rusesabagina, a hotel manager, houses over a thousand Tutsi refugees during their struggle against the Hutu militia in Rwanda, Africa.",
+    "cast": [
+      "Don Cheadle",
+      "Sophie Okonedo",
+      "Joaquin Phoenix",
+      "Xolani Mali"
+    ]
   },
   {
     "movieId": "taegukgi-hwinalrimyeo-2004",
@@ -2590,7 +4242,14 @@
     "year": 2004,
     "runtime": 140,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "When two brothers are forced to fight in the Korean War, the elder decides to take the riskiest missions if it will help shield the younger from battle.",
+    "cast": [
+      "Jang Dong-Gun",
+      "Won Bin",
+      "Eun-ju Lee",
+      "Hyeong-jin Kong"
+    ]
   },
   {
     "movieId": "before-sunset-2004",
@@ -2601,7 +4260,14 @@
     "year": 2004,
     "runtime": 80,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Nine years after Jesse and Celine first met, they encounter each other again on the French leg of Jesse's book tour.",
+    "cast": [
+      "Ethan Hawke",
+      "Julie Delpy",
+      "Vernon Dobtcheff",
+      "Louise Lemoine Torrès"
+    ]
   },
   {
     "movieId": "munna-bhai-m-b-b-s-2003",
@@ -2612,7 +4278,14 @@
     "year": 2003,
     "runtime": 156,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A gangster sets out to fulfill his father's dream of becoming a doctor.",
+    "cast": [
+      "Sanjay Dutt",
+      "Arshad Warsi",
+      "Gracy Singh",
+      "Sunil Dutt"
+    ]
   },
   {
     "movieId": "salinui-chueok-2003",
@@ -2623,7 +4296,14 @@
     "year": 2003,
     "runtime": 131,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "In a small Korean province in 1986, two detectives struggle with the case of multiple young women being found raped and murdered by an unknown culprit.",
+    "cast": [
+      "Kang-ho Song",
+      "Kim Sang-kyung",
+      "Roe-ha Kim",
+      "Jae-ho Song"
+    ]
   },
   {
     "movieId": "dil-chahta-hai-2001",
@@ -2634,7 +4314,14 @@
     "year": 2001,
     "runtime": 183,
     "imdbRating": 8.1,
-    "rated": "Unrated"
+    "rated": "Unrated",
+    "synopsis": "Three inseparable childhood friends are just out of college. Nothing comes between them - until they each fall in love, and their wildly different approaches to relationships creates tension.",
+    "cast": [
+      "Aamir Khan",
+      "Saif Ali Khan",
+      "Akshaye Khanna",
+      "Preity Zinta"
+    ]
   },
   {
     "movieId": "kill-bill-vol-1-2003",
@@ -2645,7 +4332,14 @@
     "year": 2003,
     "runtime": 111,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "After awakening from a four-year coma, a former assassin wreaks vengeance on the team of assassins who betrayed her.",
+    "cast": [
+      "Uma Thurman",
+      "David Carradine",
+      "Daryl Hannah",
+      "Michael Madsen"
+    ]
   },
   {
     "movieId": "finding-nemo-2003",
@@ -2656,7 +4350,14 @@
     "year": 2003,
     "runtime": 100,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "After his son is captured in the Great Barrier Reef and taken to Sydney, a timid clownfish sets out on a journey to bring him home.",
+    "cast": [
+      "Lee Unkrich",
+      "Albert Brooks",
+      "Ellen DeGeneres",
+      "Alexander Gould"
+    ]
   },
   {
     "movieId": "catch-me-if-you-can-2002",
@@ -2667,7 +4368,14 @@
     "year": 2002,
     "runtime": 141,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Barely 21 yet, Frank is a skilled forger who has passed as a doctor, lawyer and pilot. FBI agent Carl becomes obsessed with tracking down the con man, who only revels in the pursuit.",
+    "cast": [
+      "Leonardo DiCaprio",
+      "Tom Hanks",
+      "Christopher Walken",
+      "Martin Sheen"
+    ]
   },
   {
     "movieId": "amores-perros-2000",
@@ -2678,7 +4386,14 @@
     "year": 2000,
     "runtime": 154,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A horrific car accident connects three stories, each involving characters dealing with loss, regret, and life's harsh realities, all in the name of love.",
+    "cast": [
+      "Emilio Echevarría",
+      "Gael García Bernal",
+      "Goya Toledo",
+      "Álvaro Guerrero"
+    ]
   },
   {
     "movieId": "monsters-inc-2001",
@@ -2689,7 +4404,14 @@
     "year": 2001,
     "runtime": 92,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In order to power the city, monsters have to scare children so that they scream. However, the children are toxic to the monsters, and after a child gets through, 2 monsters realize things may not be what they think.",
+    "cast": [
+      "David Silverman",
+      "Lee Unkrich",
+      "Billy Crystal",
+      "John Goodman"
+    ]
   },
   {
     "movieId": "shin-seiki-evangelion-gekij-ban-air-magokoro-wo-kimi-ni-1997",
@@ -2700,7 +4422,14 @@
     "year": 1997,
     "runtime": 87,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Concurrent theatrical ending of the TV series Shin seiki evangerion (1995).",
+    "cast": [
+      "Kazuya Tsurumaki",
+      "Megumi Ogata",
+      "Megumi Hayashibara",
+      "Yûko Miyamura"
+    ]
   },
   {
     "movieId": "lagaan-once-upon-a-time-in-india-2001",
@@ -2711,7 +4440,14 @@
     "year": 2001,
     "runtime": 224,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The people of a small village in Victorian India stake their future on a game of cricket against their ruthless British rulers.",
+    "cast": [
+      "Aamir Khan",
+      "Raghuvir Yadav",
+      "Gracy Singh",
+      "Rachel Shelley"
+    ]
   },
   {
     "movieId": "the-sixth-sense-1999",
@@ -2722,7 +4458,14 @@
     "year": 1999,
     "runtime": 107,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A boy who communicates with spirits seeks the help of a disheartened child psychologist.",
+    "cast": [
+      "Bruce Willis",
+      "Haley Joel Osment",
+      "Toni Collette",
+      "Olivia Williams"
+    ]
   },
   {
     "movieId": "la-leggenda-del-pianista-sull-oceano-1998",
@@ -2733,7 +4476,14 @@
     "year": 1998,
     "runtime": 169,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A baby boy, discovered in 1900 on an ocean liner, grows into a musical prodigy, never setting foot on land.",
+    "cast": [
+      "Tim Roth",
+      "Pruitt Taylor Vince",
+      "Mélanie Thierry",
+      "Bill Nunn"
+    ]
   },
   {
     "movieId": "the-truman-show-1998",
@@ -2744,7 +4494,14 @@
     "year": 1998,
     "runtime": 103,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "An insurance salesman discovers his whole life is actually a reality TV show.",
+    "cast": [
+      "Jim Carrey",
+      "Ed Harris",
+      "Laura Linney",
+      "Noah Emmerich"
+    ]
   },
   {
     "movieId": "crna-macka-beli-macor-1998",
@@ -2755,7 +4512,14 @@
     "year": 1998,
     "runtime": 127,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Matko and his son Zare live on the banks of the Danube river and get by through hustling and basically doing anything to make a living. In order to pay off a business debt Matko agrees to marry off Zare to the sister of a local gangster.",
+    "cast": [
+      "Bajram Severdzan",
+      "Srdjan 'Zika' Todorovic",
+      "Branka Katic",
+      "Florijan Ajdini"
+    ]
   },
   {
     "movieId": "the-big-lebowski-1998",
@@ -2766,7 +4530,14 @@
     "year": 1998,
     "runtime": 117,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Jeff \"The Dude\" Lebowski, mistaken for a millionaire of the same name, seeks restitution for his ruined rug and enlists his bowling buddies to help get it.",
+    "cast": [
+      "Ethan Coen",
+      "Jeff Bridges",
+      "John Goodman",
+      "Julianne Moore"
+    ]
   },
   {
     "movieId": "fa-yeung-nin-wah-2000",
@@ -2777,7 +4548,14 @@
     "year": 2000,
     "runtime": 98,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Two neighbors, a woman and a man, form a strong bond after both suspect extramarital activities of their spouses. However, they agree to keep their bond platonic so as not to commit similar wrongs.",
+    "cast": [
+      "Tony Chiu-Wai Leung",
+      "Maggie Cheung",
+      "Ping Lam Siu",
+      "Tung Cho 'Joe' Cheung"
+    ]
   },
   {
     "movieId": "trainspotting-1996",
@@ -2788,7 +4566,14 @@
     "year": 1996,
     "runtime": 93,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Renton, deeply immersed in the Edinburgh drug scene, tries to clean up and get out, despite the allure of the drugs and influence of friends.",
+    "cast": [
+      "Ewan McGregor",
+      "Ewen Bremner",
+      "Jonny Lee Miller",
+      "Kevin McKidd"
+    ]
   },
   {
     "movieId": "fargo-1996",
@@ -2799,7 +4584,14 @@
     "year": 1996,
     "runtime": 98,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Jerry Lundegaard's inept crime falls apart due to his and his henchmen's bungling and the persistent police work of the quite pregnant Marge Gunderson.",
+    "cast": [
+      "Ethan Coen",
+      "William H. Macy",
+      "Frances McDormand",
+      "Steve Buscemi"
+    ]
   },
   {
     "movieId": "underground-1995",
@@ -2809,7 +4601,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNzI4YTVmMWEtMWQ3MS00OGE1LWE5YjMtNjc4NWJmYjRmZTQyXkEyXkFqcGdeQXVyNTA4NzY1MzY@._V1_SX4000.jpg",
     "year": 1995,
     "runtime": 170,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "A group of Serbian socialists prepares for the war in a surreal underground filled by parties, tragedies, love and hate.",
+    "cast": [
+      "Predrag 'Miki' Manojlovic",
+      "Lazar Ristovski",
+      "Mirjana Jokovic",
+      "Slavko Stimac"
+    ]
   },
   {
     "movieId": "la-haine-1995",
@@ -2820,7 +4619,14 @@
     "year": 1995,
     "runtime": 98,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "24 hours in the lives of three young men in the French suburbs the day after a violent riot.",
+    "cast": [
+      "Vincent Cassel",
+      "Hubert Koundé",
+      "Saïd Taghmaoui",
+      "Abdel Ahmed Ghili"
+    ]
   },
   {
     "movieId": "dilwale-dulhania-le-jayenge-1995",
@@ -2831,7 +4637,14 @@
     "year": 1995,
     "runtime": 189,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "When Raj meets Simran in Europe, it isn't love at first sight but when Simran moves to India for an arranged marriage, love makes its presence felt.",
+    "cast": [
+      "Shah Rukh Khan",
+      "Kajol",
+      "Amrish Puri",
+      "Farida Jalal"
+    ]
   },
   {
     "movieId": "before-sunrise-1995",
@@ -2842,7 +4655,14 @@
     "year": 1995,
     "runtime": 101,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A young man and woman meet on a train in Europe, and wind up spending one evening together in Vienna. Unfortunately, both know that this will probably be their only night together.",
+    "cast": [
+      "Ethan Hawke",
+      "Julie Delpy",
+      "Andrea Eckert",
+      "Hanno Pöschl"
+    ]
   },
   {
     "movieId": "trois-couleurs-rouge-1994",
@@ -2853,7 +4673,14 @@
     "year": 1994,
     "runtime": 99,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A model discovers a retired judge is keen on invading people's privacy.",
+    "cast": [
+      "Irène Jacob",
+      "Jean-Louis Trintignant",
+      "Frédérique Feder",
+      "Jean-Pierre Lorit"
+    ]
   },
   {
     "movieId": "chung-hing-sam-lam-1994",
@@ -2864,7 +4691,14 @@
     "year": 1994,
     "runtime": 102,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Two melancholy Hong Kong policemen fall in love: one with a mysterious female underworld figure, the other with a beautiful and ethereal server at a late-night restaurant he frequents.",
+    "cast": [
+      "Brigitte Lin",
+      "Takeshi Kaneshiro",
+      "Tony Chiu-Wai Leung",
+      "Faye Wong"
+    ]
   },
   {
     "movieId": "jurassic-park-1993",
@@ -2875,7 +4709,14 @@
     "year": 1993,
     "runtime": 127,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A pragmatic paleontologist visiting an almost complete theme park is tasked with protecting a couple of kids after a power failure causes the park's cloned dinosaurs to run loose.",
+    "cast": [
+      "Sam Neill",
+      "Laura Dern",
+      "Jeff Goldblum",
+      "Richard Attenborough"
+    ]
   },
   {
     "movieId": "in-the-name-of-the-father-1993",
@@ -2886,7 +4727,14 @@
     "year": 1993,
     "runtime": 133,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A man's coerced confession to an I.R.A. bombing he did not commit results in the imprisonment of his father as well. An English lawyer fights to free them.",
+    "cast": [
+      "Daniel Day-Lewis",
+      "Pete Postlethwaite",
+      "Alison Crosbie",
+      "Philip King"
+    ]
   },
   {
     "movieId": "ba-wang-bie-ji-1993",
@@ -2897,7 +4745,14 @@
     "year": 1993,
     "runtime": 171,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Two boys meet at an opera training school in Peking in 1924. Their resulting friendship will span nearly 70 years and will endure some of the most troublesome times in China's history.",
+    "cast": [
+      "Leslie Cheung",
+      "Fengyi Zhang",
+      "Gong Li",
+      "You Ge"
+    ]
   },
   {
     "movieId": "d-h-ng-denglong-gaogao-gu-1991",
@@ -2908,7 +4763,14 @@
     "year": 1991,
     "runtime": 125,
     "imdbRating": 8.1,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "A young woman becomes the fourth wife of a wealthy lord, and must learn to live with the strict rules and tensions within the household.",
+    "cast": [
+      "Gong Li",
+      "Jingwu Ma",
+      "Saifei He",
+      "Cuifen Cao"
+    ]
   },
   {
     "movieId": "dead-poets-society-1989",
@@ -2919,7 +4781,14 @@
     "year": 1989,
     "runtime": 128,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Maverick teacher John Keating uses poetry to embolden his boarding school students to new heights of self-expression.",
+    "cast": [
+      "Robin Williams",
+      "Robert Sean Leonard",
+      "Ethan Hawke",
+      "Josh Charles"
+    ]
   },
   {
     "movieId": "stand-by-me-1986",
@@ -2930,7 +4799,14 @@
     "year": 1986,
     "runtime": 89,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "After the death of one of his friends, a writer recounts a childhood journey with his friends to find the body of a missing boy.",
+    "cast": [
+      "Wil Wheaton",
+      "River Phoenix",
+      "Corey Feldman",
+      "Jerry O'Connell"
+    ]
   },
   {
     "movieId": "platoon-1986",
@@ -2941,7 +4817,14 @@
     "year": 1986,
     "runtime": 120,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Chris Taylor, a neophyte recruit in Vietnam, finds himself caught in a battle of wills between two sergeants, one good and the other evil. A shrewd examination of the brutality of war and the duality of man in conflict.",
+    "cast": [
+      "Charlie Sheen",
+      "Tom Berenger",
+      "Willem Dafoe",
+      "Keith David"
+    ]
   },
   {
     "movieId": "paris-texas-1984",
@@ -2952,7 +4835,14 @@
     "year": 1984,
     "runtime": 145,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Travis Henderson, an aimless drifter who has been missing for four years, wanders out of the desert and must reconnect with society, himself, his life, and his family.",
+    "cast": [
+      "Harry Dean Stanton",
+      "Nastassja Kinski",
+      "Dean Stockwell",
+      "Aurore Clément"
+    ]
   },
   {
     "movieId": "kaze-no-tani-no-naushika-1984",
@@ -2963,7 +4853,14 @@
     "year": 1984,
     "runtime": 117,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Warrior and pacifist Princess Nausicaä desperately struggles to prevent two warring nations from destroying themselves and their dying planet.",
+    "cast": [
+      "Sumi Shimamoto",
+      "Mahito Tsujimura",
+      "Hisako Kyôda",
+      "Gorô Naya"
+    ]
   },
   {
     "movieId": "the-thing-1982",
@@ -2974,7 +4871,14 @@
     "year": 1982,
     "runtime": 109,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A research team in Antarctica is hunted by a shape-shifting alien that assumes the appearance of its victims.",
+    "cast": [
+      "Kurt Russell",
+      "Wilford Brimley",
+      "Keith David",
+      "Richard Masur"
+    ]
   },
   {
     "movieId": "pink-floyd-the-wall-1982",
@@ -2985,7 +4889,14 @@
     "year": 1982,
     "runtime": 95,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A confined but troubled rock star descends into madness in the midst of his physical and social isolation from everyone.",
+    "cast": [
+      "Bob Geldof",
+      "Christine Hargreaves",
+      "James Laurenson",
+      "Eleanor David"
+    ]
   },
   {
     "movieId": "fitzcarraldo-1982",
@@ -2996,7 +4907,14 @@
     "year": 1982,
     "runtime": 158,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "The story of Brian Sweeney Fitzgerald, an extremely determined man who intends to build an opera house in the middle of a jungle.",
+    "cast": [
+      "Klaus Kinski",
+      "Claudia Cardinale",
+      "José Lewgoy",
+      "Miguel Ángel Fuentes"
+    ]
   },
   {
     "movieId": "fanny-och-alexander-1982",
@@ -3007,7 +4925,14 @@
     "year": 1982,
     "runtime": 188,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Two young Swedish children experience the many comedies and tragedies of their family, the Ekdahls.",
+    "cast": [
+      "Bertil Guve",
+      "Pernilla Allwin",
+      "Kristina Adolphson",
+      "Börje Ahlstedt"
+    ]
   },
   {
     "movieId": "blade-runner-1982",
@@ -3018,7 +4943,14 @@
     "year": 1982,
     "runtime": 117,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A blade runner must pursue and terminate four replicants who stole a ship in space, and have returned to Earth to find their creator.",
+    "cast": [
+      "Harrison Ford",
+      "Rutger Hauer",
+      "Sean Young",
+      "Edward James Olmos"
+    ]
   },
   {
     "movieId": "the-elephant-man-1980",
@@ -3029,7 +4961,14 @@
     "year": 1980,
     "runtime": 124,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A Victorian surgeon rescues a heavily disfigured man who is mistreated while scraping a living as a side-show freak. Behind his monstrous façade, there is revealed a person of kindness, intelligence and sophistication.",
+    "cast": [
+      "Anthony Hopkins",
+      "John Hurt",
+      "Anne Bancroft",
+      "John Gielgud"
+    ]
   },
   {
     "movieId": "life-of-brian-1979",
@@ -3040,7 +4979,14 @@
     "year": 1979,
     "runtime": 94,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Born on the original Christmas in the stable next door to Jesus Christ, Brian of Nazareth spends his life being mistaken for a messiah.",
+    "cast": [
+      "Graham Chapman",
+      "John Cleese",
+      "Michael Palin",
+      "Terry Gilliam"
+    ]
   },
   {
     "movieId": "the-deer-hunter-1978",
@@ -3051,7 +4997,14 @@
     "year": 1978,
     "runtime": 183,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An in-depth examination of the ways in which the U.S. Vietnam War impacts and disrupts the lives of people in a small industrial town in Pennsylvania.",
+    "cast": [
+      "Robert De Niro",
+      "Christopher Walken",
+      "John Cazale",
+      "John Savage"
+    ]
   },
   {
     "movieId": "rocky-1976",
@@ -3062,7 +5015,14 @@
     "year": 1976,
     "runtime": 120,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A small-time boxer gets a supremely rare chance to fight a heavy-weight champion in a bout in which he strives to go the distance for his self-respect.",
+    "cast": [
+      "Sylvester Stallone",
+      "Talia Shire",
+      "Burt Young",
+      "Carl Weathers"
+    ]
   },
   {
     "movieId": "network-1976",
@@ -3073,7 +5033,14 @@
     "year": 1976,
     "runtime": 121,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A television network cynically exploits a deranged former anchor's ravings and revelations about the news media for its own profit.",
+    "cast": [
+      "Faye Dunaway",
+      "William Holden",
+      "Peter Finch",
+      "Robert Duvall"
+    ]
   },
   {
     "movieId": "barry-lyndon-1975",
@@ -3084,7 +5051,14 @@
     "year": 1975,
     "runtime": 185,
     "imdbRating": 8.1,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "An Irish rogue wins the heart of a rich widow and assumes her dead husband's aristocratic position in 18th-century England.",
+    "cast": [
+      "Ryan O'Neal",
+      "Marisa Berenson",
+      "Patrick Magee",
+      "Hardy Krüger"
+    ]
   },
   {
     "movieId": "zerkalo-1975",
@@ -3095,7 +5069,14 @@
     "year": 1975,
     "runtime": 107,
     "imdbRating": 8.1,
-    "rated": "G"
+    "rated": "G",
+    "synopsis": "A dying man in his forties remembers his past. His childhood, his mother, the war, personal moments and things that tell of the recent history of all the Russian nation.",
+    "cast": [
+      "Margarita Terekhova",
+      "Filipp Yankovskiy",
+      "Ignat Daniltsev",
+      "Oleg Yankovskiy"
+    ]
   },
   {
     "movieId": "chinatown-1974",
@@ -3106,7 +5087,14 @@
     "year": 1974,
     "runtime": 130,
     "imdbRating": 8.1,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A private detective hired to expose an adulterer finds himself caught up in a web of deceit, corruption, and murder.",
+    "cast": [
+      "Jack Nicholson",
+      "Faye Dunaway",
+      "John Huston",
+      "Perry Lopez"
+    ]
   },
   {
     "movieId": "paper-moon-1973",
@@ -3117,7 +5105,14 @@
     "year": 1973,
     "runtime": 102,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "During the Great Depression, a con man finds himself saddled with a young girl who may or may not be his daughter, and the two forge an unlikely partnership.",
+    "cast": [
+      "Ryan O'Neal",
+      "Tatum O'Neal",
+      "Madeline Kahn",
+      "John Hillerman"
+    ]
   },
   {
     "movieId": "viskningar-och-rop-1972",
@@ -3128,7 +5123,14 @@
     "year": 1972,
     "runtime": 91,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "When a woman dying of cancer in early twentieth-century Sweden is visited by her two sisters, long-repressed feelings between the siblings rise to the surface.",
+    "cast": [
+      "Harriet Andersson",
+      "Liv Ullmann",
+      "Kari Sylwan",
+      "Ingrid Thulin"
+    ]
   },
   {
     "movieId": "solaris-1972",
@@ -3139,7 +5141,14 @@
     "year": 1972,
     "runtime": 167,
     "imdbRating": 8.1,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "A psychologist is sent to a station orbiting a distant planet in order to discover what has caused the crew to go insane.",
+    "cast": [
+      "Natalya Bondarchuk",
+      "Donatas Banionis",
+      "Jüri Järvet",
+      "Vladislav Dvorzhetskiy"
+    ]
   },
   {
     "movieId": "le-samoura-1967",
@@ -3150,7 +5159,14 @@
     "year": 1967,
     "runtime": 105,
     "imdbRating": 8.1,
-    "rated": "GP"
+    "rated": "GP",
+    "synopsis": "After professional hitman Jef Costello is seen by witnesses his efforts to provide himself an alibi drive him further into a corner.",
+    "cast": [
+      "Alain Delon",
+      "François Périer",
+      "Nathalie Delon",
+      "Cathy Rosier"
+    ]
   },
   {
     "movieId": "cool-hand-luke-1967",
@@ -3161,7 +5177,14 @@
     "year": 1967,
     "runtime": 127,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A laid back Southern man is sentenced to two years in a rural prison, but refuses to conform.",
+    "cast": [
+      "Paul Newman",
+      "George Kennedy",
+      "Strother Martin",
+      "J.D. Cannon"
+    ]
   },
   {
     "movieId": "persona-1966",
@@ -3171,7 +5194,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTM0YzExY2EtMjUyZi00ZmIwLWFkYTktNjY5NmVkYTdkMjI5XkEyXkFqcGdeQXVyNzQxNDExNTU@._V1_SX4000.jpg",
     "year": 1966,
     "runtime": 85,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "A nurse is put in charge of a mute actress and finds that their personae are melding together.",
+    "cast": [
+      "Bibi Andersson",
+      "Liv Ullmann",
+      "Margaretha Krook",
+      "Gunnar Björnstrand"
+    ]
   },
   {
     "movieId": "andrei-rublev-1966",
@@ -3182,7 +5212,14 @@
     "year": 1966,
     "runtime": 205,
     "imdbRating": 8.1,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "The life, times and afflictions of the fifteenth-century Russian iconographer St. Andrei Rublev.",
+    "cast": [
+      "Anatoliy Solonitsyn",
+      "Ivan Lapikov",
+      "Nikolay Grinko",
+      "Nikolay Sergeev"
+    ]
   },
   {
     "movieId": "la-battaglia-di-algeri-1966",
@@ -3192,7 +5229,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BZWEzMGY4OTQtYTdmMy00M2QwLTliYTQtYWUzYzc3OTA5YzIwXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_SX4000.jpg",
     "year": 1966,
     "runtime": 121,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "In the 1950s, fear and violence escalate as the people of Algiers fight for independence from the French government.",
+    "cast": [
+      "Brahim Hadjadj",
+      "Jean Martin",
+      "Yacef Saadi",
+      "Samia Kerbash"
+    ]
   },
   {
     "movieId": "el-ngel-exterminador-1962",
@@ -3202,7 +5246,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BZTg3M2ExY2EtZmI5Yy00YWM1LTg4NzItZWEzZTgxNzE2MjhhXkEyXkFqcGdeQXVyNDE5MTU2MDE@._V1_SX4000.jpg",
     "year": 1962,
     "runtime": 95,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "The guests at an upper-class dinner party find themselves unable to leave.",
+    "cast": [
+      "Silvia Pinal",
+      "Jacqueline Andere",
+      "Enrique Rambal",
+      "José Baviera"
+    ]
   },
   {
     "movieId": "what-ever-happened-to-baby-jane-1962",
@@ -3213,7 +5264,14 @@
     "year": 1962,
     "runtime": 134,
     "imdbRating": 8.1,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A former child star torments her paraplegic sister in their decaying Hollywood mansion.",
+    "cast": [
+      "Bette Davis",
+      "Joan Crawford",
+      "Victor Buono",
+      "Wesley Addy"
+    ]
   },
   {
     "movieId": "sanjuro-1962",
@@ -3224,7 +5282,14 @@
     "year": 1962,
     "runtime": 96,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A crafty samurai helps a young man and his fellow clansmen save his uncle, who has been framed and imprisoned by a corrupt superintendent.",
+    "cast": [
+      "Toshirô Mifune",
+      "Tatsuya Nakadai",
+      "Keiju Kobayashi",
+      "Yûnosuke Itô"
+    ]
   },
   {
     "movieId": "the-man-who-shot-liberty-valance-1962",
@@ -3234,7 +5299,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMGEyNzhkYzktMGMyZS00YzRiLWJlYjktZjJkOTU5ZDY0ZGI4XkEyXkFqcGdeQXVyNjUwNzk3NDc@._V1_SX4000.jpg",
     "year": 1962,
     "runtime": 123,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "A senator returns to a western town for the funeral of an old friend and tells the story of his origins.",
+    "cast": [
+      "James Stewart",
+      "John Wayne",
+      "Vera Miles",
+      "Lee Marvin"
+    ]
   },
   {
     "movieId": "ivanovo-detstvo-1962",
@@ -3244,7 +5316,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYTYzYzBhYjQtNDQxYS00MmUwLTkyZjgtZWVkOWFjNzE5OTI2XkEyXkFqcGdeQXVyNjMxMjkwMjI@._V1_SX4000.jpg",
     "year": 1962,
     "runtime": 95,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "In WW2, twelve year old Soviet orphan Ivan Bondarev works for the Soviet army as a scout behind the German lines and strikes a friendship with three sympathetic Soviet officers.",
+    "cast": [
+      "Eduard Abalov",
+      "Nikolay Burlyaev",
+      "Valentin Zubkov",
+      "Evgeniy Zharikov"
+    ]
   },
   {
     "movieId": "jungfruk-llan-1960",
@@ -3255,7 +5334,14 @@
     "year": 1960,
     "runtime": 89,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An innocent yet pampered young virgin and her family's pregnant and jealous servant set out to deliver candles to church, but only one returns from events that transpire in the woods along the way.",
+    "cast": [
+      "Max von Sydow",
+      "Birgitta Valberg",
+      "Gunnel Lindblom",
+      "Birgitta Pettersson"
+    ]
   },
   {
     "movieId": "inherit-the-wind-1960",
@@ -3266,7 +5352,14 @@
     "year": 1960,
     "runtime": 128,
     "imdbRating": 8.1,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "Based on a real-life case in 1925, two great lawyers argue the case for and against a science teacher accused of the crime of teaching evolution.",
+    "cast": [
+      "Spencer Tracy",
+      "Fredric March",
+      "Gene Kelly",
+      "Dick York"
+    ]
   },
   {
     "movieId": "les-quatre-cents-coups-1959",
@@ -3276,7 +5369,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYTQ4MjA4NmYtYjRhNi00MTEwLTg0NjgtNjk3ODJlZGU4NjRkL2ltYWdlL2ltYWdlXkEyXkFqcGdeQXVyNjU0OTQ0OTY@._V1_SX4000.jpg",
     "year": 1959,
     "runtime": 99,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "A young boy, left without attention, delves into a life of petty crime.",
+    "cast": [
+      "Jean-Pierre Léaud",
+      "Albert Rémy",
+      "Claire Maurier",
+      "Guy Decomble"
+    ]
   },
   {
     "movieId": "ben-hur-1959",
@@ -3287,7 +5387,14 @@
     "year": 1959,
     "runtime": 212,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "After a Jewish prince is betrayed and sent into slavery by a Roman friend, he regains his freedom and comes back for revenge.",
+    "cast": [
+      "Charlton Heston",
+      "Jack Hawkins",
+      "Stephen Boyd",
+      "Haya Harareet"
+    ]
   },
   {
     "movieId": "kakushi-toride-no-san-akunin-1958",
@@ -3297,7 +5404,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYjJkN2Y5MTktZDRhOS00NTUwLWFiMzEtMTVlNWU4ODM0Y2E5XkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_SX4000.jpg",
     "year": 1958,
     "runtime": 139,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "Lured by gold, two greedy peasants unknowingly escort a princess and her general across enemy lines.",
+    "cast": [
+      "Toshirô Mifune",
+      "Misa Uehara",
+      "Minoru Chiaki",
+      "Kamatari Fujiwara"
+    ]
   },
   {
     "movieId": "le-notti-di-cabiria-1957",
@@ -3307,7 +5421,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BOTdhNmUxZmQtNmMwNC00MzE3LWE1MTUtZDgxZTYwYjEzZjcwXkEyXkFqcGdeQXVyNTA1NjYyMDk@._V1_SX4000.jpg",
     "year": 1957,
     "runtime": 110,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "A waifish prostitute wanders the streets of Rome looking for true love but finds only heartbreak.",
+    "cast": [
+      "Giulietta Masina",
+      "François Périer",
+      "Franca Marzi",
+      "Dorian Gray"
+    ]
   },
   {
     "movieId": "kumonosu-j-1957",
@@ -3317,7 +5438,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNGYxZjA2M2ItYTRmNS00NzRmLWJkYzgtYTdiNGFlZDI5ZjNmXkEyXkFqcGdeQXVyNDE5MTU2MDE@._V1_SX4000.jpg",
     "year": 1957,
     "runtime": 110,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "A war-hardened general, egged on by his ambitious wife, works to fulfill a prophecy that he would become lord of Spider's Web Castle.",
+    "cast": [
+      "Toshirô Mifune",
+      "Minoru Chiaki",
+      "Isuzu Yamada",
+      "Takashi Shimura"
+    ]
   },
   {
     "movieId": "the-bridge-on-the-river-kwai-1957",
@@ -3328,7 +5456,14 @@
     "year": 1957,
     "runtime": 161,
     "imdbRating": 8.1,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "British POWs are forced to build a railway bridge across the river Kwai for their Japanese captors, not knowing that the allied forces are planning to destroy it.",
+    "cast": [
+      "William Holden",
+      "Alec Guinness",
+      "Jack Hawkins",
+      "Sessue Hayakawa"
+    ]
   },
   {
     "movieId": "on-the-waterfront-1954",
@@ -3339,7 +5474,14 @@
     "year": 1954,
     "runtime": 108,
     "imdbRating": 8.1,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An ex-prize fighter turned longshoreman struggles to stand up to his corrupt union bosses.",
+    "cast": [
+      "Marlon Brando",
+      "Karl Malden",
+      "Lee J. Cobb",
+      "Rod Steiger"
+    ]
   },
   {
     "movieId": "le-salaire-de-la-peur-1953",
@@ -3350,7 +5492,14 @@
     "year": 1953,
     "runtime": 131,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In a decrepit South American village, four men are hired to transport an urgent nitroglycerine shipment without the equipment that would make it safe.",
+    "cast": [
+      "Yves Montand",
+      "Charles Vanel",
+      "Peter van Eyck",
+      "Folco Lulli"
+    ]
   },
   {
     "movieId": "ace-in-the-hole-1951",
@@ -3361,7 +5510,14 @@
     "year": 1951,
     "runtime": 111,
     "imdbRating": 8.1,
-    "rated": "Approved"
+    "rated": "Approved",
+    "synopsis": "A frustrated former big-city journalist now stuck working for an Albuquerque newspaper exploits a story about a man trapped in a cave to rekindle his career, but the situation quickly escalates into an out-of-control circus.",
+    "cast": [
+      "Kirk Douglas",
+      "Jan Sterling",
+      "Robert Arthur",
+      "Porter Hall"
+    ]
   },
   {
     "movieId": "white-heat-1949",
@@ -3371,7 +5527,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BZmI5NTA3MjItYzdhMi00MWMxLTg3OWMtYWQyYjg5MTFmM2U0L2ltYWdlL2ltYWdlXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_SX4000.jpg",
     "year": 1949,
     "runtime": 114,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "A psychopathic criminal with a mother complex makes a daring break from prison and leads his old gang in a chemical plant payroll heist.",
+    "cast": [
+      "James Cagney",
+      "Virginia Mayo",
+      "Edmond O'Brien",
+      "Margaret Wycherly"
+    ]
   },
   {
     "movieId": "the-third-man-1949",
@@ -3382,7 +5545,14 @@
     "year": 1949,
     "runtime": 104,
     "imdbRating": 8.1,
-    "rated": "Approved"
+    "rated": "Approved",
+    "synopsis": "Pulp novelist Holly Martins travels to shadowy, postwar Vienna, only to find himself investigating the mysterious death of an old friend, Harry Lime.",
+    "cast": [
+      "Orson Welles",
+      "Joseph Cotten",
+      "Alida Valli",
+      "Trevor Howard"
+    ]
   },
   {
     "movieId": "the-red-shoes-1948",
@@ -3392,7 +5562,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BOWRmNGEwZjUtZjEwNS00OGZmLThhMmEtZTJlMTU5MGQ3ZWUwXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_SX4000.jpg",
     "year": 1948,
     "runtime": 135,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "A young ballet dancer is torn between the man she loves and her pursuit to become a prima ballerina.",
+    "cast": [
+      "Emeric Pressburger",
+      "Anton Walbrook",
+      "Marius Goring",
+      "Moira Shearer"
+    ]
   },
   {
     "movieId": "the-shop-around-the-corner-1940",
@@ -3402,7 +5579,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNzc1MTcyNTQ5N15BMl5BanBnXkFtZTgwMzgwMDI0MjE@._V1_SX4000.jpg",
     "year": 1940,
     "runtime": 99,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "Two employees at a gift shop can barely stand each other, without realizing that they are falling in love through the post as each other's anonymous pen pal.",
+    "cast": [
+      "Margaret Sullavan",
+      "James Stewart",
+      "Frank Morgan",
+      "Joseph Schildkraut"
+    ]
   },
   {
     "movieId": "rebecca-1940",
@@ -3413,7 +5597,14 @@
     "year": 1940,
     "runtime": 130,
     "imdbRating": 8.1,
-    "rated": "Approved"
+    "rated": "Approved",
+    "synopsis": "A self-conscious woman juggles adjusting to her new role as an aristocrat's wife and avoiding being intimidated by his first wife's spectral presence.",
+    "cast": [
+      "Laurence Olivier",
+      "Joan Fontaine",
+      "George Sanders",
+      "Judith Anderson"
+    ]
   },
   {
     "movieId": "mr-smith-goes-to-washington-1939",
@@ -3424,7 +5615,14 @@
     "year": 1939,
     "runtime": 129,
     "imdbRating": 8.1,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A naive man is appointed to fill a vacancy in the United States Senate. His plans promptly collide with political corruption, but he doesn't back down.",
+    "cast": [
+      "James Stewart",
+      "Jean Arthur",
+      "Claude Rains",
+      "Edward Arnold"
+    ]
   },
   {
     "movieId": "gone-with-the-wind-1939",
@@ -3435,7 +5633,14 @@
     "year": 1939,
     "runtime": 238,
     "imdbRating": 8.1,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A manipulative woman and a roguish man conduct a turbulent romance during the American Civil War and Reconstruction periods.",
+    "cast": [
+      "George Cukor",
+      "Sam Wood",
+      "Clark Gable",
+      "Vivien Leigh"
+    ]
   },
   {
     "movieId": "la-grande-illusion-1937",
@@ -3445,7 +5650,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTg3MTI5NTk0N15BMl5BanBnXkFtZTgwMjU1MDM5MTE@._V1_SX4000.jpg",
     "year": 1937,
     "runtime": 113,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "During WWI, two French soldiers are captured and imprisoned in a German P.O.W. camp. Several escape attempts follow until they are eventually sent to a seemingly inescapable fortress.",
+    "cast": [
+      "Jean Gabin",
+      "Dita Parlo",
+      "Pierre Fresnay",
+      "Erich von Stroheim"
+    ]
   },
   {
     "movieId": "it-happened-one-night-1934",
@@ -3456,7 +5668,14 @@
     "year": 1934,
     "runtime": 105,
     "imdbRating": 8.1,
-    "rated": "Approved"
+    "rated": "Approved",
+    "synopsis": "A renegade reporter and a crazy young heiress meet on a bus heading for New York, and end up stuck with each other when the bus leaves them behind at one of the stops.",
+    "cast": [
+      "Clark Gable",
+      "Claudette Colbert",
+      "Walter Connolly",
+      "Roscoe Karns"
+    ]
   },
   {
     "movieId": "la-passion-de-jeanne-d-arc-1928",
@@ -3467,7 +5686,14 @@
     "year": 1928,
     "runtime": 110,
     "imdbRating": 8.1,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "In 1431, Jeanne d'Arc is placed on trial on charges of heresy. The ecclesiastical jurists attempt to force Jeanne to recant her claims of holy visions.",
+    "cast": [
+      "Maria Falconetti",
+      "Eugene Silvain",
+      "André Berley",
+      "Maurice Schutz"
+    ]
   },
   {
     "movieId": "the-circus-1928",
@@ -3478,7 +5704,14 @@
     "year": 1928,
     "runtime": 72,
     "imdbRating": 8.1,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "The Tramp finds work and the girl of his dreams at a circus.",
+    "cast": [
+      "Charles Chaplin",
+      "Merna Kennedy",
+      "Al Ernest Garcia",
+      "Harry Crocker"
+    ]
   },
   {
     "movieId": "sunrise-a-song-of-two-humans-1927",
@@ -3489,7 +5722,14 @@
     "year": 1927,
     "runtime": 94,
     "imdbRating": 8.1,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "An allegorical tale about a man fighting the good and evil within him. Both sides are made flesh - one a sophisticated woman he is attracted to and the other his wife.",
+    "cast": [
+      "George O'Brien",
+      "Janet Gaynor",
+      "Margaret Livingston",
+      "Bodil Rosing"
+    ]
   },
   {
     "movieId": "the-general-1926",
@@ -3500,7 +5740,14 @@
     "year": 1926,
     "runtime": 67,
     "imdbRating": 8.1,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "When Union spies steal an engineer's beloved locomotive, he pursues it single-handedly and straight through enemy lines.",
+    "cast": [
+      "Buster Keaton",
+      "Buster Keaton",
+      "Marion Mack",
+      "Glen Cavender"
+    ]
   },
   {
     "movieId": "das-cabinet-des-dr-caligari-1920",
@@ -3510,7 +5757,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNWJiNGJiMTEtMGM3OC00ZWNlLTgwZTgtMzdhNTRiZjk5MTQ1XkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_SX4000.jpg",
     "year": 1920,
     "runtime": 76,
-    "imdbRating": 8.1
+    "imdbRating": 8.1,
+    "synopsis": "Hypnotist Dr. Caligari uses a somnambulist, Cesare, to commit murders.",
+    "cast": [
+      "Werner Krauss",
+      "Conrad Veidt",
+      "Friedrich Feher",
+      "Lil Dagover"
+    ]
   },
   {
     "movieId": "badhaai-ho-2018",
@@ -3521,7 +5775,14 @@
     "year": 2018,
     "runtime": 124,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A man is embarrassed when he finds out his mother is pregnant.",
+    "cast": [
+      "Ayushmann Khurrana",
+      "Neena Gupta",
+      "Gajraj Rao",
+      "Sanya Malhotra"
+    ]
   },
   {
     "movieId": "togo-2019",
@@ -3532,7 +5793,14 @@
     "year": 2019,
     "runtime": 113,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The story of Togo, the sled dog who led the 1925 serum run yet was considered by most to be too small and weak to lead such an intense race.",
+    "cast": [
+      "Willem Dafoe",
+      "Julianne Nicholson",
+      "Christopher Heyerdahl",
+      "Richard Dormer"
+    ]
   },
   {
     "movieId": "airlift-2016",
@@ -3543,7 +5811,14 @@
     "year": 2016,
     "runtime": 130,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "When Iraq invades Kuwait in August 1990, a callous Indian businessman becomes the spokesperson for more than 170,000 stranded countrymen.",
+    "cast": [
+      "Akshay Kumar",
+      "Nimrat Kaur",
+      "Kumud Mishra",
+      "Prakash Belawadi"
+    ]
   },
   {
     "movieId": "bajrangi-bhaijaan-2015",
@@ -3554,7 +5829,14 @@
     "year": 2015,
     "runtime": 163,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "An Indian man with a magnanimous heart takes a young mute Pakistani girl back to her homeland to reunite her with her family.",
+    "cast": [
+      "Salman Khan",
+      "Harshaali Malhotra",
+      "Nawazuddin Siddiqui",
+      "Kareena Kapoor"
+    ]
   },
   {
     "movieId": "baby-2015",
@@ -3565,7 +5847,14 @@
     "year": 2015,
     "runtime": 159,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "An elite counter-intelligence unit learns of a plot, masterminded by a maniacal madman. With the clock ticking, it's up to them to track the terrorists' international tentacles and prevent them from striking at the heart of India.",
+    "cast": [
+      "Akshay Kumar",
+      "Danny Denzongpa",
+      "Rana Daggubati",
+      "Taapsee Pannu"
+    ]
   },
   {
     "movieId": "la-la-land-2016",
@@ -3576,7 +5865,14 @@
     "year": 2016,
     "runtime": 128,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "While navigating their careers in Los Angeles, a pianist and an actress fall in love while attempting to reconcile their aspirations for the future.",
+    "cast": [
+      "Ryan Gosling",
+      "Emma Stone",
+      "Rosemarie DeWitt",
+      "J.K. Simmons"
+    ]
   },
   {
     "movieId": "lion-2016",
@@ -3587,7 +5883,14 @@
     "year": 2016,
     "runtime": 118,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A five-year-old Indian boy is adopted by an Australian couple after getting lost hundreds of kilometers from home. 25 years later, he sets out to find his lost family.",
+    "cast": [
+      "Dev Patel",
+      "Nicole Kidman",
+      "Rooney Mara",
+      "Sunny Pawar"
+    ]
   },
   {
     "movieId": "the-martian-2015",
@@ -3598,7 +5901,14 @@
     "year": 2015,
     "runtime": 144,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "An astronaut becomes stranded on Mars after his team assume him dead, and must rely on his ingenuity to find a way to signal to Earth that he is alive.",
+    "cast": [
+      "Matt Damon",
+      "Jessica Chastain",
+      "Kristen Wiig",
+      "Kate Mara"
+    ]
   },
   {
     "movieId": "zootopia-2016",
@@ -3609,7 +5919,14 @@
     "year": 2016,
     "runtime": 108,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In a city of anthropomorphic animals, a rookie bunny cop and a cynical con artist fox must work together to uncover a conspiracy.",
+    "cast": [
+      "Rich Moore",
+      "Jared Bush",
+      "Ginnifer Goodwin",
+      "Jason Bateman"
+    ]
   },
   {
     "movieId": "b-hubali-the-beginning-2015",
@@ -3620,7 +5937,14 @@
     "year": 2015,
     "runtime": 159,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "In ancient India, an adventurous and daring man becomes involved in a decades-old feud between two warring peoples.",
+    "cast": [
+      "Prabhas",
+      "Rana Daggubati",
+      "Ramya Krishnan",
+      "Sathyaraj"
+    ]
   },
   {
     "movieId": "kaguyahime-no-monogatari-2013",
@@ -3631,7 +5955,14 @@
     "year": 2013,
     "runtime": 137,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Found inside a shining stalk of bamboo by an old bamboo cutter and his wife, a tiny girl grows rapidly into an exquisite young lady. The mysterious young princess enthralls all who encounter her, but ultimately she must confront her fate, the punishment for her crime.",
+    "cast": [
+      "Chloë Grace Moretz",
+      "James Caan",
+      "Mary Steenburgen",
+      "James Marsden"
+    ]
   },
   {
     "movieId": "wonder-2017",
@@ -3642,7 +5973,14 @@
     "year": 2017,
     "runtime": 113,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Based on the New York Times bestseller, this movie tells the incredibly inspiring and heartwarming story of August Pullman, a boy with facial differences who enters the fifth grade, attending a mainstream elementary school for the first time.",
+    "cast": [
+      "Jacob Tremblay",
+      "Owen Wilson",
+      "Izabela Vidovic",
+      "Julia Roberts"
+    ]
   },
   {
     "movieId": "gully-boy-2019",
@@ -3653,7 +5991,14 @@
     "year": 2019,
     "runtime": 154,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A coming-of-age story based on the lives of street rappers in Mumbai.",
+    "cast": [
+      "Vijay Varma",
+      "Nakul Roshan Sahdev",
+      "Ranveer Singh",
+      "Vijay Raaz"
+    ]
   },
   {
     "movieId": "special-chabbis-2013",
@@ -3664,7 +6009,14 @@
     "year": 2013,
     "runtime": 144,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A gang of con-men rob prominent rich businessmen and politicians by posing as C.B.I and income tax officers.",
+    "cast": [
+      "Akshay Kumar",
+      "Anupam Kher",
+      "Manoj Bajpayee",
+      "Jimmy Sheirgill"
+    ]
   },
   {
     "movieId": "short-term-12-2013",
@@ -3675,7 +6027,14 @@
     "year": 2013,
     "runtime": 96,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A 20-something supervising staff member of a residential treatment facility navigates the troubled waters of that world alongside her co-worker and longtime boyfriend.",
+    "cast": [
+      "Brie Larson",
+      "Frantz Turner",
+      "John Gallagher Jr.",
+      "Kaitlyn Dever"
+    ]
   },
   {
     "movieId": "serbuan-maut-2-berandal-2014",
@@ -3686,7 +6045,14 @@
     "year": 2014,
     "runtime": 150,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Only a short time after the first raid, Rama goes undercover with the thugs of Jakarta and plans to bring down the syndicate and uncover the corruption within his police force.",
+    "cast": [
+      "Iko Uwais",
+      "Yayan Ruhian",
+      "Arifin Putra",
+      "Oka Antara"
+    ]
   },
   {
     "movieId": "the-imitation-game-2014",
@@ -3697,7 +6063,14 @@
     "year": 2014,
     "runtime": 114,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "During World War II, the English mathematical genius Alan Turing tries to crack the German Enigma code with help from fellow mathematicians.",
+    "cast": [
+      "Benedict Cumberbatch",
+      "Keira Knightley",
+      "Matthew Goode",
+      "Allen Leech"
+    ]
   },
   {
     "movieId": "guardians-of-the-galaxy-2014",
@@ -3708,7 +6081,14 @@
     "year": 2014,
     "runtime": 121,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A group of intergalactic criminals must pull together to stop a fanatical warrior with plans to purge the universe.",
+    "cast": [
+      "Chris Pratt",
+      "Vin Diesel",
+      "Bradley Cooper",
+      "Zoe Saldana"
+    ]
   },
   {
     "movieId": "blade-runner-2049-2017",
@@ -3719,7 +6099,14 @@
     "year": 2017,
     "runtime": 164,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Young Blade Runner K's discovery of a long-buried secret leads him to track down former Blade Runner Rick Deckard, who's been missing for thirty years.",
+    "cast": [
+      "Harrison Ford",
+      "Ryan Gosling",
+      "Ana de Armas",
+      "Dave Bautista"
+    ]
   },
   {
     "movieId": "her-2013",
@@ -3730,7 +6117,14 @@
     "year": 2013,
     "runtime": 126,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In a near future, a lonely writer develops an unlikely relationship with an operating system designed to meet his every need.",
+    "cast": [
+      "Joaquin Phoenix",
+      "Amy Adams",
+      "Scarlett Johansson",
+      "Rooney Mara"
+    ]
   },
   {
     "movieId": "bohemian-rhapsody-2018",
@@ -3741,7 +6135,14 @@
     "year": 2018,
     "runtime": 134,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The story of the legendary British rock band Queen and lead singer Freddie Mercury, leading up to their famous performance at Live Aid (1985).",
+    "cast": [
+      "Rami Malek",
+      "Lucy Boynton",
+      "Gwilym Lee",
+      "Ben Hardy"
+    ]
   },
   {
     "movieId": "the-revenant-2015",
@@ -3752,7 +6153,14 @@
     "year": 2015,
     "runtime": 156,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A frontiersman on a fur trading expedition in the 1820s fights for survival after being mauled by a bear and left for dead by members of his own hunting team.",
+    "cast": [
+      "Leonardo DiCaprio",
+      "Tom Hardy",
+      "Will Poulter",
+      "Domhnall Gleeson"
+    ]
   },
   {
     "movieId": "the-perks-of-being-a-wallflower-2012",
@@ -3763,7 +6171,14 @@
     "year": 2012,
     "runtime": 103,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "An introvert freshman is taken under the wings of two seniors who welcome him to the real world",
+    "cast": [
+      "Logan Lerman",
+      "Emma Watson",
+      "Ezra Miller",
+      "Paul Rudd"
+    ]
   },
   {
     "movieId": "tropa-de-elite-2-o-inimigo-agora-outro-2010",
@@ -3773,7 +6188,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMjEzMzMxOTUyNV5BMl5BanBnXkFtZTcwNjI3MDc5Ng@@._V1_SX4000.jpg",
     "year": 2010,
     "runtime": 115,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "After a prison riot, former-Captain Nascimento, now a high ranking security officer in Rio de Janeiro, is swept into a bloody political dispute that involves government officials and paramilitary groups.",
+    "cast": [
+      "Wagner Moura",
+      "Irandhir Santos",
+      "André Ramiro",
+      "Milhem Cortaz"
+    ]
   },
   {
     "movieId": "the-king-s-speech-2010",
@@ -3784,7 +6206,14 @@
     "year": 2010,
     "runtime": 118,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The story of King George VI, his impromptu ascension to the throne of the British Empire in 1936, and the speech therapist who helped the unsure monarch overcome his stammer.",
+    "cast": [
+      "Colin Firth",
+      "Geoffrey Rush",
+      "Helena Bonham Carter",
+      "Derek Jacobi"
+    ]
   },
   {
     "movieId": "the-help-2011",
@@ -3795,7 +6224,14 @@
     "year": 2011,
     "runtime": 146,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "An aspiring author during the civil rights movement of the 1960s decides to write a book detailing the African American maids' point of view on the white families for which they work, and the hardships they go through on a daily basis.",
+    "cast": [
+      "Emma Stone",
+      "Viola Davis",
+      "Octavia Spencer",
+      "Bryce Dallas Howard"
+    ]
   },
   {
     "movieId": "deadpool-2016",
@@ -3806,7 +6242,14 @@
     "year": 2016,
     "runtime": 108,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A wisecracking mercenary gets experimented on and becomes immortal but ugly, and sets out to track down the man who ruined his looks.",
+    "cast": [
+      "Ryan Reynolds",
+      "Morena Baccarin",
+      "T.J. Miller",
+      "Ed Skrein"
+    ]
   },
   {
     "movieId": "darbareye-elly-2009",
@@ -3817,7 +6260,14 @@
     "year": 2009,
     "runtime": 119,
     "imdbRating": 8.0,
-    "rated": "TV-PG"
+    "rated": "TV-PG",
+    "synopsis": "The mysterious disappearance of a kindergarten teacher during a picnic in the north of Iran is followed by a series of misadventures for her fellow travelers.",
+    "cast": [
+      "Golshifteh Farahani",
+      "Shahab Hosseini",
+      "Taraneh Alidoosti",
+      "Merila Zare'i"
+    ]
   },
   {
     "movieId": "dev-d-2009",
@@ -3828,7 +6278,14 @@
     "year": 2009,
     "runtime": 144,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "After breaking up with his childhood sweetheart, a young man finds solace in drugs. Meanwhile, a teenage girl is caught in the world of prostitution. Will they be destroyed, or will they find redemption?",
+    "cast": [
+      "Abhay Deol",
+      "Mahie Gill",
+      "Kalki Koechlin",
+      "Dibyendu Bhattacharya"
+    ]
   },
   {
     "movieId": "yip-man-2008",
@@ -3839,7 +6296,14 @@
     "year": 2008,
     "runtime": 106,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "During the Japanese invasion of China, a wealthy martial artist is forced to leave his home when his city is occupied. With little means of providing for themselves, Ip Man and the remaining members of the city must find a way to survive.",
+    "cast": [
+      "Donnie Yen",
+      "Simon Yam",
+      "Siu-Wong Fan",
+      "Ka Tung Lam"
+    ]
   },
   {
     "movieId": "my-name-is-khan-2010",
@@ -3850,7 +6314,14 @@
     "year": 2010,
     "runtime": 165,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "An Indian Muslim man with Asperger's syndrome takes a challenge to speak to the President of the United States seriously and embarks on a cross-country journey.",
+    "cast": [
+      "Shah Rukh Khan",
+      "Kajol",
+      "Sheetal Menon",
+      "Katie A. Keane"
+    ]
   },
   {
     "movieId": "nefes-vatan-sagolsun-2009",
@@ -3860,7 +6331,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMjE2NjEyMDg0M15BMl5BanBnXkFtZTcwODYyODg5Mg@@._V1_SX4000.jpg",
     "year": 2009,
     "runtime": 128,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "Story of 40-man Turkish task force who must defend a relay station.",
+    "cast": [
+      "Erdem Can",
+      "Mete Horozoglu",
+      "Ilker Kizmaz",
+      "Baris Bagci"
+    ]
   },
   {
     "movieId": "slumdog-millionaire-2008",
@@ -3871,7 +6349,14 @@
     "year": 2008,
     "runtime": 120,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A Mumbai teenager reflects on his life after being accused of cheating on the Indian version of \"Who Wants to be a Millionaire?\".",
+    "cast": [
+      "Loveleen Tandan",
+      "Dev Patel",
+      "Freida Pinto",
+      "Saurabh Shukla"
+    ]
   },
   {
     "movieId": "black-swan-2010",
@@ -3882,7 +6367,14 @@
     "year": 2010,
     "runtime": 108,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A committed dancer struggles to maintain her sanity after winning the lead role in a production of Tchaikovsky's \"Swan Lake\".",
+    "cast": [
+      "Natalie Portman",
+      "Mila Kunis",
+      "Vincent Cassel",
+      "Winona Ryder"
+    ]
   },
   {
     "movieId": "tropa-de-elite-2007",
@@ -3893,7 +6385,14 @@
     "year": 2007,
     "runtime": 115,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "In 1997 Rio de Janeiro, Captain Nascimento has to find a substitute for his position while trying to take down drug dealers and criminals before the Pope visits.",
+    "cast": [
+      "Wagner Moura",
+      "André Ramiro",
+      "Caio Junqueira",
+      "Milhem Cortaz"
+    ]
   },
   {
     "movieId": "the-avengers-2012",
@@ -3904,7 +6403,14 @@
     "year": 2012,
     "runtime": 143,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Earth's mightiest heroes must come together and learn to fight as a team if they are going to stop the mischievous Loki and his alien army from enslaving humanity.",
+    "cast": [
+      "Robert Downey Jr.",
+      "Chris Evans",
+      "Scarlett Johansson",
+      "Jeremy Renner"
+    ]
   },
   {
     "movieId": "persepolis-2007",
@@ -3915,7 +6421,14 @@
     "year": 2007,
     "runtime": 96,
     "imdbRating": 8.0,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A precocious and outspoken Iranian girl grows up during the Islamic Revolution.",
+    "cast": [
+      "Marjane Satrapi",
+      "Chiara Mastroianni",
+      "Catherine Deneuve",
+      "Gena Rowlands"
+    ]
   },
   {
     "movieId": "dallas-buyers-club-2013",
@@ -3926,7 +6439,14 @@
     "year": 2013,
     "runtime": 117,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "In 1985 Dallas, electrician and hustler Ron Woodroof works around the system to help AIDS patients get the medication they need after he is diagnosed with the disease.",
+    "cast": [
+      "Matthew McConaughey",
+      "Jennifer Garner",
+      "Jared Leto",
+      "Steve Zahn"
+    ]
   },
   {
     "movieId": "the-pursuit-of-happyness-2006",
@@ -3937,7 +6457,14 @@
     "year": 2006,
     "runtime": 117,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A struggling salesman takes custody of his son as he's poised to begin a life-changing professional career.",
+    "cast": [
+      "Will Smith",
+      "Thandie Newton",
+      "Jaden Smith",
+      "Brian Howe"
+    ]
   },
   {
     "movieId": "blood-diamond-2006",
@@ -3948,7 +6475,14 @@
     "year": 2006,
     "runtime": 143,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A fisherman, a smuggler, and a syndicate of businessmen match wits over the possession of a priceless diamond.",
+    "cast": [
+      "Leonardo DiCaprio",
+      "Djimon Hounsou",
+      "Jennifer Connelly",
+      "Kagiso Kuypers"
+    ]
   },
   {
     "movieId": "the-bourne-ultimatum-2007",
@@ -3959,7 +6493,14 @@
     "year": 2007,
     "runtime": 115,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Jason Bourne dodges a ruthless C.I.A. official and his Agents from a new assassination program while searching for the origins of his life as a trained killer.",
+    "cast": [
+      "Matt Damon",
+      "Edgar Ramírez",
+      "Joan Allen",
+      "Julia Stiles"
+    ]
   },
   {
     "movieId": "bin-jip-2004",
@@ -3970,7 +6511,14 @@
     "year": 2004,
     "runtime": 88,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A transient young man breaks into empty homes to partake of the vacationing residents' lives for a few days.",
+    "cast": [
+      "Seung-Yun Lee",
+      "Hee Jae",
+      "Hyuk-ho Kwon",
+      "Jin-mo Joo"
+    ]
   },
   {
     "movieId": "sin-city-2005",
@@ -3981,7 +6529,14 @@
     "year": 2005,
     "runtime": 124,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A movie that explores the dark and miserable town, Basin City, tells the story of three different people, all caught up in violent corruption.",
+    "cast": [
+      "Quentin Tarantino",
+      "Robert Rodriguez",
+      "Mickey Rourke",
+      "Clive Owen"
+    ]
   },
   {
     "movieId": "le-scaphandre-et-le-papillon-2007",
@@ -3992,7 +6547,14 @@
     "year": 2007,
     "runtime": 112,
     "imdbRating": 8.0,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "The true story of Elle editor Jean-Dominique Bauby who suffers a stroke and has to live with an almost totally paralyzed body; only his left eye isn't paralyzed.",
+    "cast": [
+      "Laura Obiols",
+      "Mathieu Amalric",
+      "Emmanuelle Seigner",
+      "Marie-Josée Croze"
+    ]
   },
   {
     "movieId": "g-o-r-a-2004",
@@ -4002,7 +6564,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMjE0MTY2MDI3NV5BMl5BanBnXkFtZTcwNTc1MzEzMQ@@._V1_SX4000.jpg",
     "year": 2004,
     "runtime": 127,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "A slick young Turk kidnapped by extraterrestrials shows his great « humanitarian spirit » by outwitting the evil commander-in-chief of the planet of G.O.R.A.",
+    "cast": [
+      "Cem Yilmaz",
+      "Özge Özberk",
+      "Ozan Güven",
+      "Safak Sezer"
+    ]
   },
   {
     "movieId": "ratatouille-2007",
@@ -4013,7 +6582,14 @@
     "year": 2007,
     "runtime": 111,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A rat who can cook makes an unusual alliance with a young kitchen worker at a famous restaurant.",
+    "cast": [
+      "Jan Pinkava",
+      "Brad Garrett",
+      "Lou Romano",
+      "Patton Oswalt"
+    ]
   },
   {
     "movieId": "casino-royale-2006",
@@ -4024,7 +6600,14 @@
     "year": 2006,
     "runtime": 144,
     "imdbRating": 8.0,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "After earning 00 status and a licence to kill, Secret Agent James Bond sets out on his first mission as 007. Bond must defeat a private banker funding terrorists in a high-stakes game of poker at Casino Royale, Montenegro.",
+    "cast": [
+      "Daniel Craig",
+      "Eva Green",
+      "Judi Dench",
+      "Jeffrey Wright"
+    ]
   },
   {
     "movieId": "kill-bill-vol-2-2004",
@@ -4035,7 +6618,14 @@
     "year": 2004,
     "runtime": 137,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The Bride continues her quest of vengeance against her former boss and lover Bill, the reclusive bouncer Budd, and the treacherous, one-eyed Elle.",
+    "cast": [
+      "Uma Thurman",
+      "David Carradine",
+      "Michael Madsen",
+      "Daryl Hannah"
+    ]
   },
   {
     "movieId": "vozvrashchenie-2003",
@@ -4045,7 +6635,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYmViZTY1OWEtMTQxMy00OGQ5LTgzZjAtYTQzOTYxNjliYTI4XkEyXkFqcGdeQXVyNjkxOTM4ODY@._V1_SX4000.jpg",
     "year": 2003,
     "runtime": 110,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "In the Russian wilderness, two brothers face a range of new, conflicting emotions when their father - a man they know only through a single photograph - resurfaces.",
+    "cast": [
+      "Vladimir Garin",
+      "Ivan Dobronravov",
+      "Konstantin Lavronenko",
+      "Nataliya Vdovina"
+    ]
   },
   {
     "movieId": "bom-yeoareum-gaeul-gyeoul-geurigo-bom-2003",
@@ -4056,7 +6653,14 @@
     "year": 2003,
     "runtime": 103,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A boy is raised by a Buddhist monk in an isolated floating temple where the years pass like the seasons.",
+    "cast": [
+      "Ki-duk Kim",
+      "Yeong-su Oh",
+      "Jong-ho Kim",
+      "Kim Young-Min"
+    ]
   },
   {
     "movieId": "mar-adentro-2014",
@@ -4067,7 +6671,14 @@
     "year": 2014,
     "runtime": 126,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The factual story of Spaniard Ramon Sampedro, who fought a thirty-year campaign in favor of euthanasia and his own right to die.",
+    "cast": [
+      "Javier Bardem",
+      "Belén Rueda",
+      "Lola Dueñas",
+      "Mabel Rivera"
+    ]
   },
   {
     "movieId": "cinderella-man-2005",
@@ -4078,7 +6689,14 @@
     "year": 2005,
     "runtime": 144,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The story of James J. Braddock, a supposedly washed-up boxer who came back to become a champion and an inspiration in the 1930s.",
+    "cast": [
+      "Russell Crowe",
+      "Renée Zellweger",
+      "Craig Bierko",
+      "Paul Giamatti"
+    ]
   },
   {
     "movieId": "kal-ho-naa-ho-2003",
@@ -4089,7 +6707,14 @@
     "year": 2003,
     "runtime": 186,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Naina, an introverted, perpetually depressed girl's life changes when she meets Aman. But Aman has a secret of his own which changes their lives forever. Embroiled in all this is Rohit, Naina's best friend who conceals his love for her.",
+    "cast": [
+      "Preity Zinta",
+      "Shah Rukh Khan",
+      "Saif Ali Khan",
+      "Jaya Bachchan"
+    ]
   },
   {
     "movieId": "mou-gaan-dou-2002",
@@ -4100,7 +6725,14 @@
     "year": 2002,
     "runtime": 101,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A story between a mole in the police department and an undercover cop. Their objectives are the same: to find out who is the mole, and who is the cop.",
+    "cast": [
+      "Alan Mak",
+      "Andy Lau",
+      "Tony Chiu-Wai Leung",
+      "Anthony Chau-Sang Wong"
+    ]
   },
   {
     "movieId": "pirates-of-the-caribbean-the-curse-of-the-black-pearl-2003",
@@ -4111,7 +6743,14 @@
     "year": 2003,
     "runtime": 143,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Blacksmith Will Turner teams up with eccentric pirate \"Captain\" Jack Sparrow to save his love, the governor's daughter, from Jack's former pirate allies, who are now undead.",
+    "cast": [
+      "Johnny Depp",
+      "Geoffrey Rush",
+      "Orlando Bloom",
+      "Keira Knightley"
+    ]
   },
   {
     "movieId": "big-fish-2003",
@@ -4122,7 +6761,14 @@
     "year": 2003,
     "runtime": 125,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A frustrated son tries to determine the fact from fiction in his dying father's life.",
+    "cast": [
+      "Ewan McGregor",
+      "Albert Finney",
+      "Billy Crudup",
+      "Jessica Lange"
+    ]
   },
   {
     "movieId": "the-incredibles-2004",
@@ -4133,7 +6779,14 @@
     "year": 2004,
     "runtime": 115,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A family of undercover superheroes, while trying to live the quiet suburban life, are forced into action to save the world.",
+    "cast": [
+      "Craig T. Nelson",
+      "Samuel L. Jackson",
+      "Holly Hunter",
+      "Jason Lee"
+    ]
   },
   {
     "movieId": "yeopgijeogin-geunyeo-2001",
@@ -4143,7 +6796,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMjM2NTYxMTE3OV5BMl5BanBnXkFtZTgwNDgwNjgwMzE@._V1_SX4000.jpg",
     "year": 2001,
     "runtime": 137,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "A young man sees a drunk, cute woman standing too close to the tracks at a metro station in Seoul and pulls her back. She ends up getting him into trouble repeatedly after that, starting on the train.",
+    "cast": [
+      "Tae-Hyun Cha",
+      "Jun Ji-Hyun",
+      "In-mun Kim",
+      "Song Wok-suk"
+    ]
   },
   {
     "movieId": "dogville-2003",
@@ -4154,7 +6814,14 @@
     "year": 2003,
     "runtime": 178,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A woman on the run from the mob is reluctantly accepted in a small Colorado community in exchange for labor, but when a search visits the town she finds out that their support has a price.",
+    "cast": [
+      "Nicole Kidman",
+      "Paul Bettany",
+      "Lauren Bacall",
+      "Harriet Andersson"
+    ]
   },
   {
     "movieId": "vizontele-2001",
@@ -4164,7 +6831,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMjA2MzM4NjkyMF5BMl5BanBnXkFtZTYwMTQ2ODc5._V1_SX4000.jpg",
     "year": 2001,
     "runtime": 110,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "Lives of residents in a small Anatolian village change when television is introduced to them",
+    "cast": [
+      "Ömer Faruk Sorak",
+      "Yilmaz Erdogan",
+      "Demet Akbag",
+      "Altan Erkekli"
+    ]
   },
   {
     "movieId": "donnie-darko-2001",
@@ -4175,7 +6849,14 @@
     "year": 2001,
     "runtime": 113,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "After narrowly escaping a bizarre accident, a troubled teenager is plagued by visions of a man in a large rabbit suit who manipulates him to commit a series of crimes.",
+    "cast": [
+      "Jake Gyllenhaal",
+      "Jena Malone",
+      "Mary McDonnell",
+      "Holmes Osborne"
+    ]
   },
   {
     "movieId": "magnolia-1999",
@@ -4186,7 +6867,14 @@
     "year": 1999,
     "runtime": 188,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "An epic mosaic of interrelated characters in search of love, forgiveness, and meaning in the San Fernando Valley.",
+    "cast": [
+      "Tom Cruise",
+      "Jason Robards",
+      "Julianne Moore",
+      "Philip Seymour Hoffman"
+    ]
   },
   {
     "movieId": "dancer-in-the-dark-2000",
@@ -4197,7 +6885,14 @@
     "year": 2000,
     "runtime": 140,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "An East European girl travels to the United States with her young son, expecting it to be like a Hollywood film.",
+    "cast": [
+      "Björk",
+      "Catherine Deneuve",
+      "David Morse",
+      "Peter Stormare"
+    ]
   },
   {
     "movieId": "the-straight-story-1999",
@@ -4208,7 +6903,14 @@
     "year": 1999,
     "runtime": 112,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "An old man makes a long journey by lawnmower to mend his relationship with an ill brother.",
+    "cast": [
+      "Richard Farnsworth",
+      "Sissy Spacek",
+      "Jane Galloway Heitz",
+      "Joseph A. Carpenter"
+    ]
   },
   {
     "movieId": "p-fekuto-bur-1997",
@@ -4219,7 +6921,14 @@
     "year": 1997,
     "runtime": 81,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A pop singer gives up her career to become an actress, but she slowly goes insane when she starts being stalked by an obsessed fan and what seems to be a ghost of her past.",
+    "cast": [
+      "Junko Iwao",
+      "Rica Matsumoto",
+      "Shinpachi Tsuji",
+      "Masaaki Ôkura"
+    ]
   },
   {
     "movieId": "festen-1998",
@@ -4230,7 +6939,14 @@
     "year": 1998,
     "runtime": 105,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "At Helge's 60th birthday party, some unpleasant family truths are revealed.",
+    "cast": [
+      "Ulrich Thomsen",
+      "Henning Moritzen",
+      "Thomas Bo Larsen",
+      "Paprika Steen"
+    ]
   },
   {
     "movieId": "central-do-brasil-1998",
@@ -4241,7 +6957,14 @@
     "year": 1998,
     "runtime": 110,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "An emotive journey of a former school teacher, who writes letters for illiterate people, and a young boy, whose mother has just died, as they search for the father he never knew.",
+    "cast": [
+      "Fernanda Montenegro",
+      "Vinícius de Oliveira",
+      "Marília Pêra",
+      "Soia Lira"
+    ]
   },
   {
     "movieId": "the-iron-giant-1999",
@@ -4252,7 +6975,14 @@
     "year": 1999,
     "runtime": 86,
     "imdbRating": 8.0,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "A young boy befriends a giant robot from outer space that a paranoid government agent wants to destroy.",
+    "cast": [
+      "Eli Marienthal",
+      "Harry Connick Jr.",
+      "Jennifer Aniston",
+      "Vin Diesel"
+    ]
   },
   {
     "movieId": "knockin-on-heaven-s-door-1997",
@@ -4262,7 +6992,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTk2MjcxNjMzN15BMl5BanBnXkFtZTgwMTE3OTEwNjE@._V1_SX4000.jpg",
     "year": 1997,
     "runtime": 87,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "Two terminally ill patients escape from a hospital, steal a car and rush towards the sea.",
+    "cast": [
+      "Til Schweiger",
+      "Jan Josef Liefers",
+      "Thierry van Werveke",
+      "Moritz Bleibtreu"
+    ]
   },
   {
     "movieId": "sling-blade-1996",
@@ -4273,7 +7010,14 @@
     "year": 1996,
     "runtime": 135,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Karl Childers, a simple man hospitalized since his childhood murder of his mother and her lover, is released to start a new life in a small town.",
+    "cast": [
+      "Billy Bob Thornton",
+      "Dwight Yoakam",
+      "J.T. Walsh",
+      "John Ritter"
+    ]
   },
   {
     "movieId": "secrets-lies-1996",
@@ -4284,7 +7028,14 @@
     "year": 1996,
     "runtime": 136,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Following the death of her adoptive parents, a successful young black optometrist establishes contact with her biological mother -- a lonely white factory worker living in poverty in East London.",
+    "cast": [
+      "Timothy Spall",
+      "Brenda Blethyn",
+      "Phyllis Logan",
+      "Claire Rushbrook"
+    ]
   },
   {
     "movieId": "twelve-monkeys-1995",
@@ -4295,7 +7046,14 @@
     "year": 1995,
     "runtime": 129,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In a future world devastated by disease, a convict is sent back in time to gather information about the man-made virus that wiped out most of the human population on the planet.",
+    "cast": [
+      "Bruce Willis",
+      "Madeleine Stowe",
+      "Brad Pitt",
+      "Joseph Melito"
+    ]
   },
   {
     "movieId": "k-kaku-kid-tai-1995",
@@ -4306,7 +7064,14 @@
     "year": 1995,
     "runtime": 83,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A cyborg policewoman and her partner hunt a mysterious and powerful hacker called the Puppet Master.",
+    "cast": [
+      "Atsuko Tanaka",
+      "Iemasa Kayumi",
+      "Akio Ôtsuka",
+      "Kôichi Yamadera"
+    ]
   },
   {
     "movieId": "the-nightmare-before-christmas-1993",
@@ -4317,7 +7082,14 @@
     "year": 1993,
     "runtime": 76,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Jack Skellington, king of Halloween Town, discovers Christmas Town, but his attempts to bring Christmas to his home causes confusion.",
+    "cast": [
+      "Danny Elfman",
+      "Chris Sarandon",
+      "Catherine O'Hara",
+      "William Hickey"
+    ]
   },
   {
     "movieId": "groundhog-day-1993",
@@ -4328,7 +7100,14 @@
     "year": 1993,
     "runtime": 101,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A weatherman finds himself inexplicably living the same day over and over again.",
+    "cast": [
+      "Bill Murray",
+      "Andie MacDowell",
+      "Chris Elliott",
+      "Stephen Tobolowsky"
+    ]
   },
   {
     "movieId": "bound-by-honor-1993",
@@ -4339,7 +7118,14 @@
     "year": 1993,
     "runtime": 180,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Based on the true life experiences of poet Jimmy Santiago Baca, the film focuses on step-brothers Paco and Cruz, and their bi-racial cousin Miklo.",
+    "cast": [
+      "Damian Chapa",
+      "Jesse Borrego",
+      "Benjamin Bratt",
+      "Enrique Castillo"
+    ]
   },
   {
     "movieId": "scent-of-a-woman-1992",
@@ -4350,7 +7136,14 @@
     "year": 1992,
     "runtime": 156,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A prep school student needing money agrees to \"babysit\" a blind man, but the job is not at all what he anticipated.",
+    "cast": [
+      "Al Pacino",
+      "Chris O'Donnell",
+      "James Rebhorn",
+      "Gabrielle Anwar"
+    ]
   },
   {
     "movieId": "aladdin-1992",
@@ -4361,7 +7154,14 @@
     "year": 1992,
     "runtime": 90,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A kindhearted street urchin and a power-hungry Grand Vizier vie for a magic lamp that has the power to make their deepest wishes come true.",
+    "cast": [
+      "John Musker",
+      "Scott Weinger",
+      "Robin Williams",
+      "Linda Larkin"
+    ]
   },
   {
     "movieId": "jfk-1991",
@@ -4372,7 +7172,14 @@
     "year": 1991,
     "runtime": 189,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "New Orleans District Attorney Jim Garrison discovers there's more to the Kennedy assassination than the official story.",
+    "cast": [
+      "Kevin Costner",
+      "Gary Oldman",
+      "Jack Lemmon",
+      "Walter Matthau"
+    ]
   },
   {
     "movieId": "beauty-and-the-beast-1991",
@@ -4383,7 +7190,14 @@
     "year": 1991,
     "runtime": 84,
     "imdbRating": 8.0,
-    "rated": "G"
+    "rated": "G",
+    "synopsis": "A prince cursed to spend his days as a hideous monster sets out to regain his humanity by earning a young woman's love.",
+    "cast": [
+      "Kirk Wise",
+      "Paige O'Hara",
+      "Robby Benson",
+      "Jesse Corti"
+    ]
   },
   {
     "movieId": "dances-with-wolves-1990",
@@ -4394,7 +7208,14 @@
     "year": 1990,
     "runtime": 181,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Lieutenant John Dunbar, assigned to a remote western Civil War outpost, befriends wolves and Indians, making him an intolerable aberration in the military.",
+    "cast": [
+      "Kevin Costner",
+      "Mary McDonnell",
+      "Graham Greene",
+      "Rodney A. Grant"
+    ]
   },
   {
     "movieId": "do-the-right-thing-1989",
@@ -4405,7 +7226,14 @@
     "year": 1989,
     "runtime": 120,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "On the hottest day of the year on a street in the Bedford-Stuyvesant section of Brooklyn, everyone's hate and bigotry smolders and builds until it explodes into violence.",
+    "cast": [
+      "Danny Aiello",
+      "Ossie Davis",
+      "Ruby Dee",
+      "Richard Edson"
+    ]
   },
   {
     "movieId": "rain-man-1988",
@@ -4416,7 +7244,14 @@
     "year": 1988,
     "runtime": 133,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Selfish yuppie Charlie Babbitt's father left a fortune to his savant brother Raymond and a pittance to Charlie; they travel cross-country.",
+    "cast": [
+      "Dustin Hoffman",
+      "Tom Cruise",
+      "Valeria Golino",
+      "Gerald R. Molen"
+    ]
   },
   {
     "movieId": "akira-1988",
@@ -4427,7 +7262,14 @@
     "year": 1988,
     "runtime": 124,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A secret military project endangers Neo-Tokyo when it turns a biker gang member into a rampaging psychic psychopath who can only be stopped by two teenagers and a group of psychics.",
+    "cast": [
+      "Mitsuo Iwata",
+      "Nozomu Sasaki",
+      "Mami Koyama",
+      "Tesshô Genda"
+    ]
   },
   {
     "movieId": "the-princess-bride-1987",
@@ -4438,7 +7280,14 @@
     "year": 1987,
     "runtime": 98,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "While home sick in bed, a young boy's grandfather reads him the story of a farmboy-turned-pirate who encounters numerous obstacles, enemies and allies in his quest to be reunited with his true love.",
+    "cast": [
+      "Cary Elwes",
+      "Mandy Patinkin",
+      "Robin Wright",
+      "Chris Sarandon"
+    ]
   },
   {
     "movieId": "der-himmel-ber-berlin-1987",
@@ -4449,7 +7298,14 @@
     "year": 1987,
     "runtime": 128,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "An angel tires of overseeing human activity and wishes to become human when he falls in love with a mortal.",
+    "cast": [
+      "Bruno Ganz",
+      "Solveig Dommartin",
+      "Otto Sander",
+      "Curt Bois"
+    ]
   },
   {
     "movieId": "au-revoir-les-enfants-1987",
@@ -4460,7 +7316,14 @@
     "year": 1987,
     "runtime": 104,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A French boarding school run by priests seems to be a haven from World War II until a new student arrives. He becomes the roommate of the top student in his class. Rivals at first, the roommates form a bond and share a secret.",
+    "cast": [
+      "Gaspard Manesse",
+      "Raphael Fejtö",
+      "Francine Racette",
+      "Stanislas Carré de Malberg"
+    ]
   },
   {
     "movieId": "tenk-no-shiro-rapyuta-1986",
@@ -4471,7 +7334,14 @@
     "year": 1986,
     "runtime": 125,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A young boy and a girl with a magic crystal must race against pirates and foreign agents in a search for a legendary floating castle.",
+    "cast": [
+      "Mayumi Tanaka",
+      "Keiko Yokozawa",
+      "Kotoe Hatsui",
+      "Minori Terada"
+    ]
   },
   {
     "movieId": "the-terminator-1984",
@@ -4482,7 +7352,14 @@
     "year": 1984,
     "runtime": 107,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A human soldier is sent from 2029 to 1984 to stop an almost indestructible cyborg killing machine, sent from the same year, which has been programmed to execute a young woman whose unborn son is the key to humanity's future salvation.",
+    "cast": [
+      "Arnold Schwarzenegger",
+      "Linda Hamilton",
+      "Michael Biehn",
+      "Paul Winfield"
+    ]
   },
   {
     "movieId": "gandhi-1982",
@@ -4493,7 +7370,14 @@
     "year": 1982,
     "runtime": 191,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The life of the lawyer who became the famed leader of the Indian revolts against the British rule through his philosophy of nonviolent protest.",
+    "cast": [
+      "Ben Kingsley",
+      "John Gielgud",
+      "Rohini Hattangadi",
+      "Roshan Seth"
+    ]
   },
   {
     "movieId": "kagemusha-1980",
@@ -4504,7 +7388,14 @@
     "year": 1980,
     "runtime": 180,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A petty thief with an utter resemblance to a samurai warlord is hired as the lord's double. When the warlord later dies the thief is forced to take up arms in his place.",
+    "cast": [
+      "Tatsuya Nakadai",
+      "Tsutomu Yamazaki",
+      "Ken'ichi Hagiwara",
+      "Jinpachi Nezu"
+    ]
   },
   {
     "movieId": "being-there-1979",
@@ -4515,7 +7406,14 @@
     "year": 1979,
     "runtime": 130,
     "imdbRating": 8.0,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "A simpleminded, sheltered gardener becomes an unlikely trusted advisor to a powerful businessman and an insider in Washington politics.",
+    "cast": [
+      "Peter Sellers",
+      "Shirley MacLaine",
+      "Melvyn Douglas",
+      "Jack Warden"
+    ]
   },
   {
     "movieId": "annie-hall-1977",
@@ -4526,7 +7424,14 @@
     "year": 1977,
     "runtime": 93,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Neurotic New York comedian Alvy Singer falls in love with the ditzy Annie Hall.",
+    "cast": [
+      "Woody Allen",
+      "Diane Keaton",
+      "Tony Roberts",
+      "Carol Kane"
+    ]
   },
   {
     "movieId": "jaws-1975",
@@ -4537,7 +7442,14 @@
     "year": 1975,
     "runtime": 124,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "When a killer shark unleashes chaos on a beach community, it's up to a local sheriff, a marine biologist, and an old seafarer to hunt the beast down.",
+    "cast": [
+      "Roy Scheider",
+      "Robert Shaw",
+      "Richard Dreyfuss",
+      "Lorraine Gary"
+    ]
   },
   {
     "movieId": "dog-day-afternoon-1975",
@@ -4548,7 +7460,14 @@
     "year": 1975,
     "runtime": 125,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Three amateur bank robbers plan to hold up a bank. A nice simple robbery: Walk in, take the money, and run. Unfortunately, the supposedly uncomplicated heist suddenly becomes a bizarre nightmare as everything that could go wrong does.",
+    "cast": [
+      "Al Pacino",
+      "John Cazale",
+      "Penelope Allen",
+      "Sully Boyar"
+    ]
   },
   {
     "movieId": "young-frankenstein-1974",
@@ -4559,7 +7478,14 @@
     "year": 1974,
     "runtime": 106,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An American grandson of the infamous scientist, struggling to prove that his grandfather was not as insane as people believe, is invited to Transylvania, where he discovers the process that reanimates a dead body.",
+    "cast": [
+      "Gene Wilder",
+      "Madeline Kahn",
+      "Marty Feldman",
+      "Peter Boyle"
+    ]
   },
   {
     "movieId": "papillon-1973",
@@ -4570,7 +7496,14 @@
     "year": 1973,
     "runtime": 151,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A man befriends a fellow criminal as the two of them begin serving their sentence on a dreadful prison island, which inspires the man to plot his escape.",
+    "cast": [
+      "Steve McQueen",
+      "Dustin Hoffman",
+      "Victor Jory",
+      "Don Gordon"
+    ]
   },
   {
     "movieId": "the-exorcist-1973",
@@ -4581,7 +7514,14 @@
     "year": 1973,
     "runtime": 122,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "When a 12-year-old girl is possessed by a mysterious entity, her mother seeks the help of two priests to save her.",
+    "cast": [
+      "Ellen Burstyn",
+      "Max von Sydow",
+      "Linda Blair",
+      "Lee J. Cobb"
+    ]
   },
   {
     "movieId": "sleuth-1972",
@@ -4592,7 +7532,14 @@
     "year": 1972,
     "runtime": 138,
     "imdbRating": 8.0,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "A man who loves games and theater invites his wife's lover to meet him, setting up a battle of wits with potentially deadly results.",
+    "cast": [
+      "Laurence Olivier",
+      "Michael Caine",
+      "Alec Cawthorne",
+      "John Matthews"
+    ]
   },
   {
     "movieId": "the-last-picture-show-1971",
@@ -4603,7 +7550,14 @@
     "year": 1971,
     "runtime": 118,
     "imdbRating": 8.0,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "In 1951, a group of high schoolers come of age in a bleak, isolated, atrophied North Texas town that is slowly dying, both culturally and economically.",
+    "cast": [
+      "Timothy Bottoms",
+      "Jeff Bridges",
+      "Cybill Shepherd",
+      "Ben Johnson"
+    ]
   },
   {
     "movieId": "fiddler-on-the-roof-1971",
@@ -4614,7 +7568,14 @@
     "year": 1971,
     "runtime": 181,
     "imdbRating": 8.0,
-    "rated": "G"
+    "rated": "G",
+    "synopsis": "In prerevolutionary Russia, a Jewish peasant contends with marrying off three of his daughters while growing anti-Semitic sentiment threatens his village.",
+    "cast": [
+      "Topol",
+      "Norma Crane",
+      "Leonard Frey",
+      "Molly Picon"
+    ]
   },
   {
     "movieId": "il-conformista-1970",
@@ -4625,7 +7586,14 @@
     "year": 1970,
     "runtime": 113,
     "imdbRating": 8.0,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A weak-willed Italian man becomes a fascist flunky who goes abroad to arrange the assassination of his old teacher, now a political dissident.",
+    "cast": [
+      "Jean-Louis Trintignant",
+      "Stefania Sandrelli",
+      "Gastone Moschin",
+      "Enzo Tarascio"
+    ]
   },
   {
     "movieId": "butch-cassidy-and-the-sundance-kid-1969",
@@ -4636,7 +7604,14 @@
     "year": 1969,
     "runtime": 110,
     "imdbRating": 8.0,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "Wyoming, early 1900s. Butch Cassidy and The Sundance Kid are the leaders of a band of outlaws. After a train robbery goes wrong they find themselves on the run with a posse hard on their heels. Their solution - escape to Bolivia.",
+    "cast": [
+      "Paul Newman",
+      "Robert Redford",
+      "Katharine Ross",
+      "Strother Martin"
+    ]
   },
   {
     "movieId": "rosemary-s-baby-1968",
@@ -4647,7 +7622,14 @@
     "year": 1968,
     "runtime": 137,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A young couple trying for a baby move into a fancy apartment surrounded by peculiar neighbors.",
+    "cast": [
+      "Mia Farrow",
+      "John Cassavetes",
+      "Ruth Gordon",
+      "Sidney Blackmer"
+    ]
   },
   {
     "movieId": "planet-of-the-apes-1968",
@@ -4658,7 +7640,14 @@
     "year": 1968,
     "runtime": 112,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "An astronaut crew crash-lands on a planet in the distant future where intelligent talking apes are the dominant species, and humans are the oppressed and enslaved.",
+    "cast": [
+      "Charlton Heston",
+      "Roddy McDowall",
+      "Kim Hunter",
+      "Maurice Evans"
+    ]
   },
   {
     "movieId": "the-graduate-1967",
@@ -4669,7 +7658,14 @@
     "year": 1967,
     "runtime": 106,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A disillusioned college graduate finds himself torn between his older lover and her daughter.",
+    "cast": [
+      "Dustin Hoffman",
+      "Anne Bancroft",
+      "Katharine Ross",
+      "William Daniels"
+    ]
   },
   {
     "movieId": "who-s-afraid-of-virginia-woolf-1966",
@@ -4680,7 +7676,14 @@
     "year": 1966,
     "runtime": 131,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A bitter, aging couple, with the help of alcohol, use their young houseguests to fuel anguish and emotional pain towards each other over the course of a distressing night.",
+    "cast": [
+      "Elizabeth Taylor",
+      "Richard Burton",
+      "George Segal",
+      "Sandy Dennis"
+    ]
   },
   {
     "movieId": "the-sound-of-music-1965",
@@ -4691,7 +7694,14 @@
     "year": 1965,
     "runtime": 172,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A woman leaves an Austrian convent to become a governess to the children of a Naval officer widower.",
+    "cast": [
+      "Julie Andrews",
+      "Christopher Plummer",
+      "Eleanor Parker",
+      "Richard Haydn"
+    ]
   },
   {
     "movieId": "doctor-zhivago-1965",
@@ -4702,7 +7712,14 @@
     "year": 1965,
     "runtime": 197,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The life of a Russian physician and poet who, although married to another, falls in love with a political activist's wife and experiences hardship during World War I and then the October Revolution.",
+    "cast": [
+      "Omar Sharif",
+      "Julie Christie",
+      "Geraldine Chaplin",
+      "Rod Steiger"
+    ]
   },
   {
     "movieId": "per-un-pugno-di-dollari-1964",
@@ -4713,7 +7730,14 @@
     "year": 1964,
     "runtime": 99,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A wandering gunfighter plays two rival families against each other in a town torn apart by greed, pride, and revenge.",
+    "cast": [
+      "Clint Eastwood",
+      "Gian Maria Volontè",
+      "Marianne Koch",
+      "Wolfgang Lukschy"
+    ]
   },
   {
     "movieId": "8-1963",
@@ -4723,7 +7747,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTQ4MTA0NjEzMF5BMl5BanBnXkFtZTgwMDg4NDYxMzE@._V1_SX4000.jpg",
     "year": 1963,
     "runtime": 138,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "A harried movie director retreats into his memories and fantasies.",
+    "cast": [
+      "Marcello Mastroianni",
+      "Anouk Aimée",
+      "Claudia Cardinale",
+      "Sandra Milo"
+    ]
   },
   {
     "movieId": "vivre-sa-vie-film-en-douze-tableaux-1962",
@@ -4733,7 +7764,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNjMyZmI5NmItY2JlMi00NzU3LWI5ZGItZjhkOTE0YjEyN2Q4XkEyXkFqcGdeQXVyNDkzNTM2ODg@._V1_SX4000.jpg",
     "year": 1962,
     "runtime": 80,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "Twelve episodic tales in the life of a Parisian woman and her slow descent into prostitution.",
+    "cast": [
+      "Anna Karina",
+      "Sady Rebbot",
+      "André S. Labarthe",
+      "Guylaine Schlumberger"
+    ]
   },
   {
     "movieId": "the-hustler-1961",
@@ -4744,7 +7782,14 @@
     "year": 1961,
     "runtime": 134,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An up-and-coming pool player plays a long-time champion in a single high-stakes match.",
+    "cast": [
+      "Paul Newman",
+      "Jackie Gleason",
+      "Piper Laurie",
+      "George C. Scott"
+    ]
   },
   {
     "movieId": "la-dolce-vita-1960",
@@ -4755,7 +7800,14 @@
     "year": 1960,
     "runtime": 174,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A series of stories following a week in the life of a philandering paparazzo journalist living in Rome.",
+    "cast": [
+      "Marcello Mastroianni",
+      "Anita Ekberg",
+      "Anouk Aimée",
+      "Yvonne Furneaux"
+    ]
   },
   {
     "movieId": "rio-bravo-1959",
@@ -4766,7 +7818,14 @@
     "year": 1959,
     "runtime": 141,
     "imdbRating": 8.0,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A small-town sheriff in the American West enlists the help of a cripple, a drunk, and a young gunfighter in his efforts to hold in jail the brother of the local bad guy.",
+    "cast": [
+      "John Wayne",
+      "Dean Martin",
+      "Ricky Nelson",
+      "Angie Dickinson"
+    ]
   },
   {
     "movieId": "anatomy-of-a-murder-1959",
@@ -4776,7 +7835,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMzM0MzE2ZTAtZTBjZS00MTk5LTg5OTEtNjNmYmQ5NzU2OTUyXkEyXkFqcGdeQXVyNDY2MTk1ODk@._V1_SX4000.jpg",
     "year": 1959,
     "runtime": 161,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "In a murder trial, the defendant says he suffered temporary insanity after the victim raped his wife. What is the truth, and will he win his case?",
+    "cast": [
+      "James Stewart",
+      "Lee Remick",
+      "Ben Gazzara",
+      "Arthur O'Connell"
+    ]
   },
   {
     "movieId": "touch-of-evil-1958",
@@ -4787,7 +7853,14 @@
     "year": 1958,
     "runtime": 95,
     "imdbRating": 8.0,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A stark, perverse story of murder, kidnapping, and police corruption in a Mexican border town.",
+    "cast": [
+      "Charlton Heston",
+      "Orson Welles",
+      "Janet Leigh",
+      "Joseph Calleia"
+    ]
   },
   {
     "movieId": "cat-on-a-hot-tin-roof-1958",
@@ -4798,7 +7871,14 @@
     "year": 1958,
     "runtime": 108,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Brick is an alcoholic ex-football player who drinks his days away and resists the affections of his wife. A reunion with his terminal father jogs a host of memories and revelations for both father and son.",
+    "cast": [
+      "Elizabeth Taylor",
+      "Paul Newman",
+      "Burl Ives",
+      "Jack Carson"
+    ]
   },
   {
     "movieId": "sweet-smell-of-success-1957",
@@ -4809,7 +7889,14 @@
     "year": 1957,
     "runtime": 96,
     "imdbRating": 8.0,
-    "rated": "Approved"
+    "rated": "Approved",
+    "synopsis": "Powerful but unethical Broadway columnist J.J. Hunsecker coerces unscrupulous press agent Sidney Falco into breaking up his sister's romance with a jazz musician.",
+    "cast": [
+      "Burt Lancaster",
+      "Tony Curtis",
+      "Susan Harrison",
+      "Martin Milner"
+    ]
   },
   {
     "movieId": "the-killing-1956",
@@ -4820,7 +7907,14 @@
     "year": 1956,
     "runtime": 84,
     "imdbRating": 8.0,
-    "rated": "Approved"
+    "rated": "Approved",
+    "synopsis": "Crook Johnny Clay assembles a five man team to plan and execute a daring race-track robbery.",
+    "cast": [
+      "Sterling Hayden",
+      "Coleen Gray",
+      "Vince Edwards",
+      "Jay C. Flippen"
+    ]
   },
   {
     "movieId": "the-night-of-the-hunter-1955",
@@ -4830,7 +7924,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYTNjN2M2MzYtZGEwMi00Mzc5LWEwYTMtODM1ZmRiZjFiNTU0L2ltYWdlL2ltYWdlXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_SX4000.jpg",
     "year": 1955,
     "runtime": 92,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "A religious fanatic marries a gullible widow whose young children are reluctant to tell him where their real daddy hid the $10,000 he'd stolen in a robbery.",
+    "cast": [
+      "Robert Mitchum",
+      "Shelley Winters",
+      "Lillian Gish",
+      "James Gleason"
+    ]
   },
   {
     "movieId": "la-strada-1954",
@@ -4840,7 +7941,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYjUyOGMyMTQtYTM5Yy00MjFiLTk2OGItMWYwMDc2YmM1YzhiXkEyXkFqcGdeQXVyMjA0MzYwMDY@._V1_SX4000.jpg",
     "year": 1954,
     "runtime": 108,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "A care-free girl is sold to a traveling entertainer, consequently enduring physical and emotional pain along the way.",
+    "cast": [
+      "Anthony Quinn",
+      "Giulietta Masina",
+      "Richard Basehart",
+      "Aldo Silvani"
+    ]
   },
   {
     "movieId": "les-diaboliques-1955",
@@ -4850,7 +7958,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMGJmNmU5OTAtOTQyYy00MmM3LTk4MzUtMGFiZDYzODdmMmU4XkEyXkFqcGdeQXVyNjU0OTQ0OTY@._V1_SX4000.jpg",
     "year": 1955,
     "runtime": 117,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "The wife and mistress of a loathed school principal plan to murder him with what they believe is the perfect alibi.",
+    "cast": [
+      "Simone Signoret",
+      "Véra Clouzot",
+      "Paul Meurisse",
+      "Charles Vanel"
+    ]
   },
   {
     "movieId": "stalag-17-1953",
@@ -4860,7 +7975,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNDMyNGU0NjUtNTIxMC00ZmU2LWE0ZGItZTdkNGVlODI2ZDcyL2ltYWdlXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_SX4000.jpg",
     "year": 1953,
     "runtime": 120,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "When two escaping American World War II prisoners are killed, the German P.O.W. camp barracks black marketeer, J.J. Sefton, is suspected of being an informer.",
+    "cast": [
+      "William Holden",
+      "Don Taylor",
+      "Otto Preminger",
+      "Robert Strauss"
+    ]
   },
   {
     "movieId": "roman-holiday-1953",
@@ -4870,7 +7992,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTE2MDM4MTMtZmNkZC00Y2QyLWE0YjUtMTAxZGJmODMxMDM0XkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_SX4000.jpg",
     "year": 1953,
     "runtime": 118,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "A bored and sheltered princess escapes her guardians and falls in love with an American newsman in Rome.",
+    "cast": [
+      "Gregory Peck",
+      "Audrey Hepburn",
+      "Eddie Albert",
+      "Hartley Power"
+    ]
   },
   {
     "movieId": "a-streetcar-named-desire-1951",
@@ -4881,7 +8010,14 @@
     "year": 1951,
     "runtime": 122,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Disturbed Blanche DuBois moves in with her sister in New Orleans and is tormented by her brutish brother-in-law while her reality crumbles around her.",
+    "cast": [
+      "Vivien Leigh",
+      "Marlon Brando",
+      "Kim Hunter",
+      "Karl Malden"
+    ]
   },
   {
     "movieId": "in-a-lonely-place-1950",
@@ -4891,7 +8027,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNjRmZjcwZTQtYWY0ZS00ODAwLTg4YTktZDhlZDMwMTM1MGFkXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_SX4000.jpg",
     "year": 1950,
     "runtime": 94,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "A potentially violent screenwriter is a murder suspect until his lovely neighbor clears him. However, she soon starts to have her doubts.",
+    "cast": [
+      "Humphrey Bogart",
+      "Gloria Grahame",
+      "Frank Lovejoy",
+      "Carl Benton Reid"
+    ]
   },
   {
     "movieId": "kind-hearts-and-coronets-1949",
@@ -4902,7 +8045,14 @@
     "year": 1949,
     "runtime": 106,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A distant poor relative of the Duke D'Ascoyne plots to inherit the title by murdering the eight other heirs who stand ahead of him in the line of succession.",
+    "cast": [
+      "Dennis Price",
+      "Alec Guinness",
+      "Valerie Hobson",
+      "Joan Greenwood"
+    ]
   },
   {
     "movieId": "rope-1948",
@@ -4913,7 +8063,14 @@
     "year": 1948,
     "runtime": 80,
     "imdbRating": 8.0,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Two men attempt to prove they committed the perfect crime by hosting a dinner party after strangling their former classmate to death.",
+    "cast": [
+      "James Stewart",
+      "John Dall",
+      "Farley Granger",
+      "Dick Hogan"
+    ]
   },
   {
     "movieId": "out-of-the-past-1947",
@@ -4923,7 +8080,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMDE0MjYxYmMtM2VhMC00MjhiLTg5NjItMDkzZGM5MGVlYjMxL2ltYWdlL2ltYWdlXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_SX4000.jpg",
     "year": 1947,
     "runtime": 97,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "A private eye escapes his past to run a gas station in a small town, but his past catches up with him. Now he must return to the big city world of danger, corruption, double crosses and duplicitous dames.",
+    "cast": [
+      "Robert Mitchum",
+      "Jane Greer",
+      "Kirk Douglas",
+      "Rhonda Fleming"
+    ]
   },
   {
     "movieId": "brief-encounter-1945",
@@ -4934,7 +8098,14 @@
     "year": 1945,
     "runtime": 86,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Meeting a stranger in a railway station, a woman is tempted to cheat on her husband.",
+    "cast": [
+      "Celia Johnson",
+      "Trevor Howard",
+      "Stanley Holloway",
+      "Joyce Carey"
+    ]
   },
   {
     "movieId": "laura-1944",
@@ -4945,7 +8116,14 @@
     "year": 1944,
     "runtime": 88,
     "imdbRating": 8.0,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A police detective falls in love with the woman whose murder he is investigating.",
+    "cast": [
+      "Gene Tierney",
+      "Dana Andrews",
+      "Clifton Webb",
+      "Vincent Price"
+    ]
   },
   {
     "movieId": "the-best-years-of-our-lives-1946",
@@ -4956,7 +8134,14 @@
     "year": 1946,
     "runtime": 170,
     "imdbRating": 8.0,
-    "rated": "Approved"
+    "rated": "Approved",
+    "synopsis": "Three World War II veterans return home to small-town America to discover that they and their families have been irreparably changed.",
+    "cast": [
+      "Myrna Loy",
+      "Dana Andrews",
+      "Fredric March",
+      "Teresa Wright"
+    ]
   },
   {
     "movieId": "arsenic-and-old-lace-1942",
@@ -4966,7 +8151,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BZDVlNTBjMjctNjAzNS00ZGJhLTg2NzMtNzIwYTIzYTBiMDkyXkEyXkFqcGdeQXVyNTA4NzY1MzY@._V1_SX4000.jpg",
     "year": 1942,
     "runtime": 118,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "A writer of books on the futility of marriage risks his reputation when he decides to get married. Things get even more complicated when he learns on his wedding day that his beloved maiden aunts are habitual murderers.",
+    "cast": [
+      "Cary Grant",
+      "Priscilla Lane",
+      "Raymond Massey",
+      "Jack Carson"
+    ]
   },
   {
     "movieId": "the-maltese-falcon-1941",
@@ -4976,7 +8168,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BZjIwNGM1ZTUtOThjYS00NDdiLTk2ZDYtNGY5YjJkNzliM2JjL2ltYWdlL2ltYWdlXkEyXkFqcGdeQXVyMDI2NDg0NQ@@._V1_SX4000.jpg",
     "year": 1941,
     "runtime": 100,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "A private detective takes on a case that involves him with three eccentric criminals, a gorgeous liar, and their quest for a priceless statuette.",
+    "cast": [
+      "Humphrey Bogart",
+      "Mary Astor",
+      "Gladys George",
+      "Peter Lorre"
+    ]
   },
   {
     "movieId": "the-grapes-of-wrath-1940",
@@ -4987,7 +8186,14 @@
     "year": 1940,
     "runtime": 129,
     "imdbRating": 8.0,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A poor Midwest family is forced off their land. They travel to California, suffering the misfortunes of the homeless in the Great Depression.",
+    "cast": [
+      "Henry Fonda",
+      "Jane Darwell",
+      "John Carradine",
+      "Charley Grapewin"
+    ]
   },
   {
     "movieId": "the-wizard-of-oz-1939",
@@ -4998,7 +8204,14 @@
     "year": 1939,
     "runtime": 102,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Dorothy Gale is swept away from a farm in Kansas to a magical land of Oz in a tornado and embarks on a quest with her new friends to see the Wizard who can help her return home to Kansas and help her friends as well.",
+    "cast": [
+      "George Cukor",
+      "Mervyn LeRoy",
+      "Norman Taurog",
+      "Richard Thorpe"
+    ]
   },
   {
     "movieId": "la-r-gle-du-jeu-1939",
@@ -5008,7 +8221,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYTE4NjYxMGEtZmQxZi00YWVmLWJjZTctYTJmNDFmZGEwNDVhXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_SX4000.jpg",
     "year": 1939,
     "runtime": 110,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "A bourgeois life in France at the onset of World War II, as the rich and their poor servants meet up at a French chateau.",
+    "cast": [
+      "Marcel Dalio",
+      "Nora Gregor",
+      "Paulette Dubost",
+      "Mila Parély"
+    ]
   },
   {
     "movieId": "the-thin-man-1934",
@@ -5019,7 +8239,14 @@
     "year": 1934,
     "runtime": 91,
     "imdbRating": 8.0,
-    "rated": "TV-PG"
+    "rated": "TV-PG",
+    "synopsis": "Former detective Nick Charles and his wealthy wife Nora investigate a murder case, mostly for the fun of it.",
+    "cast": [
+      "William Powell",
+      "Myrna Loy",
+      "Maureen O'Sullivan",
+      "Nat Pendleton"
+    ]
   },
   {
     "movieId": "all-quiet-on-the-western-front-1930",
@@ -5030,7 +8257,14 @@
     "year": 1930,
     "runtime": 152,
     "imdbRating": 8.0,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A German youth eagerly enters World War I, but his enthusiasm wanes as he gets a firsthand view of the horror.",
+    "cast": [
+      "Lew Ayres",
+      "Louis Wolheim",
+      "John Wray",
+      "Arnold Lucy"
+    ]
   },
   {
     "movieId": "bronenosets-potemkin-1925",
@@ -5040,7 +8274,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTEyMTQzMjQ0MTJeQTJeQWpwZ15BbWU4MDcyMjg4OTEx._V1_SX4000.jpg",
     "year": 1925,
     "runtime": 75,
-    "imdbRating": 8.0
+    "imdbRating": 8.0,
+    "synopsis": "In the midst of the Russian Revolution of 1905, the crew of the battleship Potemkin mutiny against the brutal, tyrannical regime of the vessel's officers. The resulting street demonstration in Odessa brings on a police massacre.",
+    "cast": [
+      "Aleksandr Antonov",
+      "Vladimir Barskiy",
+      "Grigoriy Aleksandrov",
+      "Ivan Bobrov"
+    ]
   },
   {
     "movieId": "knives-out-2019",
@@ -5051,7 +8292,14 @@
     "year": 2019,
     "runtime": 130,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A detective investigates the death of a patriarch of an eccentric, combative family.",
+    "cast": [
+      "Daniel Craig",
+      "Chris Evans",
+      "Ana de Armas",
+      "Jamie Lee Curtis"
+    ]
   },
   {
     "movieId": "dil-bechara-2020",
@@ -5062,7 +8310,14 @@
     "year": 2020,
     "runtime": 101,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The emotional journey of two hopelessly in love youngsters, a young girl, Kizie, suffering from cancer, and a boy, Manny, whom she meets at a support group.",
+    "cast": [
+      "Sushant Singh Rajput",
+      "Sanjana Sanghi",
+      "Sahil Vaid",
+      "Saswata Chatterjee"
+    ]
   },
   {
     "movieId": "manbiki-kazoku-2018",
@@ -5073,7 +8328,14 @@
     "year": 2018,
     "runtime": 121,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A family of small-time crooks take in a child they find outside in the cold.",
+    "cast": [
+      "Lily Franky",
+      "Sakura Andô",
+      "Kirin Kiki",
+      "Mayu Matsuoka"
+    ]
   },
   {
     "movieId": "marriage-story-2019",
@@ -5084,7 +8346,14 @@
     "year": 2019,
     "runtime": 137,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Noah Baumbach's incisive and compassionate look at a marriage breaking up and a family staying together.",
+    "cast": [
+      "Adam Driver",
+      "Scarlett Johansson",
+      "Julia Greer",
+      "Azhy Robertson"
+    ]
   },
   {
     "movieId": "call-me-by-your-name-2017",
@@ -5095,7 +8364,14 @@
     "year": 2017,
     "runtime": 132,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "In 1980s Italy, romance blossoms between a seventeen-year-old student and the older man hired as his father's research assistant.",
+    "cast": [
+      "Armie Hammer",
+      "Timothée Chalamet",
+      "Michael Stuhlbarg",
+      "Amira Casar"
+    ]
   },
   {
     "movieId": "i-daniel-blake-2016",
@@ -5106,7 +8382,14 @@
     "year": 2016,
     "runtime": 100,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "After having suffered a heart-attack, a 59-year-old carpenter must fight the bureaucratic forces of the system in order to receive Employment and Support Allowance.",
+    "cast": [
+      "Laura Obiols",
+      "Dave Johns",
+      "Hayley Squires",
+      "Sharon Percy"
+    ]
   },
   {
     "movieId": "isle-of-dogs-2018",
@@ -5117,7 +8400,14 @@
     "year": 2018,
     "runtime": 101,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Set in Japan, Isle of Dogs follows a boy's odyssey in search of his lost dog.",
+    "cast": [
+      "Bryan Cranston",
+      "Koyu Rankin",
+      "Edward Norton",
+      "Bob Balaban"
+    ]
   },
   {
     "movieId": "hunt-for-the-wilderpeople-2016",
@@ -5128,7 +8418,14 @@
     "year": 2016,
     "runtime": 101,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A national manhunt is ordered for a rebellious kid and his foster uncle who go missing in the wild New Zealand bush.",
+    "cast": [
+      "Sam Neill",
+      "Julian Dennison",
+      "Rima Te Wiata",
+      "Rachel House"
+    ]
   },
   {
     "movieId": "captain-fantastic-2016",
@@ -5139,7 +8436,14 @@
     "year": 2016,
     "runtime": 118,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "In the forests of the Pacific Northwest, a father devoted to raising his six kids with a rigorous physical and intellectual education is forced to leave his paradise and enter the world, challenging his idea of what it means to be a parent.",
+    "cast": [
+      "Viggo Mortensen",
+      "George MacKay",
+      "Samantha Isler",
+      "Annalise Basso"
+    ]
   },
   {
     "movieId": "sing-street-2016",
@@ -5150,7 +8454,14 @@
     "year": 2016,
     "runtime": 106,
     "imdbRating": 7.9,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A boy growing up in Dublin during the 1980s escapes his strained family life by starting a band to impress the mysterious girl he likes.",
+    "cast": [
+      "Ferdia Walsh-Peelo",
+      "Aidan Gillen",
+      "Maria Doyle Kennedy",
+      "Jack Reynor"
+    ]
   },
   {
     "movieId": "thor-ragnarok-2017",
@@ -5161,7 +8472,14 @@
     "year": 2017,
     "runtime": 130,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Imprisoned on the planet Sakaar, Thor must race against time to return to Asgard and stop Ragnarök, the destruction of his world, at the hands of the powerful and ruthless villain Hela.",
+    "cast": [
+      "Chris Hemsworth",
+      "Tom Hiddleston",
+      "Cate Blanchett",
+      "Mark Ruffalo"
+    ]
   },
   {
     "movieId": "nightcrawler-2014",
@@ -5172,7 +8490,14 @@
     "year": 2014,
     "runtime": 117,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "When Louis Bloom, a con man desperate for work, muscles into the world of L.A. crime journalism, he blurs the line between observer and participant to become the star of his own story.",
+    "cast": [
+      "Jake Gyllenhaal",
+      "Rene Russo",
+      "Bill Paxton",
+      "Riz Ahmed"
+    ]
   },
   {
     "movieId": "jojo-rabbit-2019",
@@ -5183,7 +8508,14 @@
     "year": 2019,
     "runtime": 108,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A young boy in Hitler's army finds out his mother is hiding a Jewish girl in their home.",
+    "cast": [
+      "Roman Griffin Davis",
+      "Thomasin McKenzie",
+      "Scarlett Johansson",
+      "Taika Waititi"
+    ]
   },
   {
     "movieId": "arrival-2016",
@@ -5194,7 +8526,14 @@
     "year": 2016,
     "runtime": 116,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A linguist works with the military to communicate with alien lifeforms after twelve mysterious spacecrafts appear around the world.",
+    "cast": [
+      "Amy Adams",
+      "Jeremy Renner",
+      "Forest Whitaker",
+      "Michael Stuhlbarg"
+    ]
   },
   {
     "movieId": "star-wars-episode-vii-the-force-awakens-2015",
@@ -5205,7 +8544,14 @@
     "year": 2015,
     "runtime": 138,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "As a new threat to the galaxy rises, Rey, a desert scavenger, and Finn, an ex-stormtrooper, must join Han Solo and Chewbacca to search for the one hope of restoring peace.",
+    "cast": [
+      "Daisy Ridley",
+      "John Boyega",
+      "Oscar Isaac",
+      "Domhnall Gleeson"
+    ]
   },
   {
     "movieId": "before-midnight-2013",
@@ -5216,7 +8562,14 @@
     "year": 2013,
     "runtime": 109,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "We meet Jesse and Celine nine years on in Greece. Almost two decades have passed since their first meeting on that train bound for Vienna.",
+    "cast": [
+      "Ethan Hawke",
+      "Julie Delpy",
+      "Seamus Davey-Fitzpatrick",
+      "Ariane Labed"
+    ]
   },
   {
     "movieId": "x-men-days-of-future-past-2014",
@@ -5227,7 +8580,14 @@
     "year": 2014,
     "runtime": 132,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The X-Men send Wolverine to the past in a desperate effort to change history and prevent an event that results in doom for both humans and mutants.",
+    "cast": [
+      "Patrick Stewart",
+      "Ian McKellen",
+      "Hugh Jackman",
+      "James McAvoy"
+    ]
   },
   {
     "movieId": "bir-zamanlar-anadolu-da-2011",
@@ -5237,7 +8597,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYTRkMDRiYmEtNGM4YS00NzM3LWI4MTMtYzk1MmVjMjM3ODg1XkEyXkFqcGdeQXVyMjgyNjk3MzE@._V1_SX4000.jpg",
     "year": 2011,
     "runtime": 157,
-    "imdbRating": 7.9
+    "imdbRating": 7.9,
+    "synopsis": "A group of men set out in search of a dead body in the Anatolian steppes.",
+    "cast": [
+      "Muhammet Uzuner",
+      "Yilmaz Erdogan",
+      "Taner Birsel",
+      "Ahmet Mümtaz Taylan"
+    ]
   },
   {
     "movieId": "the-artist-2011",
@@ -5248,7 +8615,14 @@
     "year": 2011,
     "runtime": 100,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "An egomaniacal film star develops a relationship with a young dancer against the backdrop of Hollywood's silent era.",
+    "cast": [
+      "Jean Dujardin",
+      "Bérénice Bejo",
+      "John Goodman",
+      "James Cromwell"
+    ]
   },
   {
     "movieId": "edge-of-tomorrow-2014",
@@ -5259,7 +8633,14 @@
     "year": 2014,
     "runtime": 113,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A soldier fighting aliens gets to relive the same day over and over again, the day restarting every time he dies.",
+    "cast": [
+      "Tom Cruise",
+      "Emily Blunt",
+      "Bill Paxton",
+      "Brendan Gleeson"
+    ]
   },
   {
     "movieId": "amour-2012",
@@ -5270,7 +8651,14 @@
     "year": 2012,
     "runtime": 127,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Georges and Anne are an octogenarian couple. They are cultivated, retired music teachers. Their daughter, also a musician, lives in Britain with her family. One day, Anne has a stroke, and the couple's bond of love is severely tested.",
+    "cast": [
+      "Jean-Louis Trintignant",
+      "Emmanuelle Riva",
+      "Isabelle Huppert",
+      "Alexandre Tharaud"
+    ]
   },
   {
     "movieId": "the-irishman-2019",
@@ -5281,7 +8669,14 @@
     "year": 2019,
     "runtime": 209,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "An old man recalls his time painting houses for his friend, Jimmy Hoffa, through the 1950-70s.",
+    "cast": [
+      "Robert De Niro",
+      "Al Pacino",
+      "Joe Pesci",
+      "Harvey Keitel"
+    ]
   },
   {
     "movieId": "un-proph-te-2009",
@@ -5292,7 +8687,14 @@
     "year": 2009,
     "runtime": 155,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A young Arab man is sent to a French prison.",
+    "cast": [
+      "Tahar Rahim",
+      "Niels Arestrup",
+      "Adel Bencherif",
+      "Reda Kateb"
+    ]
   },
   {
     "movieId": "moon-2009",
@@ -5303,7 +8705,14 @@
     "year": 2009,
     "runtime": 97,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Astronaut Sam Bell has a quintessentially personal encounter toward the end of his three-year stint on the Moon, where he, working alongside his computer, GERTY, sends back to Earth parcels of a resource that has helped diminish our planet's power problems.",
+    "cast": [
+      "Sam Rockwell",
+      "Kevin Spacey",
+      "Dominique McElligott",
+      "Rosie Shaw"
+    ]
   },
   {
     "movieId": "l-t-den-r-tte-komma-in-2008",
@@ -5314,7 +8723,14 @@
     "year": 2008,
     "runtime": 114,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Oskar, an overlooked and bullied boy, finds love and revenge through Eli, a beautiful but peculiar girl.",
+    "cast": [
+      "Kåre Hedebrant",
+      "Lina Leandersson",
+      "Per Ragnar",
+      "Henrik Dahl"
+    ]
   },
   {
     "movieId": "district-9-2009",
@@ -5325,7 +8741,14 @@
     "year": 2009,
     "runtime": 112,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Violence ensues after an extraterrestrial race forced to live in slum-like conditions on Earth finds a kindred spirit in a government agent exposed to their biotechnology.",
+    "cast": [
+      "Sharlto Copley",
+      "David James",
+      "Jason Cope",
+      "Nathalie Boltt"
+    ]
   },
   {
     "movieId": "the-wrestler-2008",
@@ -5336,7 +8759,14 @@
     "year": 2008,
     "runtime": 109,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A faded professional wrestler must retire, but finds his quest for a new life outside the ring a dispiriting struggle.",
+    "cast": [
+      "Mickey Rourke",
+      "Marisa Tomei",
+      "Evan Rachel Wood",
+      "Mark Margolis"
+    ]
   },
   {
     "movieId": "jab-we-met-2007",
@@ -5347,7 +8777,14 @@
     "year": 2007,
     "runtime": 138,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A depressed wealthy businessman finds his life changing after he meets a spunky and care-free young woman.",
+    "cast": [
+      "Shahid Kapoor",
+      "Kareena Kapoor",
+      "Tarun Arora",
+      "Dara Singh"
+    ]
   },
   {
     "movieId": "boyhood-2014",
@@ -5358,7 +8795,14 @@
     "year": 2014,
     "runtime": 165,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The life of Mason, from early childhood to his arrival at college.",
+    "cast": [
+      "Ellar Coltrane",
+      "Patricia Arquette",
+      "Ethan Hawke",
+      "Elijah Smith"
+    ]
   },
   {
     "movieId": "4-luni-3-saptam-ni-si-2-zile-2007",
@@ -5368,7 +8812,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYzU1YWUzNjYtNmVhZi00ODUyLTg4M2ItMTFlMmU1Mzc5OTE5XkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_SX4000.jpg",
     "year": 2007,
     "runtime": 113,
-    "imdbRating": 7.9
+    "imdbRating": 7.9,
+    "synopsis": "A woman assists her friend in arranging an illegal abortion in 1980s Romania.",
+    "cast": [
+      "Anamaria Marinca",
+      "Laura Vasiliu",
+      "Vlad Ivanov",
+      "Alexandru Potocean"
+    ]
   },
   {
     "movieId": "star-trek-2009",
@@ -5379,7 +8830,14 @@
     "year": 2009,
     "runtime": 127,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The brash James T. Kirk tries to live up to his father's legacy with Mr. Spock keeping him in check as a vengeful Romulan from the future creates black holes to destroy the Federation one planet at a time.",
+    "cast": [
+      "Chris Pine",
+      "Zachary Quinto",
+      "Simon Pegg",
+      "Leonard Nimoy"
+    ]
   },
   {
     "movieId": "in-bruges-2008",
@@ -5390,7 +8848,14 @@
     "year": 2008,
     "runtime": 107,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Guilt-stricken after a job gone wrong, hitman Ray and his partner await orders from their ruthless boss in Bruges, Belgium, the last place in the world Ray wants to be.",
+    "cast": [
+      "Colin Farrell",
+      "Brendan Gleeson",
+      "Ciarán Hinds",
+      "Elizabeth Berrington"
+    ]
   },
   {
     "movieId": "the-man-from-earth-2007",
@@ -5400,7 +8865,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMzQ5NGQwOTUtNWJlZi00ZTFiLWI0ZTEtOGU3MTA2ZGU5OWZiXkEyXkFqcGdeQXVyMTczNjQwOTY@._V1_SX4000.jpg",
     "year": 2007,
     "runtime": 87,
-    "imdbRating": 7.9
+    "imdbRating": 7.9,
+    "synopsis": "An impromptu goodbye party for Professor John Oldman becomes a mysterious interrogation after the retiring scholar reveals to his colleagues he has a longer and stranger past than they can imagine.",
+    "cast": [
+      "David Lee Smith",
+      "Tony Todd",
+      "John Billingsley",
+      "Ellen Crawford"
+    ]
   },
   {
     "movieId": "letters-from-iwo-jima-2006",
@@ -5411,7 +8883,14 @@
     "year": 2006,
     "runtime": 141,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The story of the battle of Iwo Jima between the United States and Imperial Japan during World War II, as told from the perspective of the Japanese who fought it.",
+    "cast": [
+      "Ken Watanabe",
+      "Kazunari Ninomiya",
+      "Tsuyoshi Ihara",
+      "Ryô Kase"
+    ]
   },
   {
     "movieId": "the-fall-2006",
@@ -5422,7 +8901,14 @@
     "year": 2006,
     "runtime": 117,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "In a hospital on the outskirts of 1920s Los Angeles, an injured stuntman begins to tell a fellow patient, a little girl with a broken arm, a fantastic story of five mythical heroes. Thanks to his fractured state of mind and her vivid imagination, the line between fiction and reality blurs as the tale advances.",
+    "cast": [
+      "Lee Pace",
+      "Catinca Untaru",
+      "Justine Waddell",
+      "Kim Uylenbroek"
+    ]
   },
   {
     "movieId": "life-of-pi-2012",
@@ -5433,7 +8919,14 @@
     "year": 2012,
     "runtime": 127,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A young man who survives a disaster at sea is hurtled into an epic journey of adventure and discovery. While cast away, he forms an unexpected connection with another survivor: a fearsome Bengal tiger.",
+    "cast": [
+      "Suraj Sharma",
+      "Irrfan Khan",
+      "Adil Hussain",
+      "Tabu"
+    ]
   },
   {
     "movieId": "fantastic-mr-fox-2009",
@@ -5444,7 +8937,14 @@
     "year": 2009,
     "runtime": 87,
     "imdbRating": 7.9,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "An urbane fox cannot resist returning to his farm raiding ways and then must help his community survive the farmers' retaliation.",
+    "cast": [
+      "George Clooney",
+      "Meryl Streep",
+      "Bill Murray",
+      "Jason Schwartzman"
+    ]
   },
   {
     "movieId": "c-r-a-z-y-2005",
@@ -5454,7 +8954,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTU3MDc2MjUwMV5BMl5BanBnXkFtZTcwNzQyMDAzMQ@@._V1_SX4000.jpg",
     "year": 2005,
     "runtime": 129,
-    "imdbRating": 7.9
+    "imdbRating": 7.9,
+    "synopsis": "A young French-Canadian, growing up in the 1960s and 1970s, struggles to reconcile his emerging homosexuality with his father's conservative values and his own Catholic beliefs.",
+    "cast": [
+      "Michel Côté",
+      "Marc-André Grondin",
+      "Danielle Proulx",
+      "Émile Vallée"
+    ]
   },
   {
     "movieId": "les-choristes-2004",
@@ -5465,7 +8972,14 @@
     "year": 2004,
     "runtime": 97,
     "imdbRating": 7.9,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "The new teacher at a severely administered boys' boarding school works to positively affect the students' lives through music.",
+    "cast": [
+      "Gérard Jugnot",
+      "François Berléand",
+      "Jean-Baptiste Maunier",
+      "Kad Merad"
+    ]
   },
   {
     "movieId": "iron-man-2008",
@@ -5476,7 +8990,14 @@
     "year": 2008,
     "runtime": 126,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "After being held captive in an Afghan cave, billionaire engineer Tony Stark creates a unique weaponized suit of armor to fight evil.",
+    "cast": [
+      "Robert Downey Jr.",
+      "Gwyneth Paltrow",
+      "Terrence Howard",
+      "Jeff Bridges"
+    ]
   },
   {
     "movieId": "shaun-of-the-dead-2004",
@@ -5487,7 +9008,14 @@
     "year": 2004,
     "runtime": 99,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A man's uneventful life is disrupted by the zombie apocalypse.",
+    "cast": [
+      "Simon Pegg",
+      "Nick Frost",
+      "Kate Ashfield",
+      "Lucy Davis"
+    ]
   },
   {
     "movieId": "gegen-die-wand-2004",
@@ -5498,7 +9026,14 @@
     "year": 2004,
     "runtime": 121,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "With the intention to break free from the strict familial restrictions, a suicidal young woman sets up a marriage of convenience with a forty-year-old addict, an act that will lead to an outburst of envious love.",
+    "cast": [
+      "Birol Ünel",
+      "Sibel Kekilli",
+      "Güven Kiraç",
+      "Zarah Jane McKenzie"
+    ]
   },
   {
     "movieId": "mystic-river-2003",
@@ -5509,7 +9044,14 @@
     "year": 2003,
     "runtime": 138,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The lives of three men who were childhood friends are shattered when one of them has a family tragedy.",
+    "cast": [
+      "Sean Penn",
+      "Tim Robbins",
+      "Kevin Bacon",
+      "Emmy Rossum"
+    ]
   },
   {
     "movieId": "harry-potter-and-the-prisoner-of-azkaban-2004",
@@ -5520,7 +9062,14 @@
     "year": 2004,
     "runtime": 142,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Harry Potter, Ron and Hermione return to Hogwarts School of Witchcraft and Wizardry for their third year of study, where they delve into the mystery surrounding an escaped prisoner who poses a dangerous threat to the young wizard.",
+    "cast": [
+      "Daniel Radcliffe",
+      "Emma Watson",
+      "Rupert Grint",
+      "Richard Griffiths"
+    ]
   },
   {
     "movieId": "ying-xiong-2002",
@@ -5531,7 +9080,14 @@
     "year": 2002,
     "runtime": 120,
     "imdbRating": 7.9,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A defense officer, Nameless, was summoned by the King of Qin regarding his success of terminating three warriors.",
+    "cast": [
+      "Jet Li",
+      "Tony Chiu-Wai Leung",
+      "Maggie Cheung",
+      "Ziyi Zhang"
+    ]
   },
   {
     "movieId": "hable-con-ella-2002",
@@ -5542,7 +9098,14 @@
     "year": 2002,
     "runtime": 112,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Two men share an odd friendship while they care for two women who are both in deep comas.",
+    "cast": [
+      "Rosario Flores",
+      "Javier Cámara",
+      "Darío Grandinetti",
+      "Leonor Watling"
+    ]
   },
   {
     "movieId": "no-man-s-land-2001",
@@ -5553,7 +9116,14 @@
     "year": 2001,
     "runtime": 98,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Bosnia and Herzegovina during 1993 at the time of the heaviest fighting between the two warring sides. Two soldiers from opposing sides in the conflict, Nino and Ciki, become trapped in no man's land, whilst a third soldier becomes a living booby trap.",
+    "cast": [
+      "Branko Djuric",
+      "Rene Bitorajac",
+      "Filip Sovagovic",
+      "Georges Siatidis"
+    ]
   },
   {
     "movieId": "cowboy-bebop-tengoku-no-tobira-2001",
@@ -5564,7 +9134,14 @@
     "year": 2001,
     "runtime": 115,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A terrorist explosion releases a deadly virus on the masses, and it's up the bounty-hunting Bebop crew to catch the cold-blooded culprit.",
+    "cast": [
+      "Tensai Okamura",
+      "Hiroyuki Okiura",
+      "Yoshiyuki Takei",
+      "Beau Billingslea"
+    ]
   },
   {
     "movieId": "the-bourne-identity-2002",
@@ -5575,7 +9152,14 @@
     "year": 2002,
     "runtime": 119,
     "imdbRating": 7.9,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A man is picked up by a fishing boat, bullet-riddled and suffering from amnesia, before racing to elude assassins and attempting to regain his memory.",
+    "cast": [
+      "Franka Potente",
+      "Matt Damon",
+      "Chris Cooper",
+      "Clive Owen"
+    ]
   },
   {
     "movieId": "nueve-reinas-2000",
@@ -5586,7 +9170,14 @@
     "year": 2000,
     "runtime": 114,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Two con artists try to swindle a stamp collector by selling him a sheet of counterfeit rare stamps (the \"nine queens\").",
+    "cast": [
+      "Ricardo Darín",
+      "Gastón Pauls",
+      "Graciela Tenenbaum",
+      "María Mercedes Villagra"
+    ]
   },
   {
     "movieId": "children-of-men-2006",
@@ -5597,7 +9188,14 @@
     "year": 2006,
     "runtime": 109,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In 2027, in a chaotic world in which women have become somehow infertile, a former activist agrees to help transport a miraculously pregnant woman to a sanctuary at sea.",
+    "cast": [
+      "Julianne Moore",
+      "Clive Owen",
+      "Chiwetel Ejiofor",
+      "Michael Caine"
+    ]
   },
   {
     "movieId": "almost-famous-2000",
@@ -5608,7 +9206,14 @@
     "year": 2000,
     "runtime": 122,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A high-school boy is given the chance to write a story for Rolling Stone Magazine about an up-and-coming rock band as he accompanies them on their concert tour.",
+    "cast": [
+      "Billy Crudup",
+      "Patrick Fugit",
+      "Kate Hudson",
+      "Frances McDormand"
+    ]
   },
   {
     "movieId": "mulholland-dr-2001",
@@ -5619,7 +9224,14 @@
     "year": 2001,
     "runtime": 147,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "After a car wreck on the winding Mulholland Drive renders a woman amnesiac, she and a perky Hollywood-hopeful search for clues and answers across Los Angeles in a twisting venture beyond dreams and reality.",
+    "cast": [
+      "Naomi Watts",
+      "Laura Harring",
+      "Justin Theroux",
+      "Jeanne Bates"
+    ]
   },
   {
     "movieId": "toy-story-2-1999",
@@ -5630,7 +9242,14 @@
     "year": 1999,
     "runtime": 92,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "When Woody is stolen by a toy collector, Buzz and his friends set out on a rescue mission to save Woody before he becomes a museum toy property with his roundup gang Jessie, Prospector, and Bullseye.",
+    "cast": [
+      "Ash Brannon",
+      "Lee Unkrich",
+      "Tom Hanks",
+      "Tim Allen"
+    ]
   },
   {
     "movieId": "boogie-nights-1997",
@@ -5641,7 +9260,14 @@
     "year": 1997,
     "runtime": 155,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Back when sex was safe, pleasure was a business and business was booming, an idealistic porn producer aspires to elevate his craft to an art when he discovers a hot young talent.",
+    "cast": [
+      "Mark Wahlberg",
+      "Julianne Moore",
+      "Burt Reynolds",
+      "Luis Guzmán"
+    ]
   },
   {
     "movieId": "mimi-wo-sumaseba-1995",
@@ -5652,7 +9278,14 @@
     "year": 1995,
     "runtime": 111,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A love story between a girl who loves reading books, and a boy who has previously checked out all of the library books she chooses.",
+    "cast": [
+      "Yoko Honna",
+      "Issey Takahashi",
+      "Takashi Tachibana",
+      "Shigeru Muroi"
+    ]
   },
   {
     "movieId": "once-were-warriors-1994",
@@ -5663,7 +9296,14 @@
     "year": 1994,
     "runtime": 102,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A family descended from Maori warriors is bedeviled by a violent father and the societal problems of being treated as outcasts.",
+    "cast": [
+      "Rena Owen",
+      "Temuera Morrison",
+      "Mamaengaroa Kerr-Bell",
+      "Julian Arahanga"
+    ]
   },
   {
     "movieId": "true-romance-1993",
@@ -5674,7 +9314,14 @@
     "year": 1993,
     "runtime": 119,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "In Detroit, a lonely pop culture geek marries a call girl, steals cocaine from her pimp, and tries to sell it in Hollywood. Meanwhile, the owners of the cocaine, the Mob, track them down in an attempt to reclaim it.",
+    "cast": [
+      "Christian Slater",
+      "Patricia Arquette",
+      "Dennis Hopper",
+      "Val Kilmer"
+    ]
   },
   {
     "movieId": "trois-couleurs-bleu-1993",
@@ -5685,7 +9332,14 @@
     "year": 1993,
     "runtime": 94,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A woman struggles to find a way to live her life after the death of her husband and child.",
+    "cast": [
+      "Juliette Binoche",
+      "Zbigniew Zamachowski",
+      "Julie Delpy",
+      "Benoît Régent"
+    ]
   },
   {
     "movieId": "j-b-ninp-ch-1993",
@@ -5696,7 +9350,14 @@
     "year": 1993,
     "runtime": 94,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A vagabond swordsman is aided by a beautiful ninja girl and a crafty spy in confronting a demonic clan of killers - with a ghost from his past as their leader - who are bent on overthrowing the Tokugawa Shogunate.",
+    "cast": [
+      "Kôichi Yamadera",
+      "Emi Shinohara",
+      "Takeshi Aono",
+      "Osamu Saka"
+    ]
   },
   {
     "movieId": "carlito-s-way-1993",
@@ -5707,7 +9368,14 @@
     "year": 1993,
     "runtime": 144,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A Puerto Rican former convict, just released from prison, pledges to stay away from drugs and violence despite the pressure around him and lead on to a better life outside of N.Y.C.",
+    "cast": [
+      "Al Pacino",
+      "Sean Penn",
+      "Penelope Ann Miller",
+      "John Leguizamo"
+    ]
   },
   {
     "movieId": "edward-scissorhands-1990",
@@ -5718,7 +9386,14 @@
     "year": 1990,
     "runtime": 105,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "An artificial man, who was incompletely constructed and has scissors for hands, leads a solitary life. Then one day, a suburban lady meets him and introduces him to her world.",
+    "cast": [
+      "Johnny Depp",
+      "Winona Ryder",
+      "Dianne Wiest",
+      "Anthony Michael Hall"
+    ]
   },
   {
     "movieId": "my-left-foot-the-story-of-christy-brown-1989",
@@ -5729,7 +9404,14 @@
     "year": 1989,
     "runtime": 103,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Christy Brown, born with cerebral palsy, learns to paint and write with his only controllable limb - his left foot.",
+    "cast": [
+      "Daniel Day-Lewis",
+      "Brenda Fricker",
+      "Alison Whelan",
+      "Kirsten Sheridan"
+    ]
   },
   {
     "movieId": "crimes-and-misdemeanors-1989",
@@ -5740,7 +9422,14 @@
     "year": 1989,
     "runtime": 104,
     "imdbRating": 7.9,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "An ophthalmologist's mistress threatens to reveal their affair to his wife while a married documentary filmmaker is infatuated with another woman.",
+    "cast": [
+      "Martin Landau",
+      "Woody Allen",
+      "Bill Bernstein",
+      "Claire Bloom"
+    ]
   },
   {
     "movieId": "the-untouchables-1987",
@@ -5751,7 +9440,14 @@
     "year": 1987,
     "runtime": 119,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "During the era of Prohibition in the United States, Federal Agent Eliot Ness sets out to stop ruthless Chicago gangster Al Capone and, because of rampant corruption, assembles a small, hand-picked team to help him.",
+    "cast": [
+      "Kevin Costner",
+      "Sean Connery",
+      "Robert De Niro",
+      "Charles Martin Smith"
+    ]
   },
   {
     "movieId": "hannah-and-her-sisters-1986",
@@ -5762,7 +9458,14 @@
     "year": 1986,
     "runtime": 107,
     "imdbRating": 7.9,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "Between two Thanksgivings two years apart, Hannah's husband falls in love with her sister Lee, while her hypochondriac ex-husband rekindles his relationship with her sister Holly.",
+    "cast": [
+      "Mia Farrow",
+      "Dianne Wiest",
+      "Michael Caine",
+      "Barbara Hershey"
+    ]
   },
   {
     "movieId": "brazil-1985",
@@ -5773,7 +9476,14 @@
     "year": 1985,
     "runtime": 132,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A bureaucrat in a dystopic society becomes an enemy of the state as he pursues the woman of his dreams.",
+    "cast": [
+      "Jonathan Pryce",
+      "Kim Greist",
+      "Robert De Niro",
+      "Katherine Helmond"
+    ]
   },
   {
     "movieId": "this-is-spinal-tap-1984",
@@ -5784,7 +9494,14 @@
     "year": 1984,
     "runtime": 82,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Spinal Tap, one of England's loudest bands, is chronicled by film director Marty DiBergi on what proves to be a fateful tour.",
+    "cast": [
+      "Rob Reiner",
+      "Michael McKean",
+      "Christopher Guest",
+      "Kimberly Stringer"
+    ]
   },
   {
     "movieId": "a-christmas-story-1983",
@@ -5795,7 +9512,14 @@
     "year": 1983,
     "runtime": 93,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In the 1940s, a young boy named Ralphie attempts to convince his parents, his teacher and Santa that a Red Ryder BB gun really is the perfect Christmas gift.",
+    "cast": [
+      "Peter Billingsley",
+      "Melinda Dillon",
+      "Darren McGavin",
+      "Scott Schwartz"
+    ]
   },
   {
     "movieId": "the-blues-brothers-1980",
@@ -5806,7 +9530,14 @@
     "year": 1980,
     "runtime": 133,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Jake Blues, just released from prison, puts together his old band to save the Catholic home where he and his brother Elwood were raised.",
+    "cast": [
+      "John Belushi",
+      "Dan Aykroyd",
+      "Cab Calloway",
+      "John Candy"
+    ]
   },
   {
     "movieId": "manhattan-1979",
@@ -5817,7 +9548,14 @@
     "year": 1979,
     "runtime": 96,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "The life of a divorced television writer dating a teenage girl is further complicated when he falls in love with his best friend's mistress.",
+    "cast": [
+      "Woody Allen",
+      "Diane Keaton",
+      "Mariel Hemingway",
+      "Michael Murphy"
+    ]
   },
   {
     "movieId": "all-that-jazz-1979",
@@ -5828,7 +9566,14 @@
     "year": 1979,
     "runtime": 123,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Director/choreographer Bob Fosse tells his own life story as he details the sordid career of Joe Gideon, a womanizing, drug-using dancer.",
+    "cast": [
+      "Roy Scheider",
+      "Jessica Lange",
+      "Ann Reinking",
+      "Leland Palmer"
+    ]
   },
   {
     "movieId": "dawn-of-the-dead-1978",
@@ -5839,7 +9584,14 @@
     "year": 1978,
     "runtime": 127,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Following an ever-growing epidemic of zombies that have risen from the dead, two Philadelphia S.W.A.T. team members, a traffic reporter, and his television executive girlfriend seek refuge in a secluded shopping mall.",
+    "cast": [
+      "David Emge",
+      "Ken Foree",
+      "Scott H. Reiniger",
+      "Gaylen Ross"
+    ]
   },
   {
     "movieId": "all-the-president-s-men-1976",
@@ -5850,7 +9602,14 @@
     "year": 1976,
     "runtime": 138,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "\"The Washington Post\" reporters Bob Woodward and Carl Bernstein uncover the details of the Watergate scandal that leads to President Richard Nixon's resignation.",
+    "cast": [
+      "Dustin Hoffman",
+      "Robert Redford",
+      "Jack Warden",
+      "Martin Balsam"
+    ]
   },
   {
     "movieId": "la-monta-a-sagrada-1973",
@@ -5861,7 +9620,14 @@
     "year": 1973,
     "runtime": 114,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "In a corrupt, greed-fueled world, a powerful alchemist leads a messianic character and seven materialistic figures to the Holy Mountain, where they hope to achieve enlightenment.",
+    "cast": [
+      "Alejandro Jodorowsky",
+      "Horacio Salinas",
+      "Zamira Saunders",
+      "Juan Ferrara"
+    ]
   },
   {
     "movieId": "amarcord-1973",
@@ -5872,7 +9638,14 @@
     "year": 1973,
     "runtime": 123,
     "imdbRating": 7.9,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A series of comedic and nostalgic vignettes set in a 1930s Italian coastal town.",
+    "cast": [
+      "Magali Noël",
+      "Bruno Zanin",
+      "Pupella Maggio",
+      "Armando Brancia"
+    ]
   },
   {
     "movieId": "le-charme-discret-de-la-bourgeoisie-1972",
@@ -5883,7 +9656,14 @@
     "year": 1972,
     "runtime": 102,
     "imdbRating": 7.9,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "A surreal, virtually plotless series of dreams centered around six middle-class people and their consistently interrupted attempts to have a meal together.",
+    "cast": [
+      "Fernando Rey",
+      "Delphine Seyrig",
+      "Paul Frankeur",
+      "Bulle Ogier"
+    ]
   },
   {
     "movieId": "aguirre-der-zorn-gottes-1972",
@@ -5893,7 +9673,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMjRkY2VhYzMtZWQyNS00OTY2LWE5NTAtYjlhNmQyYzE5MmUxXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_SX4000.jpg",
     "year": 1972,
     "runtime": 95,
-    "imdbRating": 7.9
+    "imdbRating": 7.9,
+    "synopsis": "In the 16th century, the ruthless and insane Don Lope de Aguirre leads a Spanish expedition in search of El Dorado.",
+    "cast": [
+      "Klaus Kinski",
+      "Ruy Guerra",
+      "Helena Rojo",
+      "Del Negro"
+    ]
   },
   {
     "movieId": "harold-and-maude-1971",
@@ -5904,7 +9691,14 @@
     "year": 1971,
     "runtime": 91,
     "imdbRating": 7.9,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "Young, rich, and obsessed with death, Harold finds himself changed forever when he meets lively septuagenarian Maude at a funeral.",
+    "cast": [
+      "Ruth Gordon",
+      "Bud Cort",
+      "Vivian Pickles",
+      "Cyril Cusack"
+    ]
   },
   {
     "movieId": "patton-1970",
@@ -5915,7 +9709,14 @@
     "year": 1970,
     "runtime": 172,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The World War II phase of the career of controversial American general George S. Patton.",
+    "cast": [
+      "George C. Scott",
+      "Karl Malden",
+      "Stephen Young",
+      "Michael Strong"
+    ]
   },
   {
     "movieId": "the-wild-bunch-1969",
@@ -5926,7 +9727,14 @@
     "year": 1969,
     "runtime": 145,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An aging group of outlaws look for one last big score as the \"traditional\" American West is disappearing around them.",
+    "cast": [
+      "William Holden",
+      "Ernest Borgnine",
+      "Robert Ryan",
+      "Edmond O'Brien"
+    ]
   },
   {
     "movieId": "night-of-the-living-dead-1968",
@@ -5936,7 +9744,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMzRmN2E1ZDUtZDc2ZC00ZmI3LTkwOTctNzE2ZDIzMGJiMTYzXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_SX4000.jpg",
     "year": 1968,
     "runtime": 96,
-    "imdbRating": 7.9
+    "imdbRating": 7.9,
+    "synopsis": "A ragtag group of Pennsylvanians barricade themselves in an old farmhouse to remain safe from a horde of flesh-eating ghouls that are ravaging the East Coast of the United States.",
+    "cast": [
+      "Duane Jones",
+      "Judith O'Dea",
+      "Karl Hardman",
+      "Marilyn Eastman"
+    ]
   },
   {
     "movieId": "the-lion-in-winter-1968",
@@ -5947,7 +9762,14 @@
     "year": 1968,
     "runtime": 134,
     "imdbRating": 7.9,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "1183 A.D.: King Henry II's three sons all want to inherit the throne, but he won't commit to a choice. They and his wife variously plot to force him.",
+    "cast": [
+      "Peter O'Toole",
+      "Katharine Hepburn",
+      "Anthony Hopkins",
+      "John Castle"
+    ]
   },
   {
     "movieId": "in-the-heat-of-the-night-1967",
@@ -5958,7 +9780,14 @@
     "year": 1967,
     "runtime": 110,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A black police detective is asked to investigate a murder in a racially hostile southern town.",
+    "cast": [
+      "Sidney Poitier",
+      "Rod Steiger",
+      "Warren Oates",
+      "Lee Grant"
+    ]
   },
   {
     "movieId": "charade-1963",
@@ -5969,7 +9798,14 @@
     "year": 1963,
     "runtime": 113,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Romance and suspense ensue in Paris as a woman is pursued by several men who want a fortune her murdered husband had stolen. Whom can she trust?",
+    "cast": [
+      "Cary Grant",
+      "Audrey Hepburn",
+      "Walter Matthau",
+      "James Coburn"
+    ]
   },
   {
     "movieId": "the-manchurian-candidate-1962",
@@ -5980,7 +9816,14 @@
     "year": 1962,
     "runtime": 126,
     "imdbRating": 7.9,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A former prisoner of war is brainwashed as an unwitting assassin for an international Communist conspiracy.",
+    "cast": [
+      "Frank Sinatra",
+      "Laurence Harvey",
+      "Janet Leigh",
+      "Angela Lansbury"
+    ]
   },
   {
     "movieId": "spartacus-1960",
@@ -5991,7 +9834,14 @@
     "year": 1960,
     "runtime": 197,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The slave Spartacus leads a violent revolt against the decadent Roman Republic.",
+    "cast": [
+      "Kirk Douglas",
+      "Laurence Olivier",
+      "Jean Simmons",
+      "Charles Laughton"
+    ]
   },
   {
     "movieId": "l-avventura-1960",
@@ -6002,7 +9852,14 @@
     "year": 1960,
     "runtime": 144,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A woman disappears during a Mediterranean boating trip. During the search, her lover and her best friend become attracted to each other.",
+    "cast": [
+      "Gabriele Ferzetti",
+      "Monica Vitti",
+      "Lea Massari",
+      "Dominique Blanchar"
+    ]
   },
   {
     "movieId": "hiroshima-mon-amour-1959",
@@ -6012,7 +9869,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMzY2NTA1MzUwN15BMl5BanBnXkFtZTgwOTc4NTU4MjE@._V1_SX4000.jpg",
     "year": 1959,
     "runtime": 90,
-    "imdbRating": 7.9
+    "imdbRating": 7.9,
+    "synopsis": "A French actress filming an anti-war film in Hiroshima has an affair with a married Japanese architect as they share their differing perspectives on war.",
+    "cast": [
+      "Emmanuelle Riva",
+      "Eiji Okada",
+      "Stella Dassas",
+      "Pierre Barbaud"
+    ]
   },
   {
     "movieId": "the-ten-commandments-1956",
@@ -6023,7 +9887,14 @@
     "year": 1956,
     "runtime": 220,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Moses, an Egyptian Prince, learns of his true heritage as a Hebrew and his divine mission as the deliverer of his people.",
+    "cast": [
+      "Charlton Heston",
+      "Yul Brynner",
+      "Anne Baxter",
+      "Edward G. Robinson"
+    ]
   },
   {
     "movieId": "the-searchers-1956",
@@ -6034,7 +9905,14 @@
     "year": 1956,
     "runtime": 119,
     "imdbRating": 7.9,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "An American Civil War veteran embarks on a journey to rescue his niece from the Comanches.",
+    "cast": [
+      "John Wayne",
+      "Jeffrey Hunter",
+      "Vera Miles",
+      "Ward Bond"
+    ]
   },
   {
     "movieId": "east-of-eden-1955",
@@ -6045,7 +9923,14 @@
     "year": 1955,
     "runtime": 118,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Two brothers struggle to maintain their strict, Bible-toting father's favor.",
+    "cast": [
+      "James Dean",
+      "Raymond Massey",
+      "Julie Harris",
+      "Burl Ives"
+    ]
   },
   {
     "movieId": "high-noon-1952",
@@ -6056,7 +9941,14 @@
     "year": 1952,
     "runtime": 85,
     "imdbRating": 7.9,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "A town Marshal, despite the disagreements of his newlywed bride and the townspeople around him, must face a gang of deadly killers alone at high noon when the gang leader, an outlaw he sent up years ago, arrives on the noon train.",
+    "cast": [
+      "Gary Cooper",
+      "Grace Kelly",
+      "Thomas Mitchell",
+      "Lloyd Bridges"
+    ]
   },
   {
     "movieId": "strangers-on-a-train-1951",
@@ -6067,7 +9959,14 @@
     "year": 1951,
     "runtime": 101,
     "imdbRating": 7.9,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A psychopath forces a tennis star to comply with his theory that two strangers can get away with murder.",
+    "cast": [
+      "Farley Granger",
+      "Robert Walker",
+      "Ruth Roman",
+      "Leo G. Carroll"
+    ]
   },
   {
     "movieId": "harvey-1950",
@@ -6078,7 +9977,14 @@
     "year": 1950,
     "runtime": 104,
     "imdbRating": 7.9,
-    "rated": "Approved"
+    "rated": "Approved",
+    "synopsis": "Due to his insistence that he has an invisible six foot-tall rabbit for a best friend, a whimsical middle-aged man is thought by his family to be insane - but he may be wiser than anyone knows.",
+    "cast": [
+      "James Stewart",
+      "Wallace Ford",
+      "William H. Lynn",
+      "Victoria Horne"
+    ]
   },
   {
     "movieId": "miracle-on-34th-street-1947",
@@ -6088,7 +9994,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNjRkOGEwYTUtY2E5Yy00ODg4LTk2ZWItY2IyMzUxOGVhMTM1XkEyXkFqcGdeQXVyNDk0MDg4NDk@._V1_SX4000.jpg",
     "year": 1947,
     "runtime": 96,
-    "imdbRating": 7.9
+    "imdbRating": 7.9,
+    "synopsis": "When a nice old man who claims to be Santa Claus is institutionalized as insane, a young lawyer decides to defend him by arguing in court that he is the real thing.",
+    "cast": [
+      "Edmund Gwenn",
+      "Maureen O'Hara",
+      "John Payne",
+      "Gene Lockhart"
+    ]
   },
   {
     "movieId": "notorious-1946",
@@ -6099,7 +10012,14 @@
     "year": 1946,
     "runtime": 102,
     "imdbRating": 7.9,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A woman is asked to spy on a group of Nazi friends in South America. How far will she have to go to ingratiate herself with them?",
+    "cast": [
+      "Cary Grant",
+      "Ingrid Bergman",
+      "Claude Rains",
+      "Louis Calhern"
+    ]
   },
   {
     "movieId": "the-big-sleep-1946",
@@ -6110,7 +10030,14 @@
     "year": 1946,
     "runtime": 114,
     "imdbRating": 7.9,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "Private detective Philip Marlowe is hired by a wealthy family. Before the complex case is over, he's seen murder, blackmail, and what might be love.",
+    "cast": [
+      "Humphrey Bogart",
+      "Lauren Bacall",
+      "John Ridgely",
+      "Martha Vickers"
+    ]
   },
   {
     "movieId": "the-lost-weekend-1945",
@@ -6121,7 +10048,14 @@
     "year": 1945,
     "runtime": 101,
     "imdbRating": 7.9,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "The desperate life of a chronic alcoholic is followed through a four-day drinking bout.",
+    "cast": [
+      "Ray Milland",
+      "Jane Wyman",
+      "Phillip Terry",
+      "Howard Da Silva"
+    ]
   },
   {
     "movieId": "the-philadelphia-story-1940",
@@ -6131,7 +10065,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYjQ4ZDA4NGMtMTkwYi00NThiLThhZDUtZTEzNTAxOWYyY2E4XkEyXkFqcGdeQXVyMjUxODE0MDY@._V1_SX4000.jpg",
     "year": 1940,
     "runtime": 112,
-    "imdbRating": 7.9
+    "imdbRating": 7.9,
+    "synopsis": "When a rich woman's ex-husband and a tabloid-type reporter turn up just before her planned remarriage, she begins to learn the truth about herself.",
+    "cast": [
+      "Cary Grant",
+      "Katharine Hepburn",
+      "James Stewart",
+      "Ruth Hussey"
+    ]
   },
   {
     "movieId": "his-girl-friday-1940",
@@ -6142,7 +10083,14 @@
     "year": 1940,
     "runtime": 92,
     "imdbRating": 7.9,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A newspaper editor uses every trick in the book to keep his ace reporter ex-wife from remarrying.",
+    "cast": [
+      "Cary Grant",
+      "Rosalind Russell",
+      "Ralph Bellamy",
+      "Gene Lockhart"
+    ]
   },
   {
     "movieId": "the-adventures-of-robin-hood-1938",
@@ -6153,7 +10101,14 @@
     "year": 1938,
     "runtime": 102,
     "imdbRating": 7.9,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "When Prince John and the Norman Lords begin oppressing the Saxon masses in King Richard's absence, a Saxon lord fights back as the outlaw leader of a rebel guerrilla army.",
+    "cast": [
+      "William Keighley",
+      "Errol Flynn",
+      "Olivia de Havilland",
+      "Basil Rathbone"
+    ]
   },
   {
     "movieId": "a-night-at-the-opera-1935",
@@ -6164,7 +10119,14 @@
     "year": 1935,
     "runtime": 96,
     "imdbRating": 7.9,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A sly business manager and two wacky friends of two opera singers help them achieve success while humiliating their stuffy and snobbish enemies.",
+    "cast": [
+      "Edmund Goulding",
+      "Groucho Marx",
+      "Chico Marx",
+      "Harpo Marx"
+    ]
   },
   {
     "movieId": "king-kong-1933",
@@ -6175,7 +10137,14 @@
     "year": 1933,
     "runtime": 100,
     "imdbRating": 7.9,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A film crew goes to a tropical island for an exotic location shoot and discovers a colossal ape who takes a shine to their female blonde star. He is then captured and brought back to New York City for public exhibition.",
+    "cast": [
+      "Ernest B. Schoedsack",
+      "Fay Wray",
+      "Robert Armstrong",
+      "Bruce Cabot"
+    ]
   },
   {
     "movieId": "freaks-1932",
@@ -6185,7 +10154,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMjMyYjgyOTQtZDVlZS00NTQ0LWJiNDItNGRlZmM3Yzc0N2Y0XkEyXkFqcGdeQXVyNTA4NzY1MzY@._V1_SX4000.jpg",
     "year": 1932,
     "runtime": 64,
-    "imdbRating": 7.9
+    "imdbRating": 7.9,
+    "synopsis": "A circus' beautiful trapeze artist agrees to marry the leader of side-show performers, but his deformed friends discover she is only marrying him for his inheritance.",
+    "cast": [
+      "Wallace Ford",
+      "Leila Hyams",
+      "Olga Baclanova",
+      "Roscoe Ates"
+    ]
   },
   {
     "movieId": "nosferatu-1922",
@@ -6195,7 +10171,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTAxYjEyMTctZTg3Ni00MGZmLWIxMmMtOGM2NTFiY2U3MmExXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_SX4000.jpg",
     "year": 1922,
     "runtime": 94,
-    "imdbRating": 7.9
+    "imdbRating": 7.9,
+    "synopsis": "Vampire Count Orlok expresses interest in a new residence and real estate agent Hutter's wife.",
+    "cast": [
+      "Max Schreck",
+      "Alexander Granach",
+      "Gustav von Wangenheim",
+      "Greta Schröder"
+    ]
   },
   {
     "movieId": "the-gentlemen-2019",
@@ -6206,7 +10189,14 @@
     "year": 2019,
     "runtime": 113,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An American expat tries to sell off his highly profitable marijuana empire in London, triggering plots, schemes, bribery and blackmail in an attempt to steal his domain out from under him.",
+    "cast": [
+      "Matthew McConaughey",
+      "Charlie Hunnam",
+      "Michelle Dockery",
+      "Jeremy Strong"
+    ]
   },
   {
     "movieId": "raazi-2018",
@@ -6217,7 +10207,14 @@
     "year": 2018,
     "runtime": 138,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A Kashmiri woman agrees to marry a Pakistani army officer in order to spy on Pakistan during the Indo-Pakistan War of 1971.",
+    "cast": [
+      "Alia Bhatt",
+      "Vicky Kaushal",
+      "Rajit Kapoor",
+      "Shishir Sharma"
+    ]
   },
   {
     "movieId": "sound-of-metal-2019",
@@ -6228,7 +10225,14 @@
     "year": 2019,
     "runtime": 120,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A heavy-metal drummer's life is thrown into freefall when he begins to lose his hearing.",
+    "cast": [
+      "Riz Ahmed",
+      "Olivia Cooke",
+      "Paul Raci",
+      "Lauren Ridloff"
+    ]
   },
   {
     "movieId": "forushande-2016",
@@ -6239,7 +10243,14 @@
     "year": 2016,
     "runtime": 124,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "While both participating in a production of \"Death of a Salesman,\" a teacher's wife is assaulted in her new home, which leaves him determined to find the perpetrator over his wife's traumatized objections.",
+    "cast": [
+      "Shahab Hosseini",
+      "Taraneh Alidoosti",
+      "Babak Karimi",
+      "Mina Sadati"
+    ]
   },
   {
     "movieId": "dunkirk-2017",
@@ -6250,7 +10261,14 @@
     "year": 2017,
     "runtime": 106,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Allied soldiers from Belgium, the British Empire, and France are surrounded by the German Army and evacuated during a fierce battle in World War II.",
+    "cast": [
+      "Fionn Whitehead",
+      "Barry Keoghan",
+      "Mark Rylance",
+      "Tom Hardy"
+    ]
   },
   {
     "movieId": "perfetti-sconosciuti-2016",
@@ -6260,7 +10278,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNDQzZmQ5MjItYmJlNy00MGI2LWExMDQtMjBiNjNmMzc5NTk1XkEyXkFqcGdeQXVyNjY1OTY4MTk@._V1_SX4000.jpg",
     "year": 2016,
     "runtime": 96,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "Seven long-time friends get together for a dinner. When they decide to share with each other the content of every text message, email and phone call they receive, many secrets start to unveil and the equilibrium trembles.",
+    "cast": [
+      "Giuseppe Battiston",
+      "Anna Foglietta",
+      "Marco Giallini",
+      "Edoardo Leo"
+    ]
   },
   {
     "movieId": "hidden-figures-2016",
@@ -6271,7 +10296,14 @@
     "year": 2016,
     "runtime": 127,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The story of a team of female African-American mathematicians who served a vital role in NASA during the early years of the U.S. space program.",
+    "cast": [
+      "Taraji P. Henson",
+      "Octavia Spencer",
+      "Janelle Monáe",
+      "Kevin Costner"
+    ]
   },
   {
     "movieId": "paddington-2-2017",
@@ -6282,7 +10314,14 @@
     "year": 2017,
     "runtime": 103,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Paddington (Ben Whishaw), now happily settled with the Brown family and a popular member of the local community, picks up a series of odd jobs to buy the perfect present for his Aunt Lucy's (Imelda Staunton's) 100th birthday, only for the gift to be stolen.",
+    "cast": [
+      "Ben Whishaw",
+      "Hugh Grant",
+      "Hugh Bonneville",
+      "Sally Hawkins"
+    ]
   },
   {
     "movieId": "udta-punjab-2016",
@@ -6293,7 +10332,14 @@
     "year": 2016,
     "runtime": 148,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A story that revolves around drug abuse in the affluent north Indian State of Punjab and how the youth there have succumbed to it en-masse resulting in a socio-economic decline.",
+    "cast": [
+      "Shahid Kapoor",
+      "Alia Bhatt",
+      "Kareena Kapoor",
+      "Diljit Dosanjh"
+    ]
   },
   {
     "movieId": "kubo-and-the-two-strings-2016",
@@ -6304,7 +10350,14 @@
     "year": 2016,
     "runtime": 101,
     "imdbRating": 7.8,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "A young boy named Kubo must locate a magical suit of armour worn by his late father in order to defeat a vengeful spirit from the past.",
+    "cast": [
+      "Charlize Theron",
+      "Art Parkinson",
+      "Matthew McConaughey",
+      "Ralph Fiennes"
+    ]
   },
   {
     "movieId": "m-s-dhoni-the-untold-story-2016",
@@ -6315,7 +10368,14 @@
     "year": 2016,
     "runtime": 184,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The untold story of Mahendra Singh Dhoni's journey from ticket collector to trophy collector - the world-cup-winning captain of the Indian Cricket Team.",
+    "cast": [
+      "Sushant Singh Rajput",
+      "Kiara Advani",
+      "Anupam Kher",
+      "Disha Patani"
+    ]
   },
   {
     "movieId": "manchester-by-the-sea-2016",
@@ -6326,7 +10386,14 @@
     "year": 2016,
     "runtime": 137,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A depressed uncle is asked to take care of his teenage nephew after the boy's father dies.",
+    "cast": [
+      "Casey Affleck",
+      "Michelle Williams",
+      "Kyle Chandler",
+      "Lucas Hedges"
+    ]
   },
   {
     "movieId": "under-sandet-2015",
@@ -6337,7 +10404,14 @@
     "year": 2015,
     "runtime": 100,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "In post-World War II Denmark, a group of young German POWs are forced to clear a beach of thousands of land mines under the watch of a Danish Sergeant who slowly learns to appreciate their plight.",
+    "cast": [
+      "Roland Møller",
+      "Louis Hofmann",
+      "Joel Basman",
+      "Mikkel Boe Følsgaard"
+    ]
   },
   {
     "movieId": "rogue-one-2016",
@@ -6348,7 +10422,14 @@
     "year": 2016,
     "runtime": 133,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The daughter of an Imperial scientist joins the Rebel Alliance in a risky move to steal the plans for the Death Star.",
+    "cast": [
+      "Felicity Jones",
+      "Diego Luna",
+      "Alan Tudyk",
+      "Donnie Yen"
+    ]
   },
   {
     "movieId": "captain-america-civil-war-2016",
@@ -6359,7 +10440,14 @@
     "year": 2016,
     "runtime": 147,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Political involvement in the Avengers' affairs causes a rift between Captain America and Iron Man.",
+    "cast": [
+      "Joe Russo",
+      "Chris Evans",
+      "Robert Downey Jr.",
+      "Scarlett Johansson"
+    ]
   },
   {
     "movieId": "the-hateful-eight-2015",
@@ -6370,7 +10458,14 @@
     "year": 2015,
     "runtime": 168,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In the dead of a Wyoming winter, a bounty hunter and his prisoner find shelter in a cabin currently inhabited by a collection of nefarious characters.",
+    "cast": [
+      "Samuel L. Jackson",
+      "Kurt Russell",
+      "Jennifer Jason Leigh",
+      "Walton Goggins"
+    ]
   },
   {
     "movieId": "little-women-2019",
@@ -6381,7 +10476,14 @@
     "year": 2019,
     "runtime": 135,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Jo March reflects back and forth on her life, telling the beloved story of the March sisters - four young women, each determined to live life on her own terms.",
+    "cast": [
+      "Saoirse Ronan",
+      "Emma Watson",
+      "Florence Pugh",
+      "Eliza Scanlen"
+    ]
   },
   {
     "movieId": "loving-vincent-2017",
@@ -6392,7 +10494,14 @@
     "year": 2017,
     "runtime": 94,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "In a story depicted in oil painted animation, a young man comes to the last hometown of painter Vincent van Gogh (Robert Gulaczyk) to deliver the troubled artist's final letter and ends up investigating his final days there.",
+    "cast": [
+      "Hugh Welchman",
+      "Douglas Booth",
+      "Jerome Flynn",
+      "Robert Gulaczyk"
+    ]
   },
   {
     "movieId": "pride-2014",
@@ -6403,7 +10512,14 @@
     "year": 2014,
     "runtime": 119,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "U.K. gay activists work to help miners during their lengthy strike of the National Union of Mineworkers in the summer of 1984.",
+    "cast": [
+      "Bill Nighy",
+      "Imelda Staunton",
+      "Dominic West",
+      "Paddy Considine"
+    ]
   },
   {
     "movieId": "le-pass-2013",
@@ -6414,7 +10530,14 @@
     "year": 2013,
     "runtime": 130,
     "imdbRating": 7.8,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "An Iranian man deserts his French wife and her two children to return to his homeland. Meanwhile, his wife starts up a new relationship, a reality her husband confronts upon his wife's request for a divorce.",
+    "cast": [
+      "Bérénice Bejo",
+      "Tahar Rahim",
+      "Ali Mosaffa",
+      "Pauline Burlet"
+    ]
   },
   {
     "movieId": "la-grande-bellezza-2013",
@@ -6424,7 +10547,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNjg5NmI3NmUtZDQ2Mi00ZTI0LWE0YzAtOGRhOWJmNDJkOWNkXkEyXkFqcGdeQXVyMzIzNDU1NTY@._V1_SX4000.jpg",
     "year": 2013,
     "runtime": 141,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "Jep Gambardella has seduced his way through the lavish nightlife of Rome for decades, but after his 65th birthday and a shock from the past, Jep looks past the nightclubs and parties to find a timeless landscape of absurd, exquisite beauty.",
+    "cast": [
+      "Toni Servillo",
+      "Carlo Verdone",
+      "Sabrina Ferilli",
+      "Carlo Buccirosso"
+    ]
   },
   {
     "movieId": "the-lunchbox-2013",
@@ -6435,7 +10565,14 @@
     "year": 2013,
     "runtime": 104,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A mistaken delivery in Mumbai's famously efficient lunchbox delivery system connects a young housewife to an older man in the dusk of his life as they build a fantasy world together through notes in the lunchbox.",
+    "cast": [
+      "Irrfan Khan",
+      "Nimrat Kaur",
+      "Nawazuddin Siddiqui",
+      "Lillete Dubey"
+    ]
   },
   {
     "movieId": "vicky-donor-2012",
@@ -6446,7 +10583,14 @@
     "year": 2012,
     "runtime": 126,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A man is brought in by an infertility doctor to supply him with his sperm, where he becomes the biggest sperm donor for his clinic.",
+    "cast": [
+      "Ayushmann Khurrana",
+      "Yami Gautam",
+      "Annu Kapoor",
+      "Dolly Ahluwalia"
+    ]
   },
   {
     "movieId": "big-hero-6-2014",
@@ -6457,7 +10601,14 @@
     "year": 2014,
     "runtime": 102,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A special bond develops between plus-sized inflatable robot Baymax and prodigy Hiro Hamada, who together team up with a group of friends to form a band of high-tech heroes.",
+    "cast": [
+      "Chris Williams",
+      "Ryan Potter",
+      "Scott Adsit",
+      "Jamie Chung"
+    ]
   },
   {
     "movieId": "about-time-2013",
@@ -6468,7 +10619,14 @@
     "year": 2013,
     "runtime": 123,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "At the age of 21, Tim discovers he can travel in time and change what happens and has happened in his own life. His decision to make his world a better place by getting a girlfriend turns out not to be as easy as you might think.",
+    "cast": [
+      "Domhnall Gleeson",
+      "Rachel McAdams",
+      "Bill Nighy",
+      "Lydia Wilson"
+    ]
   },
   {
     "movieId": "english-vinglish-2012",
@@ -6479,7 +10637,14 @@
     "year": 2012,
     "runtime": 134,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A quiet, sweet tempered housewife endures small slights from her well-educated husband and daughter every day because of her inability to speak and understand English.",
+    "cast": [
+      "Sridevi",
+      "Adil Hussain",
+      "Mehdi Nebbou",
+      "Priya Anand"
+    ]
   },
   {
     "movieId": "kaze-tachinu-2013",
@@ -6490,7 +10655,14 @@
     "year": 2013,
     "runtime": 126,
     "imdbRating": 7.8,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A look at the life of Jiro Horikoshi, the man who designed Japanese fighter planes during World War II.",
+    "cast": [
+      "Hideaki Anno",
+      "Hidetoshi Nishijima",
+      "Miori Takimoto",
+      "Masahiko Nishimura"
+    ]
   },
   {
     "movieId": "toy-story-4-2019",
@@ -6501,7 +10673,14 @@
     "year": 2019,
     "runtime": 100,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "When a new toy called \"Forky\" joins Woody and the gang, a road trip alongside old and new friends reveals how big the world can be for a toy.",
+    "cast": [
+      "Tom Hanks",
+      "Tim Allen",
+      "Annie Potts",
+      "Tony Hale"
+    ]
   },
   {
     "movieId": "la-migliore-offerta-2013",
@@ -6512,7 +10691,14 @@
     "year": 2013,
     "runtime": 131,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A lonely art expert working for a mysterious and reclusive heiress finds not only her art worth examining.",
+    "cast": [
+      "Geoffrey Rush",
+      "Jim Sturgess",
+      "Sylvia Hoeks",
+      "Donald Sutherland"
+    ]
   },
   {
     "movieId": "moonrise-kingdom-2012",
@@ -6523,7 +10709,14 @@
     "year": 2012,
     "runtime": 94,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A pair of young lovers flee their New England town, which causes a local search party to fan out to find them.",
+    "cast": [
+      "Jared Gilman",
+      "Kara Hayward",
+      "Bruce Willis",
+      "Bill Murray"
+    ]
   },
   {
     "movieId": "how-to-train-your-dragon-2-2014",
@@ -6534,7 +10727,14 @@
     "year": 2014,
     "runtime": 102,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "When Hiccup and Toothless discover an ice cave that is home to hundreds of new wild dragons and the mysterious Dragon Rider, the two friends find themselves at the center of a battle to protect the peace.",
+    "cast": [
+      "Jay Baruchel",
+      "Cate Blanchett",
+      "Gerard Butler",
+      "Craig Ferguson"
+    ]
   },
   {
     "movieId": "the-big-short-2015",
@@ -6545,7 +10745,14 @@
     "year": 2015,
     "runtime": 130,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In 2006-2007 a group of investors bet against the US mortgage market. In their research they discover how flawed and corrupt the market is.",
+    "cast": [
+      "Christian Bale",
+      "Steve Carell",
+      "Ryan Gosling",
+      "Brad Pitt"
+    ]
   },
   {
     "movieId": "kokuhaku-2010",
@@ -6555,7 +10762,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYzM2OGQ2NzUtNzlmYi00ZDg4LWExODgtMDVmOTU2Yzg2N2U5XkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_SX4000.jpg",
     "year": 2010,
     "runtime": 106,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "A psychological thriller of a grieving mother turned cold-blooded avenger with a twisty master plan to pay back those who were responsible for her daughter's death.",
+    "cast": [
+      "Takako Matsu",
+      "Yoshino Kimura",
+      "Masaki Okada",
+      "Yukito Nishii"
+    ]
   },
   {
     "movieId": "ang-ma-reul-bo-at-da-2010",
@@ -6565,7 +10779,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BZjRmNjc5MTYtYjc3My00ZjNiLTg4YjUtMTQ0ZTFkZmMxMDUzXkEyXkFqcGdeQXVyNDY5MTUyNjU@._V1_SX4000.jpg",
     "year": 2010,
     "runtime": 144,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "A secret agent exacts revenge on a serial killer through a series of captures and releases.",
+    "cast": [
+      "Lee Byung-Hun",
+      "Choi Min-sik",
+      "Jeon Gook-Hwan",
+      "Ho-jin Chun"
+    ]
   },
   {
     "movieId": "the-girl-with-the-dragon-tattoo-2011",
@@ -6576,7 +10797,14 @@
     "year": 2011,
     "runtime": 158,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Journalist Mikael Blomkvist is aided in his search for a woman who has been missing for forty years by Lisbeth Salander, a young computer hacker.",
+    "cast": [
+      "Daniel Craig",
+      "Rooney Mara",
+      "Christopher Plummer",
+      "Stellan Skarsgård"
+    ]
   },
   {
     "movieId": "captain-phillips-2013",
@@ -6587,7 +10815,14 @@
     "year": 2013,
     "runtime": 134,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The true story of Captain Richard Phillips and the 2009 hijacking by Somali pirates of the U.S.-flagged MV Maersk Alabama, the first American cargo ship to be hijacked in two hundred years.",
+    "cast": [
+      "Tom Hanks",
+      "Barkhad Abdi",
+      "Barkhad Abdirahman",
+      "Catherine Keener"
+    ]
   },
   {
     "movieId": "ajeossi-2010",
@@ -6598,7 +10833,14 @@
     "year": 2010,
     "runtime": 119,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A quiet pawnshop keeper with a violent past takes on a drug-and-organ trafficking ring in hope of saving the child who is his only friend.",
+    "cast": [
+      "Won Bin",
+      "Sae-ron Kim",
+      "Tae-hoon Kim",
+      "Hee-won Kim"
+    ]
   },
   {
     "movieId": "straight-outta-compton-2015",
@@ -6609,7 +10851,14 @@
     "year": 2015,
     "runtime": 147,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "The rap group NWA emerges from the mean streets of Compton in Los Angeles, California, in the mid-1980s and revolutionizes Hip Hop culture with their music and tales about life in the hood.",
+    "cast": [
+      "O'Shea Jackson Jr.",
+      "Corey Hawkins",
+      "Jason Mitchell",
+      "Neil Brown Jr."
+    ]
   },
   {
     "movieId": "madeo-2009",
@@ -6620,7 +10869,14 @@
     "year": 2009,
     "runtime": 129,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A mother desperately searches for the killer who framed her son for a girl's horrific murder.",
+    "cast": [
+      "Hye-ja Kim",
+      "Won Bin",
+      "Jin Goo",
+      "Je-mun Yun"
+    ]
   },
   {
     "movieId": "chugyeokja-2008",
@@ -6630,7 +10886,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BY2ViOTU5MDQtZTRiZi00YjViLWFiY2ItOTRhNWYyN2ZiMzUyXkEyXkFqcGdeQXVyNTAyODkwOQ@@._V1_SX4000.jpg",
     "year": 2008,
     "runtime": 125,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "A disgraced ex-policeman who runs a small ring of prostitutes finds himself in a race against time when one of his women goes missing.",
+    "cast": [
+      "Kim Yoon-seok",
+      "Jung-woo Ha",
+      "Yeong-hie Seo",
+      "Yoo-Jeong Kim"
+    ]
   },
   {
     "movieId": "the-hobbit-the-desolation-of-smaug-2013",
@@ -6641,7 +10904,14 @@
     "year": 2013,
     "runtime": 161,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The dwarves, along with Bilbo Baggins and Gandalf the Grey, continue their quest to reclaim Erebor, their homeland, from Smaug. Bilbo Baggins is in possession of a mysterious and magical ring.",
+    "cast": [
+      "Ian McKellen",
+      "Martin Freeman",
+      "Richard Armitage",
+      "Ken Stott"
+    ]
   },
   {
     "movieId": "das-wei-e-band-eine-deutsche-kindergeschichte-2009",
@@ -6652,7 +10922,14 @@
     "year": 2009,
     "runtime": 144,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Strange events happen in a small village in the north of Germany during the years before World War I, which seem to be ritual punishment. Who is responsible?",
+    "cast": [
+      "Christian Friedel",
+      "Ernst Jacobi",
+      "Leonie Benesch",
+      "Ulrich Tukur"
+    ]
   },
   {
     "movieId": "m-n-som-hatar-kvinnor-2009",
@@ -6663,7 +10940,14 @@
     "year": 2009,
     "runtime": 152,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A journalist is aided by a young female hacker in his search for the killer of a woman who has been dead for forty years.",
+    "cast": [
+      "Michael Nyqvist",
+      "Noomi Rapace",
+      "Ewa Fröling",
+      "Lena Endre"
+    ]
   },
   {
     "movieId": "the-trial-of-the-chicago-7-2020",
@@ -6674,7 +10958,14 @@
     "year": 2020,
     "runtime": 129,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "The story of 7 people on trial stemming from various charges surrounding the uprising at the 1968 Democratic National Convention in Chicago, Illinois.",
+    "cast": [
+      "Eddie Redmayne",
+      "Alex Sharp",
+      "Sacha Baron Cohen",
+      "Jeremy Strong"
+    ]
   },
   {
     "movieId": "druk-2020",
@@ -6684,7 +10975,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BOTNjM2Y2ZjgtMDc5NS00MDQ1LTgyNGYtYzYwMTAyNWQwYTMyXkEyXkFqcGdeQXVyMjE4NzUxNDA@._V1_SX4000.jpg",
     "year": 2020,
     "runtime": 117,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "Four friends, all high school teachers, test a theory that they will improve their lives by maintaining a constant level of alcohol in their blood.",
+    "cast": [
+      "Mads Mikkelsen",
+      "Thomas Bo Larsen",
+      "Magnus Millang",
+      "Lars Ranthe"
+    ]
   },
   {
     "movieId": "the-fighter-2010",
@@ -6695,7 +10993,14 @@
     "year": 2010,
     "runtime": 116,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Based on the story of Micky Ward, a fledgling boxer who tries to escape the shadow of his more famous but troubled older boxing brother and get his own shot at greatness.",
+    "cast": [
+      "Mark Wahlberg",
+      "Christian Bale",
+      "Amy Adams",
+      "Melissa Leo"
+    ]
   },
   {
     "movieId": "taken-2008",
@@ -6706,7 +11011,14 @@
     "year": 2008,
     "runtime": 90,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A retired CIA agent travels across Europe and relies on his old skills to save his estranged daughter, who has been kidnapped while on a trip to Paris.",
+    "cast": [
+      "Liam Neeson",
+      "Maggie Grace",
+      "Famke Janssen",
+      "Leland Orser"
+    ]
   },
   {
     "movieId": "the-boy-in-the-striped-pyjamas-2008",
@@ -6717,7 +11029,14 @@
     "year": 2008,
     "runtime": 94,
     "imdbRating": 7.8,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "Through the innocent eyes of Bruno, the eight-year-old son of the commandant at a German concentration camp, a forbidden friendship with a Jewish boy on the other side of the camp fence has startling and unexpected consequences.",
+    "cast": [
+      "Asa Butterfield",
+      "David Thewlis",
+      "Rupert Friend",
+      "Zac Mattoon O'Brien"
+    ]
   },
   {
     "movieId": "once-2007",
@@ -6728,7 +11047,14 @@
     "year": 2007,
     "runtime": 86,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A modern-day musical about a busker and an immigrant and their eventful week in Dublin, as they write, rehearse and record songs that tell their love story.",
+    "cast": [
+      "Glen Hansard",
+      "Markéta Irglová",
+      "Hugh Walsh",
+      "Gerard Hendrick"
+    ]
   },
   {
     "movieId": "the-hobbit-an-unexpected-journey-2012",
@@ -6739,7 +11065,14 @@
     "year": 2012,
     "runtime": 169,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A reluctant Hobbit, Bilbo Baggins, sets out to the Lonely Mountain with a spirited group of dwarves to reclaim their mountain home, and the gold within it from the dragon Smaug.",
+    "cast": [
+      "Martin Freeman",
+      "Ian McKellen",
+      "Richard Armitage",
+      "Andy Serkis"
+    ]
   },
   {
     "movieId": "auf-der-anderen-seite-2007",
@@ -6749,7 +11082,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMzgxMzYyNzAyOF5BMl5BanBnXkFtZTcwODY5MjY3MQ@@._V1_SX4000.jpg",
     "year": 2007,
     "runtime": 122,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "A Turkish man travels to Istanbul to find the daughter of his father's former girlfriend.",
+    "cast": [
+      "Baki Davrak",
+      "Nurgül Yesilçay",
+      "Tuncel Kurtiz",
+      "Nursel Köse"
+    ]
   },
   {
     "movieId": "atonement-2007",
@@ -6760,7 +11100,14 @@
     "year": 2007,
     "runtime": 123,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Thirteen-year-old fledgling writer Briony Tallis irrevocably changes the course of several lives when she accuses her older sister's lover of a crime he did not commit.",
+    "cast": [
+      "Keira Knightley",
+      "James McAvoy",
+      "Brenda Blethyn",
+      "Saoirse Ronan"
+    ]
   },
   {
     "movieId": "drive-2011",
@@ -6771,7 +11118,14 @@
     "year": 2011,
     "runtime": 100,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A mysterious Hollywood stuntman and mechanic moonlights as a getaway driver and finds himself in trouble when he helps out his neighbor.",
+    "cast": [
+      "Ryan Gosling",
+      "Carey Mulligan",
+      "Bryan Cranston",
+      "Albert Brooks"
+    ]
   },
   {
     "movieId": "american-gangster-2007",
@@ -6782,7 +11136,14 @@
     "year": 2007,
     "runtime": 157,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An outcast New York City cop is charged with bringing down Harlem drug lord Frank Lucas, whose real life inspired this partly biographical film.",
+    "cast": [
+      "Denzel Washington",
+      "Russell Crowe",
+      "Chiwetel Ejiofor",
+      "Josh Brolin"
+    ]
   },
   {
     "movieId": "avatar-2009",
@@ -6793,7 +11154,14 @@
     "year": 2009,
     "runtime": 162,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A paraplegic Marine dispatched to the moon Pandora on a unique mission becomes torn between following his orders and protecting the world he feels is his home.",
+    "cast": [
+      "Sam Worthington",
+      "Zoe Saldana",
+      "Sigourney Weaver",
+      "Michelle Rodriguez"
+    ]
   },
   {
     "movieId": "mr-nobody-2009",
@@ -6804,7 +11172,14 @@
     "year": 2009,
     "runtime": 141,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A boy stands on a station platform as a train is about to leave. Should he go with his mother or stay with his father? Infinite possibilities arise from this decision. As long as he doesn't choose, anything is possible.",
+    "cast": [
+      "Jared Leto",
+      "Sarah Polley",
+      "Diane Kruger",
+      "Linh Dan Pham"
+    ]
   },
   {
     "movieId": "apocalypto-2006",
@@ -6815,7 +11190,14 @@
     "year": 2006,
     "runtime": 139,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "As the Mayan kingdom faces its decline, a young man is taken on a perilous journey to a world ruled by fear and oppression.",
+    "cast": [
+      "Gerardo Taracena",
+      "Raoul Max Trujillo",
+      "Dalia Hernández",
+      "Rudy Youngblood"
+    ]
   },
   {
     "movieId": "little-miss-sunshine-2006",
@@ -6826,7 +11208,14 @@
     "year": 2006,
     "runtime": 101,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A family determined to get their young daughter into the finals of a beauty pageant take a cross-country trip in their VW bus.",
+    "cast": [
+      "Valerie Faris",
+      "Steve Carell",
+      "Toni Collette",
+      "Greg Kinnear"
+    ]
   },
   {
     "movieId": "hot-fuzz-2007",
@@ -6837,7 +11226,14 @@
     "year": 2007,
     "runtime": 121,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A skilled London police officer is transferred to a small town with a dark secret.",
+    "cast": [
+      "Simon Pegg",
+      "Nick Frost",
+      "Martin Freeman",
+      "Bill Nighy"
+    ]
   },
   {
     "movieId": "the-curious-case-of-benjamin-button-2008",
@@ -6848,7 +11244,14 @@
     "year": 2008,
     "runtime": 166,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Tells the story of Benjamin Button, a man who starts aging backwards with consequences.",
+    "cast": [
+      "Brad Pitt",
+      "Cate Blanchett",
+      "Tilda Swinton",
+      "Julia Ormond"
+    ]
   },
   {
     "movieId": "veer-zaara-2004",
@@ -6859,7 +11262,14 @@
     "year": 2004,
     "runtime": 192,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Veer-Zaara is a saga of love, separation, courage and sacrifice. A love story that is an inspiration and will remain a legend forever.",
+    "cast": [
+      "Shah Rukh Khan",
+      "Preity Zinta",
+      "Rani Mukerji",
+      "Kirron Kher"
+    ]
   },
   {
     "movieId": "adams-bler-2005",
@@ -6870,7 +11280,14 @@
     "year": 2005,
     "runtime": 94,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A neo-nazi sentenced to community service at a church clashes with the blindly devotional priest.",
+    "cast": [
+      "Ulrich Thomsen",
+      "Mads Mikkelsen",
+      "Nicolas Bro",
+      "Paprika Steen"
+    ]
   },
   {
     "movieId": "pride-prejudice-2005",
@@ -6881,7 +11298,14 @@
     "year": 2005,
     "runtime": 129,
     "imdbRating": 7.8,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "Sparks fly when spirited Elizabeth Bennet meets single, rich, and proud Mr. Darcy. But Mr. Darcy reluctantly finds himself falling in love with a woman beneath his class. Can each overcome their own pride and prejudice?",
+    "cast": [
+      "Keira Knightley",
+      "Matthew Macfadyen",
+      "Brenda Blethyn",
+      "Donald Sutherland"
+    ]
   },
   {
     "movieId": "the-world-s-fastest-indian-2005",
@@ -6892,7 +11316,14 @@
     "year": 2005,
     "runtime": 127,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The story of New Zealander Burt Munro, who spent years rebuilding a 1920 Indian motorcycle, which helped him set the land speed world record at Utah's Bonneville Salt Flats in 1967.",
+    "cast": [
+      "Anthony Hopkins",
+      "Diane Ladd",
+      "Iain Rea",
+      "Tessa Mitchell"
+    ]
   },
   {
     "movieId": "t-ky-goddof-z-zu-2003",
@@ -6903,7 +11334,14 @@
     "year": 2003,
     "runtime": 90,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "On Christmas Eve, three homeless people living on the streets of Tokyo discover a newborn baby among the trash and set out to find its parents.",
+    "cast": [
+      "Shôgo Furuya",
+      "Tôru Emori",
+      "Yoshiaki Umegaki",
+      "Aya Okamoto"
+    ]
   },
   {
     "movieId": "serenity-2005",
@@ -6914,7 +11352,14 @@
     "year": 2005,
     "runtime": 119,
     "imdbRating": 7.8,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "The crew of the ship Serenity try to evade an assassin sent to recapture one of their members who is telepathic.",
+    "cast": [
+      "Nathan Fillion",
+      "Gina Torres",
+      "Chiwetel Ejiofor",
+      "Alan Tudyk"
+    ]
   },
   {
     "movieId": "walk-the-line-2005",
@@ -6925,7 +11370,14 @@
     "year": 2005,
     "runtime": 136,
     "imdbRating": 7.8,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A chronicle of country music legend Johnny Cash's life, from his early days on an Arkansas cotton farm to his rise to fame with Sun Records in Memphis, where he recorded alongside Elvis Presley, Jerry Lee Lewis, and Carl Perkins.",
+    "cast": [
+      "Joaquin Phoenix",
+      "Reese Witherspoon",
+      "Ginnifer Goodwin",
+      "Robert Patrick"
+    ]
   },
   {
     "movieId": "ondskan-2003",
@@ -6935,7 +11387,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMzYwODUxNjkyMF5BMl5BanBnXkFtZTcwODUzNjQyMQ@@._V1_SX4000.jpg",
     "year": 2003,
     "runtime": 113,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "A teenage boy expelled from school for fighting arrives at a boarding school where the systematic bullying of younger students is encouraged as a means to maintain discipline, and decides to fight back.",
+    "cast": [
+      "Andreas Wilson",
+      "Henrik Lundström",
+      "Gustaf Skarsgård",
+      "Linda Zilliacus"
+    ]
   },
   {
     "movieId": "the-notebook-2004",
@@ -6946,7 +11405,14 @@
     "year": 2004,
     "runtime": 123,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A poor yet passionate young man falls in love with a rich young woman, giving her a sense of freedom, but they are soon separated because of their social differences.",
+    "cast": [
+      "Gena Rowlands",
+      "James Garner",
+      "Rachel McAdams",
+      "Ryan Gosling"
+    ]
   },
   {
     "movieId": "diarios-de-motocicleta-2004",
@@ -6957,7 +11423,14 @@
     "year": 2004,
     "runtime": 126,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The dramatization of a motorcycle road trip Che Guevara went on in his youth that showed him his life's calling.",
+    "cast": [
+      "Gael García Bernal",
+      "Rodrigo De la Serna",
+      "Mía Maestro",
+      "Mercedes Morán"
+    ]
   },
   {
     "movieId": "lilja-4-ever-2002",
@@ -6968,7 +11441,14 @@
     "year": 2002,
     "runtime": 109,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Sixteen-year-old Lilja and her only friend, the young boy Volodja, live in Russia, fantasizing about a better life. One day, Lilja falls in love with Andrej, who is going to Sweden, and invites Lilja to come along and start a new life.",
+    "cast": [
+      "Oksana Akinshina",
+      "Artyom Bogucharskiy",
+      "Pavel Ponomaryov",
+      "Lyubov Agapova"
+    ]
   },
   {
     "movieId": "les-triplettes-de-belleville-2003",
@@ -6979,7 +11459,14 @@
     "year": 2003,
     "runtime": 80,
     "imdbRating": 7.8,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "When her grandson is kidnapped during the Tour de France, Madame Souza and her beloved pooch Bruno team up with the Belleville Sisters--an aged song-and-dance team from the days of Fred Astaire--to rescue him.",
+    "cast": [
+      "Michèle Caucheteux",
+      "Jean-Claude Donda",
+      "Michel Robin",
+      "Monica Viegas"
+    ]
   },
   {
     "movieId": "gongdong-gyeongbi-guyeok-jsa-2000",
@@ -6989,7 +11476,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTI1NDA4NTMyN15BMl5BanBnXkFtZTYwNTA2ODc5._V1_SX4000.jpg",
     "year": 2000,
     "runtime": 110,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "After a shooting incident at the North/South Korean border/DMZ leaves 2 North Korean soldiers dead, a neutral Swiss/Swedish team investigates, what actually happened.",
+    "cast": [
+      "Lee Yeong-ae",
+      "Lee Byung-Hun",
+      "Kang-ho Song",
+      "Kim Tae-Woo"
+    ]
   },
   {
     "movieId": "the-count-of-monte-cristo-2002",
@@ -7000,7 +11494,14 @@
     "year": 2002,
     "runtime": 131,
     "imdbRating": 7.8,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A young man, falsely imprisoned by his jealous \"friend\", escapes and uses a hidden treasure to exact his revenge.",
+    "cast": [
+      "Jim Caviezel",
+      "Guy Pearce",
+      "Christopher Adamson",
+      "JB Blanc"
+    ]
   },
   {
     "movieId": "waking-life-2001",
@@ -7011,7 +11512,14 @@
     "year": 2001,
     "runtime": 99,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A man shuffles through a dream meeting various people and discussing the meanings and purposes of the universe.",
+    "cast": [
+      "Ethan Hawke",
+      "Trevor Jack Brooks",
+      "Lorelei Linklater",
+      "Wiley Wiggins"
+    ]
   },
   {
     "movieId": "remember-the-titans-2000",
@@ -7022,7 +11530,14 @@
     "year": 2000,
     "runtime": 113,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The true story of a newly appointed African-American coach and his high school team on their first season as a racially integrated unit.",
+    "cast": [
+      "Denzel Washington",
+      "Will Patton",
+      "Wood Harris",
+      "Ryan Hurst"
+    ]
   },
   {
     "movieId": "wo-hu-cang-long-2000",
@@ -7033,7 +11548,14 @@
     "year": 2000,
     "runtime": 120,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A young Chinese warrior steals a sword from a famed swordsman and then escapes into a world of romantic adventure with a mysterious man in the frontier of the nation.",
+    "cast": [
+      "Yun-Fat Chow",
+      "Michelle Yeoh",
+      "Ziyi Zhang",
+      "Chen Chang"
+    ]
   },
   {
     "movieId": "todo-sobre-mi-madre-1999",
@@ -7044,7 +11566,14 @@
     "year": 1999,
     "runtime": 101,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Young Esteban wants to become a writer and also to discover the identity of his second mother, a trans woman, carefully concealed by his mother Manuela.",
+    "cast": [
+      "Cecilia Roth",
+      "Marisa Paredes",
+      "Candela Peña",
+      "Antonia San Juan"
+    ]
   },
   {
     "movieId": "cast-away-2000",
@@ -7055,7 +11584,14 @@
     "year": 2000,
     "runtime": 143,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A FedEx executive undergoes a physical and emotional transformation after crash landing on a deserted island.",
+    "cast": [
+      "Tom Hanks",
+      "Helen Hunt",
+      "Paul Sanchez",
+      "Lari White"
+    ]
   },
   {
     "movieId": "the-boondock-saints-1999",
@@ -7066,7 +11602,14 @@
     "year": 1999,
     "runtime": 108,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Two Irish Catholic brothers become vigilantes and wipe out Boston's criminal underworld in the name of God.",
+    "cast": [
+      "Willem Dafoe",
+      "Sean Patrick Flanery",
+      "Norman Reedus",
+      "David Della Rocco"
+    ]
   },
   {
     "movieId": "the-insider-1999",
@@ -7077,7 +11620,14 @@
     "year": 1999,
     "runtime": 157,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A research chemist comes under personal and professional attack when he decides to appear in a 60 Minutes exposé on Big Tobacco.",
+    "cast": [
+      "Russell Crowe",
+      "Al Pacino",
+      "Christopher Plummer",
+      "Diane Venora"
+    ]
   },
   {
     "movieId": "october-sky-1999",
@@ -7088,7 +11638,14 @@
     "year": 1999,
     "runtime": 108,
     "imdbRating": 7.8,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "The true story of Homer Hickam, a coal miner's son who was inspired by the first Sputnik launch to take up rocketry against his father's wishes.",
+    "cast": [
+      "Jake Gyllenhaal",
+      "Chris Cooper",
+      "Laura Dern",
+      "Chris Owen"
+    ]
   },
   {
     "movieId": "shrek-2001",
@@ -7099,7 +11656,14 @@
     "year": 2001,
     "runtime": 90,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A mean lord exiles fairytale creatures to the swamp of a grumpy ogre, who must go on a quest and rescue a princess for the lord in order to get his land back.",
+    "cast": [
+      "Vicky Jenson",
+      "Mike Myers",
+      "Eddie Murphy",
+      "Cameron Diaz"
+    ]
   },
   {
     "movieId": "titanic-1997",
@@ -7110,7 +11674,14 @@
     "year": 1997,
     "runtime": 194,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A seventeen-year-old aristocrat falls in love with a kind but poor artist aboard the luxurious, ill-fated R.M.S. Titanic.",
+    "cast": [
+      "Leonardo DiCaprio",
+      "Kate Winslet",
+      "Billy Zane",
+      "Kathy Bates"
+    ]
   },
   {
     "movieId": "hana-bi-1997",
@@ -7120,7 +11691,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BODk4MzE5NjgtN2ZhOS00YTdkLTg0YzktMmE1MTkxZmMyMWI2L2ltYWdlXkEyXkFqcGdeQXVyNTAyODkwOQ@@._V1_SX4000.jpg",
     "year": 1997,
     "runtime": 103,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "Nishi leaves the police in the face of harrowing personal and professional difficulties. Spiraling into depression, he makes questionable decisions.",
+    "cast": [
+      "Takeshi Kitano",
+      "Kayoko Kishimoto",
+      "Ren Osugi",
+      "Susumu Terajima"
+    ]
   },
   {
     "movieId": "gattaca-1997",
@@ -7131,7 +11709,14 @@
     "year": 1997,
     "runtime": 106,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A genetically inferior man assumes the identity of a superior one in order to pursue his lifelong dream of space travel.",
+    "cast": [
+      "Ethan Hawke",
+      "Uma Thurman",
+      "Jude Law",
+      "Gore Vidal"
+    ]
   },
   {
     "movieId": "the-game-1997",
@@ -7142,7 +11727,14 @@
     "year": 1997,
     "runtime": 129,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "After a wealthy banker is given an opportunity to participate in a mysterious game, his life is turned upside down when he becomes unable to distinguish between the game and reality.",
+    "cast": [
+      "Michael Douglas",
+      "Deborah Kara Unger",
+      "Sean Penn",
+      "James Rebhorn"
+    ]
   },
   {
     "movieId": "breaking-the-waves-1996",
@@ -7153,7 +11745,14 @@
     "year": 1996,
     "runtime": 159,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Oilman Jan is paralyzed in an accident. His wife, who prayed for his return, feels guilty; even more, when Jan urges her to have sex with another.",
+    "cast": [
+      "Emily Watson",
+      "Stellan Skarsgård",
+      "Katrin Cartlidge",
+      "Jean-Marc Barr"
+    ]
   },
   {
     "movieId": "ed-wood-1994",
@@ -7164,7 +11763,14 @@
     "year": 1994,
     "runtime": 127,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Ambitious but troubled movie director Edward D. Wood Jr. tries his best to fulfill his dreams, despite his lack of talent.",
+    "cast": [
+      "Johnny Depp",
+      "Martin Landau",
+      "Sarah Jessica Parker",
+      "Patricia Arquette"
+    ]
   },
   {
     "movieId": "what-s-eating-gilbert-grape-1993",
@@ -7175,7 +11781,14 @@
     "year": 1993,
     "runtime": 118,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A young man in a small Midwestern town struggles to care for his mentally-disabled younger brother and morbidly obese mother while attempting to pursue his own happiness.",
+    "cast": [
+      "Johnny Depp",
+      "Leonardo DiCaprio",
+      "Juliette Lewis",
+      "Mary Steenburgen"
+    ]
   },
   {
     "movieId": "tombstone-1993",
@@ -7186,7 +11799,14 @@
     "year": 1993,
     "runtime": 130,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A successful lawman's plans to retire anonymously in Tombstone, Arizona are disrupted by the kind of outlaws he was famous for eliminating.",
+    "cast": [
+      "Kevin Jarre",
+      "Kurt Russell",
+      "Val Kilmer",
+      "Sam Elliott"
+    ]
   },
   {
     "movieId": "the-sandlot-1993",
@@ -7197,7 +11817,14 @@
     "year": 1993,
     "runtime": 101,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In the summer of 1962, a new kid in town is taken under the wing of a young baseball prodigy and his rowdy team, resulting in many adventures.",
+    "cast": [
+      "Tom Guiry",
+      "Mike Vitar",
+      "Art LaFleur",
+      "Patrick Renna"
+    ]
   },
   {
     "movieId": "the-remains-of-the-day-1993",
@@ -7208,7 +11835,14 @@
     "year": 1993,
     "runtime": 134,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A butler who sacrificed body and soul to service in the years leading up to World War II realizes too late how misguided his loyalty was to his lordly employer.",
+    "cast": [
+      "Anthony Hopkins",
+      "Emma Thompson",
+      "John Haycraft",
+      "Christopher Reeve"
+    ]
   },
   {
     "movieId": "naked-1993",
@@ -7218,7 +11852,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMjA3Y2I4NjAtMDQyZS00ZGJhLWEwMzgtODBiNzE5Zjc1Nzk1L2ltYWdlXkEyXkFqcGdeQXVyNTc2MDU0NDE@._V1_SX4000.jpg",
     "year": 1993,
     "runtime": 132,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "Parallel tales of two sexually obsessed men, one hurting and annoying women physically and mentally, one wandering around the city talking to strangers and experiencing dimensions of life.",
+    "cast": [
+      "David Thewlis",
+      "Lesley Sharp",
+      "Katrin Cartlidge",
+      "Greg Cruttwell"
+    ]
   },
   {
     "movieId": "the-fugitive-1993",
@@ -7229,7 +11870,14 @@
     "year": 1993,
     "runtime": 130,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Dr. Richard Kimble, unjustly accused of murdering his wife, must find the real killer while being the target of a nationwide manhunt led by a seasoned U.S. Marshal.",
+    "cast": [
+      "Harrison Ford",
+      "Tommy Lee Jones",
+      "Sela Ward",
+      "Julianne Moore"
+    ]
   },
   {
     "movieId": "a-bronx-tale-1993",
@@ -7240,7 +11888,14 @@
     "year": 1993,
     "runtime": 121,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A father becomes worried when a local gangster befriends his son in the Bronx in the 1960s.",
+    "cast": [
+      "Robert De Niro",
+      "Chazz Palminteri",
+      "Lillo Brancato",
+      "Francis Capra"
+    ]
   },
   {
     "movieId": "batman-mask-of-the-phantasm-1993",
@@ -7251,7 +11906,14 @@
     "year": 1993,
     "runtime": 76,
     "imdbRating": 7.8,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "Batman is wrongly implicated in a series of murders of mob bosses actually done by a new vigilante assassin.",
+    "cast": [
+      "Boyd Kirkland",
+      "Frank Paur",
+      "Dan Riba",
+      "Eric Radomski"
+    ]
   },
   {
     "movieId": "lat-sau-san-taam-1992",
@@ -7262,7 +11924,14 @@
     "year": 1992,
     "runtime": 128,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A tough-as-nails cop teams up with an undercover agent to shut down a sinister mobster and his crew.",
+    "cast": [
+      "Yun-Fat Chow",
+      "Tony Chiu-Wai Leung",
+      "Teresa Mo",
+      "Philip Chan"
+    ]
   },
   {
     "movieId": "night-on-earth-1991",
@@ -7273,7 +11942,14 @@
     "year": 1991,
     "runtime": 129,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "An anthology of 5 different cab drivers in 5 American and European cities and their remarkable fares on the same eventful night.",
+    "cast": [
+      "Winona Ryder",
+      "Gena Rowlands",
+      "Lisanne Falk",
+      "Alan Randolph Scott"
+    ]
   },
   {
     "movieId": "la-double-vie-de-v-ronique-1991",
@@ -7284,7 +11960,14 @@
     "year": 1991,
     "runtime": 98,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Two parallel stories about two identical women; one living in Poland, the other in France. They don't know each other, but their lives are nevertheless profoundly connected.",
+    "cast": [
+      "Irène Jacob",
+      "Wladyslaw Kowalski",
+      "Halina Gryglaszewska",
+      "Kalina Jedrusik"
+    ]
   },
   {
     "movieId": "boyz-n-the-hood-1991",
@@ -7295,7 +11978,14 @@
     "year": 1991,
     "runtime": 112,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Follows the lives of three young males living in the Crenshaw ghetto of Los Angeles, dissecting questions of race, relationships, violence, and future prospects.",
+    "cast": [
+      "Cuba Gooding Jr.",
+      "Laurence Fishburne",
+      "Hudhail Al-Amir",
+      "Lloyd Avery II"
+    ]
   },
   {
     "movieId": "misery-1990",
@@ -7306,7 +11996,14 @@
     "year": 1990,
     "runtime": 107,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "After a famous author is rescued from a car crash by a fan of his novels, he comes to realize that the care he is receiving is only the beginning of a nightmare of captivity and abuse.",
+    "cast": [
+      "James Caan",
+      "Kathy Bates",
+      "Richard Farnsworth",
+      "Frances Sternhagen"
+    ]
   },
   {
     "movieId": "awakenings-1990",
@@ -7317,7 +12014,14 @@
     "year": 1990,
     "runtime": 121,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The victims of an encephalitis epidemic many years ago have been catatonic ever since, but now a new drug offers the prospect of reviving them.",
+    "cast": [
+      "Robert De Niro",
+      "Robin Williams",
+      "Julie Kavner",
+      "Ruth Nelson"
+    ]
   },
   {
     "movieId": "majo-no-takky-bin-1989",
@@ -7328,7 +12032,14 @@
     "year": 1989,
     "runtime": 103,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A young witch, on her mandatory year of independent life, finds fitting into a new community difficult while she supports herself by running an air courier service.",
+    "cast": [
+      "Kirsten Dunst",
+      "Minami Takayama",
+      "Rei Sakuma",
+      "Kappei Yamaguchi"
+    ]
   },
   {
     "movieId": "glory-1989",
@@ -7339,7 +12050,14 @@
     "year": 1989,
     "runtime": 122,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Robert Gould Shaw leads the U.S. Civil War's first all-black volunteer company, fighting prejudices from both his own Union Army, and the Confederates.",
+    "cast": [
+      "Matthew Broderick",
+      "Denzel Washington",
+      "Cary Elwes",
+      "Morgan Freeman"
+    ]
   },
   {
     "movieId": "dip-huet-seung-hung-1989",
@@ -7350,7 +12068,14 @@
     "year": 1989,
     "runtime": 111,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A disillusioned assassin accepts one last hit in hopes of using his earnings to restore vision to a singer he accidentally blinded.",
+    "cast": [
+      "Yun-Fat Chow",
+      "Danny Lee",
+      "Sally Yeh",
+      "Kong Chu"
+    ]
   },
   {
     "movieId": "back-to-the-future-part-ii-1989",
@@ -7361,7 +12086,14 @@
     "year": 1989,
     "runtime": 108,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "After visiting 2015, Marty McFly must repeat his visit to 1955 to prevent disastrous changes to 1985...without interfering with his first trip.",
+    "cast": [
+      "Michael J. Fox",
+      "Christopher Lloyd",
+      "Lea Thompson",
+      "Thomas F. Wilson"
+    ]
   },
   {
     "movieId": "mississippi-burning-1988",
@@ -7372,7 +12104,14 @@
     "year": 1988,
     "runtime": 128,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Two F.B.I. Agents with wildly different styles arrive in Mississippi to investigate the disappearance of some civil rights activists.",
+    "cast": [
+      "Gene Hackman",
+      "Willem Dafoe",
+      "Frances McDormand",
+      "Brad Dourif"
+    ]
   },
   {
     "movieId": "predator-1987",
@@ -7383,7 +12122,14 @@
     "year": 1987,
     "runtime": 107,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A team of commandos on a mission in a Central American jungle find themselves hunted by an extraterrestrial warrior.",
+    "cast": [
+      "Arnold Schwarzenegger",
+      "Carl Weathers",
+      "Kevin Peter Hall",
+      "Elpidia Carrillo"
+    ]
   },
   {
     "movieId": "evil-dead-ii-1987",
@@ -7394,7 +12140,14 @@
     "year": 1987,
     "runtime": 84,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The lone survivor of an onslaught of flesh-possessing spirits holes up in a cabin with a group of strangers while the demons continue their attack.",
+    "cast": [
+      "Bruce Campbell",
+      "Sarah Berry",
+      "Dan Hicks",
+      "Kassie Wesley DePaiva"
+    ]
   },
   {
     "movieId": "ferris-bueller-s-day-off-1986",
@@ -7405,7 +12158,14 @@
     "year": 1986,
     "runtime": 103,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A high school wise guy is determined to have a day off from school, despite what the Principal thinks of that.",
+    "cast": [
+      "Matthew Broderick",
+      "Alan Ruck",
+      "Mia Sara",
+      "Jeffrey Jones"
+    ]
   },
   {
     "movieId": "down-by-law-1986",
@@ -7416,7 +12176,14 @@
     "year": 1986,
     "runtime": 107,
     "imdbRating": 7.8,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Two men are framed and sent to jail, where they meet a murderer who helps them escape and leave the state.",
+    "cast": [
+      "Tom Waits",
+      "John Lurie",
+      "Roberto Benigni",
+      "Nicoletta Braschi"
+    ]
   },
   {
     "movieId": "the-goonies-1985",
@@ -7427,7 +12194,14 @@
     "year": 1985,
     "runtime": 114,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A group of young misfits called The Goonies discover an ancient map and set out on an adventure to find a legendary pirate's long-lost treasure.",
+    "cast": [
+      "Sean Astin",
+      "Josh Brolin",
+      "Jeff Cohen",
+      "Corey Feldman"
+    ]
   },
   {
     "movieId": "the-color-purple-1985",
@@ -7438,7 +12212,14 @@
     "year": 1985,
     "runtime": 154,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A black Southern woman struggles to find her identity after suffering abuse from her father and others over four decades.",
+    "cast": [
+      "Danny Glover",
+      "Whoopi Goldberg",
+      "Oprah Winfrey",
+      "Margaret Avery"
+    ]
   },
   {
     "movieId": "the-breakfast-club-1985",
@@ -7449,7 +12230,14 @@
     "year": 1985,
     "runtime": 97,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Five high school students meet in Saturday detention and discover how they have a lot more in common than they thought.",
+    "cast": [
+      "Emilio Estevez",
+      "Judd Nelson",
+      "Molly Ringwald",
+      "Ally Sheedy"
+    ]
   },
   {
     "movieId": "the-killing-fields-1984",
@@ -7460,7 +12248,14 @@
     "year": 1984,
     "runtime": 141,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A journalist is trapped in Cambodia during tyrant Pol Pot's bloody 'Year Zero' cleansing campaign, which claimed the lives of two million 'undesirable' civilians.",
+    "cast": [
+      "Sam Waterston",
+      "Haing S. Ngor",
+      "John Malkovich",
+      "Julian Sands"
+    ]
   },
   {
     "movieId": "ghostbusters-1984",
@@ -7471,7 +12266,14 @@
     "year": 1984,
     "runtime": 105,
     "imdbRating": 7.8,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Three former parapsychology professors set up shop as a unique ghost removal service.",
+    "cast": [
+      "Bill Murray",
+      "Dan Aykroyd",
+      "Sigourney Weaver",
+      "Harold Ramis"
+    ]
   },
   {
     "movieId": "the-right-stuff-1983",
@@ -7482,7 +12284,14 @@
     "year": 1983,
     "runtime": 193,
     "imdbRating": 7.8,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "The story of the original Mercury 7 astronauts and their macho, seat-of-the-pants approach to the space program.",
+    "cast": [
+      "Sam Shepard",
+      "Scott Glenn",
+      "Ed Harris",
+      "Dennis Quaid"
+    ]
   },
   {
     "movieId": "the-king-of-comedy-1982",
@@ -7493,7 +12302,14 @@
     "year": 1982,
     "runtime": 109,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Rupert Pupkin is a passionate yet unsuccessful comic who craves nothing more than to be in the spotlight and to achieve this, he stalks and kidnaps his idol to take the spotlight for himself.",
+    "cast": [
+      "Robert De Niro",
+      "Jerry Lewis",
+      "Diahnne Abbott",
+      "Sandra Bernhard"
+    ]
   },
   {
     "movieId": "e-t-the-extra-terrestrial-1982",
@@ -7504,7 +12320,14 @@
     "year": 1982,
     "runtime": 115,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A troubled child summons the courage to help a friendly alien escape Earth and return to his home world.",
+    "cast": [
+      "Henry Thomas",
+      "Drew Barrymore",
+      "Peter Coyote",
+      "Dee Wallace"
+    ]
   },
   {
     "movieId": "kramer-vs-kramer-1979",
@@ -7515,7 +12338,14 @@
     "year": 1979,
     "runtime": 105,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Ted Kramer's wife leaves him, allowing for a lost bond to be rediscovered between Ted and his son, Billy. But a heated custody battle ensues over the divorced couple's son, deepening the wounds left by the separation.",
+    "cast": [
+      "Dustin Hoffman",
+      "Meryl Streep",
+      "Jane Alexander",
+      "Justin Henry"
+    ]
   },
   {
     "movieId": "days-of-heaven-1978",
@@ -7526,7 +12356,14 @@
     "year": 1978,
     "runtime": 94,
     "imdbRating": 7.8,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "A hot-tempered farm laborer convinces the woman he loves to marry their rich but dying boss so that they can have a claim to his fortune.",
+    "cast": [
+      "Richard Gere",
+      "Brooke Adams",
+      "Sam Shepard",
+      "Linda Manz"
+    ]
   },
   {
     "movieId": "the-outlaw-josey-wales-1976",
@@ -7537,7 +12374,14 @@
     "year": 1976,
     "runtime": 135,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Missouri farmer Josey Wales joins a Confederate guerrilla unit and winds up on the run from the Union soldiers who murdered his family.",
+    "cast": [
+      "Clint Eastwood",
+      "Sondra Locke",
+      "Chief Dan George",
+      "Bill McKinney"
+    ]
   },
   {
     "movieId": "the-man-who-would-be-king-1975",
@@ -7548,7 +12392,14 @@
     "year": 1975,
     "runtime": 129,
     "imdbRating": 7.8,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "Two British former soldiers decide to set themselves up as Kings in Kafiristan, a land where no white man has set foot since Alexander the Great.",
+    "cast": [
+      "Sean Connery",
+      "Michael Caine",
+      "Christopher Plummer",
+      "Saeed Jaffrey"
+    ]
   },
   {
     "movieId": "the-conversation-1974",
@@ -7559,7 +12410,14 @@
     "year": 1974,
     "runtime": 113,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A paranoid, secretive surveillance expert has a crisis of conscience when he suspects that the couple he is spying on will be murdered.",
+    "cast": [
+      "Gene Hackman",
+      "John Cazale",
+      "Allen Garfield",
+      "Frederic Forrest"
+    ]
   },
   {
     "movieId": "la-plan-te-sauvage-1973",
@@ -7570,7 +12428,14 @@
     "year": 1973,
     "runtime": 72,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "On a faraway planet where blue giants rule, oppressed humanoids rebel against their machine-like leaders.",
+    "cast": [
+      "Barry Bostwick",
+      "Jennifer Drake",
+      "Eric Baugin",
+      "Jean Topart"
+    ]
   },
   {
     "movieId": "the-day-of-the-jackal-1973",
@@ -7581,7 +12446,14 @@
     "year": 1973,
     "runtime": 143,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A professional assassin codenamed \"Jackal\" plots to kill Charles de Gaulle, the President of France.",
+    "cast": [
+      "Edward Fox",
+      "Terence Alexander",
+      "Michel Auclair",
+      "Alan Badel"
+    ]
   },
   {
     "movieId": "badlands-1973",
@@ -7592,7 +12464,14 @@
     "year": 1973,
     "runtime": 94,
     "imdbRating": 7.8,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "An impressionable teenage girl from a dead-end town and her older greaser boyfriend embark on a killing spree in the South Dakota badlands.",
+    "cast": [
+      "Martin Sheen",
+      "Sissy Spacek",
+      "Warren Oates",
+      "Ramon Bieri"
+    ]
   },
   {
     "movieId": "cabaret-1972",
@@ -7603,7 +12482,14 @@
     "year": 1972,
     "runtime": 124,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A female girlie club entertainer in Weimar Republic era Berlin romances two men while the Nazi Party rises to power around them.",
+    "cast": [
+      "Liza Minnelli",
+      "Michael York",
+      "Helmut Griem",
+      "Joel Grey"
+    ]
   },
   {
     "movieId": "willy-wonka-the-chocolate-factory-1971",
@@ -7614,7 +12500,14 @@
     "year": 1971,
     "runtime": 100,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A poor but hopeful boy seeks one of the five coveted golden tickets that will send him on a tour of Willy Wonka's mysterious chocolate factory.",
+    "cast": [
+      "Gene Wilder",
+      "Jack Albertson",
+      "Peter Ostrum",
+      "Roy Kinnear"
+    ]
   },
   {
     "movieId": "midnight-cowboy-1969",
@@ -7625,7 +12518,14 @@
     "year": 1969,
     "runtime": 113,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A naive hustler travels from Texas to New York City to seek personal fortune, finding a new friend in the process.",
+    "cast": [
+      "Dustin Hoffman",
+      "Jon Voight",
+      "Sylvia Miles",
+      "John McGiver"
+    ]
   },
   {
     "movieId": "wait-until-dark-1967",
@@ -7635,7 +12535,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTQyNTAzOTI3NF5BMl5BanBnXkFtZTcwNTM0Mjg0Mg@@._V1_SX4000.jpg",
     "year": 1967,
     "runtime": 108,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "A recently blinded woman is terrorized by a trio of thugs while they search for a heroin-stuffed doll they believe is in her apartment.",
+    "cast": [
+      "Audrey Hepburn",
+      "Alan Arkin",
+      "Richard Crenna",
+      "Efrem Zimbalist Jr."
+    ]
   },
   {
     "movieId": "guess-who-s-coming-to-dinner-1967",
@@ -7645,7 +12552,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BZTVmMTk2NjUtNjVjNC00OTcwLWE4OWEtNzA4Mjk1ZmIwNDExXkEyXkFqcGdeQXVyNjUwNzk3NDc@._V1_SX4000.jpg",
     "year": 1967,
     "runtime": 108,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "A couple's attitudes are challenged when their daughter introduces them to her African-American fiancé.",
+    "cast": [
+      "Spencer Tracy",
+      "Sidney Poitier",
+      "Katharine Hepburn",
+      "Katharine Houghton"
+    ]
   },
   {
     "movieId": "bonnie-and-clyde-1967",
@@ -7656,7 +12570,14 @@
     "year": 1967,
     "runtime": 111,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Bored waitress Bonnie Parker falls in love with an ex-con named Clyde Barrow and together they start a violent crime spree through the country, stealing cars and robbing banks.",
+    "cast": [
+      "Warren Beatty",
+      "Faye Dunaway",
+      "Michael J. Pollard",
+      "Gene Hackman"
+    ]
   },
   {
     "movieId": "my-fair-lady-1964",
@@ -7667,7 +12588,14 @@
     "year": 1964,
     "runtime": 170,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Snobbish phonetics Professor Henry Higgins agrees to a wager that he can make flower girl Eliza Doolittle presentable in high society.",
+    "cast": [
+      "Audrey Hepburn",
+      "Rex Harrison",
+      "Stanley Holloway",
+      "Wilfrid Hyde-White"
+    ]
   },
   {
     "movieId": "mary-poppins-1964",
@@ -7678,7 +12606,14 @@
     "year": 1964,
     "runtime": 139,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In turn of the century London, a magical nanny employs music and adventure to help two neglected children become closer to their father.",
+    "cast": [
+      "Julie Andrews",
+      "Dick Van Dyke",
+      "David Tomlinson",
+      "Glynis Johns"
+    ]
   },
   {
     "movieId": "the-longest-day-1962",
@@ -7689,7 +12624,14 @@
     "year": 1962,
     "runtime": 178,
     "imdbRating": 7.8,
-    "rated": "G"
+    "rated": "G",
+    "synopsis": "The events of D-Day, told on a grand scale from both the Allied and German points of view.",
+    "cast": [
+      "Andrew Marton",
+      "Gerd Oswald",
+      "Bernhard Wicki",
+      "Darryl F. Zanuck"
+    ]
   },
   {
     "movieId": "jules-et-jim-1962",
@@ -7699,7 +12641,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BZTM1MTRiNDctMTFiMC00NGM1LTkyMWQtNTY1M2JjZDczOWQ3XkEyXkFqcGdeQXVyMDI3OTIzOA@@._V1_SX4000.jpg",
     "year": 1962,
     "runtime": 105,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "Decades of a love triangle concerning two friends and an impulsive woman.",
+    "cast": [
+      "Jeanne Moreau",
+      "Oskar Werner",
+      "Henri Serre",
+      "Vanna Urbino"
+    ]
   },
   {
     "movieId": "the-innocents-1961",
@@ -7710,7 +12659,14 @@
     "year": 1961,
     "runtime": 100,
     "imdbRating": 7.8,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A young governess for two children becomes convinced that the house and grounds are haunted.",
+    "cast": [
+      "Deborah Kerr",
+      "Peter Wyngarde",
+      "Megs Jenkins",
+      "Michael Redgrave"
+    ]
   },
   {
     "movieId": "bout-de-souffle-1960",
@@ -7721,7 +12677,14 @@
     "year": 1960,
     "runtime": 90,
     "imdbRating": 7.8,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A small-time thief steals a car and impulsively murders a motorcycle policeman. Wanted by the authorities, he reunites with a hip American journalism student and attempts to persuade her to run away with him to Italy.",
+    "cast": [
+      "Jean-Paul Belmondo",
+      "Jean Seberg",
+      "Daniel Boulanger",
+      "Henri-Jacques Huet"
+    ]
   },
   {
     "movieId": "red-river-1948",
@@ -7732,7 +12695,14 @@
     "year": 1948,
     "runtime": 133,
     "imdbRating": 7.8,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "Dunson leads a cattle drive, the culmination of over 14 years of work, to its destination in Missouri. But his tyrannical behavior along the way causes a mutiny, led by his adopted son.",
+    "cast": [
+      "Arthur Rosson",
+      "John Wayne",
+      "Montgomery Clift",
+      "Joanne Dru"
+    ]
   },
   {
     "movieId": "key-largo-1948",
@@ -7742,7 +12712,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BODI3YzNiZTUtYjEyZS00ODkwLWE2ZDUtNGJmMTNiYTc4ZTM4XkEyXkFqcGdeQXVyMDI2NDg0NQ@@._V1_SX4000.jpg",
     "year": 1948,
     "runtime": 100,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "A man visits his war buddy's family hotel and finds a gangster running things. As a hurricane approaches, the two end up confronting each other.",
+    "cast": [
+      "Humphrey Bogart",
+      "Edward G. Robinson",
+      "Lauren Bacall",
+      "Lionel Barrymore"
+    ]
   },
   {
     "movieId": "to-have-and-have-not-1944",
@@ -7753,7 +12730,14 @@
     "year": 1944,
     "runtime": 100,
     "imdbRating": 7.8,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "During World War II, American expatriate Harry Morgan helps transport a French Resistance leader and his beautiful wife to Martinique while romancing a sensuous lounge singer.",
+    "cast": [
+      "Humphrey Bogart",
+      "Lauren Bacall",
+      "Walter Brennan",
+      "Dolores Moran"
+    ]
   },
   {
     "movieId": "shadow-of-a-doubt-1943",
@@ -7764,7 +12748,14 @@
     "year": 1943,
     "runtime": 108,
     "imdbRating": 7.8,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "A young girl, overjoyed when her favorite uncle comes to visit the family, slowly begins to suspect that he is in fact the \"Merry Widow\" killer sought by the authorities.",
+    "cast": [
+      "Teresa Wright",
+      "Joseph Cotten",
+      "Macdonald Carey",
+      "Henry Travers"
+    ]
   },
   {
     "movieId": "stagecoach-1939",
@@ -7775,7 +12766,14 @@
     "year": 1939,
     "runtime": 96,
     "imdbRating": 7.8,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A group of people traveling on a stagecoach find their journey complicated by the threat of Geronimo and learn something about each other in the process.",
+    "cast": [
+      "John Wayne",
+      "Claire Trevor",
+      "Andy Devine",
+      "John Carradine"
+    ]
   },
   {
     "movieId": "the-lady-vanishes-1938",
@@ -7785,7 +12783,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNjk3YzFjYTktOGY0ZS00Y2EwLTk2NTctYTI1Nzc2OWNiN2I4XkEyXkFqcGdeQXVyNzM0MTUwNTY@._V1_SX4000.jpg",
     "year": 1938,
     "runtime": 96,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "While travelling in continental Europe, a rich young playgirl realizes that an elderly lady seems to have disappeared from the train.",
+    "cast": [
+      "Margaret Lockwood",
+      "Michael Redgrave",
+      "Paul Lukas",
+      "May Whitty"
+    ]
   },
   {
     "movieId": "bringing-up-baby-1938",
@@ -7796,7 +12801,14 @@
     "year": 1938,
     "runtime": 102,
     "imdbRating": 7.8,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "While trying to secure a $1 million donation for his museum, a befuddled paleontologist is pursued by a flighty and often irritating heiress and her pet leopard, Baby.",
+    "cast": [
+      "Katharine Hepburn",
+      "Cary Grant",
+      "Charles Ruggles",
+      "Walter Catlett"
+    ]
   },
   {
     "movieId": "bride-of-frankenstein-1935",
@@ -7806,7 +12818,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BOTUzMzAzMzEzNV5BMl5BanBnXkFtZTgwOTg1NTAwMjE@._V1_SX4000.jpg",
     "year": 1935,
     "runtime": 75,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "Mary Shelley reveals the main characters of her novel survived: Dr. Frankenstein, goaded by an even madder scientist, builds his monster a mate.",
+    "cast": [
+      "Boris Karloff",
+      "Elsa Lanchester",
+      "Colin Clive",
+      "Valerie Hobson"
+    ]
   },
   {
     "movieId": "duck-soup-1933",
@@ -7816,7 +12835,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYmYxZGU2NWYtNzQxZS00NmEyLWIzN2YtMDk5MWM0ODc5ZTE4XkEyXkFqcGdeQXVyNTA4NzY1MzY@._V1_SX4000.jpg",
     "year": 1933,
     "runtime": 69,
-    "imdbRating": 7.8
+    "imdbRating": 7.8,
+    "synopsis": "Rufus T. Firefly is named president/dictator of bankrupt Freedonia and declares war on neighboring Sylvania over the love of wealthy Mrs. Teasdale.",
+    "cast": [
+      "Groucho Marx",
+      "Harpo Marx",
+      "Chico Marx",
+      "Zeppo Marx"
+    ]
   },
   {
     "movieId": "scarface-the-shame-of-the-nation-1932",
@@ -7827,7 +12853,14 @@
     "year": 1932,
     "runtime": 93,
     "imdbRating": 7.8,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "An ambitious and nearly insane violent gangster climbs the ladder of success in the mob, but his weaknesses prove to be his downfall.",
+    "cast": [
+      "Richard Rosson",
+      "Paul Muni",
+      "Ann Dvorak",
+      "Karen Morley"
+    ]
   },
   {
     "movieId": "frankenstein-1931",
@@ -7838,7 +12871,14 @@
     "year": 1931,
     "runtime": 70,
     "imdbRating": 7.8,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "Dr. Frankenstein dares to tamper with life and death by creating a human monster out of lifeless body parts.",
+    "cast": [
+      "Colin Clive",
+      "Mae Clarke",
+      "Boris Karloff",
+      "John Boles"
+    ]
   },
   {
     "movieId": "roma-2018",
@@ -7849,7 +12889,14 @@
     "year": 2018,
     "runtime": 135,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A year in the life of a middle-class family's maid in Mexico City in the early 1970s.",
+    "cast": [
+      "Yalitza Aparicio",
+      "Marina de Tavira",
+      "Diego Cortina Autrey",
+      "Carlos Peralta"
+    ]
   },
   {
     "movieId": "god-s-own-country-2017",
@@ -7859,7 +12906,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNjRhYzk2NDAtYzA1Mi00MmNmLWE1ZjQtMDBhZmUyMTdjZjBiXkEyXkFqcGdeQXVyNjk1Njg5NTA@._V1_SX4000.jpg",
     "year": 2017,
     "runtime": 104,
-    "imdbRating": 7.7
+    "imdbRating": 7.7,
+    "synopsis": "Spring. Yorkshire. Young farmer Johnny Saxby numbs his daily frustrations with binge drinking and casual sex, until the arrival of a Romanian migrant worker for lambing season ignites an intense relationship that sets Johnny on a new path.",
+    "cast": [
+      "Josh O'Connor",
+      "Alec Secareanu",
+      "Gemma Jones",
+      "Ian Hart"
+    ]
   },
   {
     "movieId": "deadpool-2-2018",
@@ -7870,7 +12924,14 @@
     "year": 2018,
     "runtime": 119,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Foul-mouthed mutant mercenary Wade Wilson (a.k.a. Deadpool), brings together a team of fellow mutant rogues to protect a young boy with supernatural abilities from the brutal, time-traveling cyborg Cable.",
+    "cast": [
+      "Ryan Reynolds",
+      "Josh Brolin",
+      "Morena Baccarin",
+      "Julian Dennison"
+    ]
   },
   {
     "movieId": "wind-river-2017",
@@ -7881,7 +12942,14 @@
     "year": 2017,
     "runtime": 107,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A veteran hunter helps an FBI agent investigate the murder of a young woman on a Wyoming Native American reservation.",
+    "cast": [
+      "Kelsey Asbille",
+      "Jeremy Renner",
+      "Julia Jones",
+      "Teo Briones"
+    ]
   },
   {
     "movieId": "get-out-2017",
@@ -7892,7 +12960,14 @@
     "year": 2017,
     "runtime": 104,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A young African-American visits his white girlfriend's parents for the weekend, where his simmering uneasiness about their reception of him eventually reaches a boiling point.",
+    "cast": [
+      "Daniel Kaluuya",
+      "Allison Williams",
+      "Bradley Whitford",
+      "Catherine Keener"
+    ]
   },
   {
     "movieId": "mission-impossible-fallout-2018",
@@ -7903,7 +12978,14 @@
     "year": 2018,
     "runtime": 147,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Ethan Hunt and his IMF team, along with some familiar allies, race against time after a mission gone wrong.",
+    "cast": [
+      "Tom Cruise",
+      "Henry Cavill",
+      "Ving Rhames",
+      "Simon Pegg"
+    ]
   },
   {
     "movieId": "en-man-som-heter-ove-2015",
@@ -7914,7 +12996,14 @@
     "year": 2015,
     "runtime": 116,
     "imdbRating": 7.7,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "Ove, an ill-tempered, isolated retiree who spends his days enforcing block association rules and visiting his wife's grave, has finally given up on life just as an unlikely friendship develops with his boisterous new neighbors.",
+    "cast": [
+      "Rolf Lassgård",
+      "Bahar Pars",
+      "Filip Berg",
+      "Ida Engvoll"
+    ]
   },
   {
     "movieId": "what-we-do-in-the-shadows-2014",
@@ -7925,7 +13014,14 @@
     "year": 2014,
     "runtime": 86,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Viago, Deacon and Vladislav are vampires who are finding that modern life has them struggling with the mundane - like paying rent, keeping up with the chore wheel, trying to get into nightclubs and overcoming flatmate conflicts.",
+    "cast": [
+      "Taika Waititi",
+      "Jemaine Clement",
+      "Taika Waititi",
+      "Cori Gonzalez-Macuer"
+    ]
   },
   {
     "movieId": "omoide-no-m-n-2014",
@@ -7936,7 +13032,14 @@
     "year": 2014,
     "runtime": 103,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Due to 12 y.o. Anna's asthma, she's sent to stay with relatives of her guardian in the Japanese countryside. She likes to be alone, sketching. She befriends Marnie. Who is the mysterious, blonde Marnie.",
+    "cast": [
+      "Hiromasa Yonebayashi",
+      "Sara Takatsuki",
+      "Kasumi Arimura",
+      "Nanako Matsushima"
+    ]
   },
   {
     "movieId": "the-theory-of-everything-2014",
@@ -7947,7 +13050,14 @@
     "year": 2014,
     "runtime": 123,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A look at the relationship between the famous physicist Stephen Hawking and his wife.",
+    "cast": [
+      "Eddie Redmayne",
+      "Felicity Jones",
+      "Tom Prior",
+      "Sophie Perry"
+    ]
   },
   {
     "movieId": "kingsman-the-secret-service-2014",
@@ -7958,7 +13068,14 @@
     "year": 2014,
     "runtime": 129,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A spy organisation recruits a promising street kid into the agency's training program, while a global threat emerges from a twisted tech genius.",
+    "cast": [
+      "Colin Firth",
+      "Taron Egerton",
+      "Samuel L. Jackson",
+      "Michael Caine"
+    ]
   },
   {
     "movieId": "the-fault-in-our-stars-2014",
@@ -7969,7 +13086,14 @@
     "year": 2014,
     "runtime": 126,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Two teenage cancer patients begin a life-affirming journey to visit a reclusive author in Amsterdam.",
+    "cast": [
+      "Shailene Woodley",
+      "Ansel Elgort",
+      "Nat Wolff",
+      "Laura Dern"
+    ]
   },
   {
     "movieId": "me-and-earl-and-the-dying-girl-2015",
@@ -7980,7 +13104,14 @@
     "year": 2015,
     "runtime": 105,
     "imdbRating": 7.7,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "High schooler Greg, who spends most of his time making parodies of classic movies with his co-worker Earl, finds his outlook forever altered after befriending a classmate who has just been diagnosed with cancer.",
+    "cast": [
+      "Thomas Mann",
+      "RJ Cyler",
+      "Olivia Cooke",
+      "Nick Offerman"
+    ]
   },
   {
     "movieId": "birdman-or-the-unexpected-virtue-of-ignorance-2014",
@@ -7991,7 +13122,14 @@
     "year": 2014,
     "runtime": 119,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A washed-up superhero actor attempts to revive his fading career by writing, directing, and starring in a Broadway production.",
+    "cast": [
+      "Michael Keaton",
+      "Zach Galifianakis",
+      "Edward Norton",
+      "Andrea Riseborough"
+    ]
   },
   {
     "movieId": "la-vie-d-ad-le-2013",
@@ -8002,7 +13140,14 @@
     "year": 2013,
     "runtime": 180,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Adèle's life is changed when she meets Emma, a young woman with blue hair, who will allow her to discover desire and to assert herself as a woman and as an adult. In front of others, Adèle grows, seeks herself, loses herself, and ultimately finds herself through love and loss.",
+    "cast": [
+      "Léa Seydoux",
+      "Adèle Exarchopoulos",
+      "Salim Kechiouche",
+      "Aurélien Recoing"
+    ]
   },
   {
     "movieId": "kai-po-che-2013",
@@ -8013,7 +13158,14 @@
     "year": 2013,
     "runtime": 130,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Three friends growing up in India at the turn of the millennium set out to open a training academy to produce the country's next cricket stars.",
+    "cast": [
+      "Amit Sadh",
+      "Sushant Singh Rajput",
+      "Rajkummar Rao",
+      "Amrita Puri"
+    ]
   },
   {
     "movieId": "the-broken-circle-breakdown-2012",
@@ -8023,7 +13175,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTQzMzg2Nzg2MF5BMl5BanBnXkFtZTgwNjUzNzIzMDE@._V1_SX4000.jpg",
     "year": 2012,
     "runtime": 111,
-    "imdbRating": 7.7
+    "imdbRating": 7.7,
+    "synopsis": "Elise and Didier fall in love at first sight, in spite of their differences. He talks, she listens. He's a romantic atheist, she's a religious realist. When their daughter becomes seriously ill, their love is put on trial.",
+    "cast": [
+      "Veerle Baetens",
+      "Johan Heldenbergh",
+      "Nell Cattrysse",
+      "Geert Van Rampelberg"
+    ]
   },
   {
     "movieId": "captain-america-the-winter-soldier-2014",
@@ -8034,7 +13193,14 @@
     "year": 2014,
     "runtime": 136,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "As Steve Rogers struggles to embrace his role in the modern world, he teams up with a fellow Avenger and S.H.I.E.L.D agent, Black Widow, to battle a new threat from history: an assassin known as the Winter Soldier.",
+    "cast": [
+      "Joe Russo",
+      "Chris Evans",
+      "Samuel L. Jackson",
+      "Scarlett Johansson"
+    ]
   },
   {
     "movieId": "rockstar-2011",
@@ -8045,7 +13211,14 @@
     "year": 2011,
     "runtime": 159,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Janardhan Jakhar chases his dreams of becoming a big Rock star, during which he falls in love with Heer.",
+    "cast": [
+      "Ranbir Kapoor",
+      "Nargis Fakhri",
+      "Shammi Kapoor",
+      "Kumud Mishra"
+    ]
   },
   {
     "movieId": "nebraska-2013",
@@ -8056,7 +13229,14 @@
     "year": 2013,
     "runtime": 115,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "An aging, booze-addled father makes the trip from Montana to Nebraska with his estranged son in order to claim a million-dollar Mega Sweepstakes Marketing prize.",
+    "cast": [
+      "Bruce Dern",
+      "Will Forte",
+      "June Squibb",
+      "Bob Odenkirk"
+    ]
   },
   {
     "movieId": "wreck-it-ralph-2012",
@@ -8067,7 +13247,14 @@
     "year": 2012,
     "runtime": 101,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A video game villain wants to be a hero and sets out to fulfill his dream, but his quest brings havoc to the whole arcade where he lives.",
+    "cast": [
+      "John C. Reilly",
+      "Jack McBrayer",
+      "Jane Lynch",
+      "Sarah Silverman"
+    ]
   },
   {
     "movieId": "le-petit-prince-2015",
@@ -8078,7 +13265,14 @@
     "year": 2015,
     "runtime": 108,
     "imdbRating": 7.7,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "A little girl lives in a very grown-up world with her mother, who tries to prepare her for it. Her neighbor, the Aviator, introduces the girl to an extraordinary world where anything is possible, the world of the Little Prince.",
+    "cast": [
+      "Jeff Bridges",
+      "Mackenzie Foy",
+      "Rachel McAdams",
+      "Marion Cotillard"
+    ]
   },
   {
     "movieId": "detachment-2011",
@@ -8088,7 +13282,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTM3NzQzMDA5Ml5BMl5BanBnXkFtZTcwODA5NTcyNw@@._V1_SX4000.jpg",
     "year": 2011,
     "runtime": 98,
-    "imdbRating": 7.7
+    "imdbRating": 7.7,
+    "synopsis": "A substitute teacher who drifts from classroom to classroom finds a connection to the students and teachers during his latest assignment.",
+    "cast": [
+      "Adrien Brody",
+      "Christina Hendricks",
+      "Marcia Gay Harden",
+      "Lucy Liu"
+    ]
   },
   {
     "movieId": "midnight-in-paris-2011",
@@ -8099,7 +13300,14 @@
     "year": 2011,
     "runtime": 96,
     "imdbRating": 7.7,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "While on a trip to Paris with his fiancée's family, a nostalgic screenwriter finds himself mysteriously going back to the 1920s every day at midnight.",
+    "cast": [
+      "Owen Wilson",
+      "Rachel McAdams",
+      "Kathy Bates",
+      "Kurt Fuller"
+    ]
   },
   {
     "movieId": "the-lego-movie-2014",
@@ -8110,7 +13318,14 @@
     "year": 2014,
     "runtime": 100,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "An ordinary LEGO construction worker, thought to be the prophesied as \"special\", is recruited to join a quest to stop an evil tyrant from gluing the LEGO universe into eternal stasis.",
+    "cast": [
+      "Phil Lord",
+      "Chris Pratt",
+      "Will Ferrell",
+      "Elizabeth Banks"
+    ]
   },
   {
     "movieId": "gravity-2013",
@@ -8121,7 +13336,14 @@
     "year": 2013,
     "runtime": 91,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Two astronauts work together to survive after an accident leaves them stranded in space.",
+    "cast": [
+      "Sandra Bullock",
+      "George Clooney",
+      "Ed Harris",
+      "Orto Ignatiussen"
+    ]
   },
   {
     "movieId": "star-trek-into-darkness-2013",
@@ -8132,7 +13354,14 @@
     "year": 2013,
     "runtime": 132,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "After the crew of the Enterprise find an unstoppable force of terror from within their own organization, Captain Kirk leads a manhunt to a war-zone world to capture a one-man weapon of mass destruction.",
+    "cast": [
+      "Chris Pine",
+      "Zachary Quinto",
+      "Zoe Saldana",
+      "Benedict Cumberbatch"
+    ]
   },
   {
     "movieId": "beasts-of-no-nation-2015",
@@ -8142,7 +13371,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTYwMzMzMDI0NF5BMl5BanBnXkFtZTgwNDQ3NjI3NjE@._V1_SX4000.jpg",
     "year": 2015,
     "runtime": 137,
-    "imdbRating": 7.7
+    "imdbRating": 7.7,
+    "synopsis": "A drama based on the experiences of Agu, a child soldier fighting in the civil war of an unnamed African country.",
+    "cast": [
+      "Abraham Attah",
+      "Emmanuel Affadzi",
+      "Ricky Adelayitor",
+      "Andrew Adote"
+    ]
   },
   {
     "movieId": "the-social-network-2010",
@@ -8153,7 +13389,14 @@
     "year": 2010,
     "runtime": 120,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "As Harvard student Mark Zuckerberg creates the social networking site that would become known as Facebook, he is sued by the twins who claimed he stole their idea, and by the co-founder who was later squeezed out of the business.",
+    "cast": [
+      "Jesse Eisenberg",
+      "Andrew Garfield",
+      "Justin Timberlake",
+      "Rooney Mara"
+    ]
   },
   {
     "movieId": "x-first-class-2011",
@@ -8164,7 +13407,14 @@
     "year": 2011,
     "runtime": 131,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "In the 1960s, superpowered humans Charles Xavier and Erik Lensherr work together to find others like them, but Erik's vengeful pursuit of an ambitious mutant who ruined his life causes a schism to divide them.",
+    "cast": [
+      "James McAvoy",
+      "Michael Fassbender",
+      "Jennifer Lawrence",
+      "Kevin Bacon"
+    ]
   },
   {
     "movieId": "the-hangover-2009",
@@ -8175,7 +13425,14 @@
     "year": 2009,
     "runtime": 100,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Three buddies wake up from a bachelor party in Las Vegas, with no memory of the previous night and the bachelor missing. They make their way around the city in order to find their friend before his wedding.",
+    "cast": [
+      "Zach Galifianakis",
+      "Bradley Cooper",
+      "Justin Bartha",
+      "Ed Helms"
+    ]
   },
   {
     "movieId": "skyfall-2012",
@@ -8186,7 +13443,14 @@
     "year": 2012,
     "runtime": 143,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "James Bond's loyalty to M is tested when her past comes back to haunt her. When MI6 comes under attack, 007 must track down and destroy the threat, no matter how personal the cost.",
+    "cast": [
+      "Daniel Craig",
+      "Javier Bardem",
+      "Naomie Harris",
+      "Judi Dench"
+    ]
   },
   {
     "movieId": "silver-linings-playbook-2012",
@@ -8197,7 +13461,14 @@
     "year": 2012,
     "runtime": 122,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "After a stint in a mental institution, former teacher Pat Solitano moves back in with his parents and tries to reconcile with his ex-wife. Things get more challenging when Pat meets Tiffany, a mysterious girl with problems of her own.",
+    "cast": [
+      "Bradley Cooper",
+      "Jennifer Lawrence",
+      "Robert De Niro",
+      "Jacki Weaver"
+    ]
   },
   {
     "movieId": "argo-2012",
@@ -8208,7 +13479,14 @@
     "year": 2012,
     "runtime": 120,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Acting under the cover of a Hollywood producer scouting a location for a science fiction film, a CIA agent launches a dangerous operation to rescue six Americans in Tehran during the U.S. hostage crisis in Iran in 1979.",
+    "cast": [
+      "Ben Affleck",
+      "Bryan Cranston",
+      "John Goodman",
+      "Alan Arkin"
+    ]
   },
   {
     "movieId": "500-days-of-summer-2009",
@@ -8219,7 +13497,14 @@
     "year": 2009,
     "runtime": 95,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "An offbeat romantic comedy about a woman who doesn't believe true love exists, and the young man who falls for her.",
+    "cast": [
+      "Zooey Deschanel",
+      "Joseph Gordon-Levitt",
+      "Geoffrey Arend",
+      "Chloë Grace Moretz"
+    ]
   },
   {
     "movieId": "harry-potter-and-the-deathly-hallows-part-1-2010",
@@ -8230,7 +13515,14 @@
     "year": 2010,
     "runtime": 146,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "As Harry, Ron, and Hermione race against time and evil to destroy the Horcruxes, they uncover the existence of the three most powerful objects in the wizarding world: the Deathly Hallows.",
+    "cast": [
+      "Daniel Radcliffe",
+      "Emma Watson",
+      "Rupert Grint",
+      "Bill Nighy"
+    ]
   },
   {
     "movieId": "gake-no-ue-no-ponyo-2008",
@@ -8241,7 +13533,14 @@
     "year": 2008,
     "runtime": 101,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A five-year-old boy develops a relationship with Ponyo, a young goldfish princess who longs to become a human after falling in love with him.",
+    "cast": [
+      "Cate Blanchett",
+      "Matt Damon",
+      "Liam Neeson",
+      "Tomoko Yamaguchi"
+    ]
   },
   {
     "movieId": "frost-nixon-2008",
@@ -8252,7 +13551,14 @@
     "year": 2008,
     "runtime": 122,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A dramatic retelling of the post-Watergate television interviews between British talk-show host David Frost and former president Richard Nixon.",
+    "cast": [
+      "Frank Langella",
+      "Michael Sheen",
+      "Kevin Bacon",
+      "Sam Rockwell"
+    ]
   },
   {
     "movieId": "papurika-2006",
@@ -8263,7 +13569,14 @@
     "year": 2006,
     "runtime": 90,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "When a machine that allows therapists to enter their patients' dreams is stolen, all Hell breaks loose. Only a young female therapist, Paprika, can stop it.",
+    "cast": [
+      "Megumi Hayashibara",
+      "Tôru Emori",
+      "Katsunosuke Hori",
+      "Tôru Furuya"
+    ]
   },
   {
     "movieId": "changeling-2008",
@@ -8274,7 +13587,14 @@
     "year": 2008,
     "runtime": 141,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Grief-stricken mother Christine Collins (Angelina Jolie) takes on the L.A.P.D. to her own detriment when it tries to pass off an obvious impostor as her missing child.",
+    "cast": [
+      "Angelina Jolie",
+      "Colm Feore",
+      "Amy Ryan",
+      "Gattlin Griffith"
+    ]
   },
   {
     "movieId": "flipped-2010",
@@ -8285,7 +13605,14 @@
     "year": 2010,
     "runtime": 90,
     "imdbRating": 7.7,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "Two eighth-graders start to have feelings for each other despite being total opposites.",
+    "cast": [
+      "Madeline Carroll",
+      "Callan McAuliffe",
+      "Rebecca De Mornay",
+      "Anthony Edwards"
+    ]
   },
   {
     "movieId": "toki-o-kakeru-sh-jo-2006",
@@ -8296,7 +13623,14 @@
     "year": 2006,
     "runtime": 98,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A high-school girl named Makoto acquires the power to travel back in time, and decides to use it for her own personal benefits. Little does she know that she is affecting the lives of others just as much as she is her own.",
+    "cast": [
+      "Riisa Naka",
+      "Takuya Ishida",
+      "Mitsutaka Itakura",
+      "Ayami Kakiuchi"
+    ]
   },
   {
     "movieId": "death-note-desu-n-to-2006",
@@ -8306,7 +13640,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BZDNlNjEzMzQtZDM0MS00YzhiLTk0MGUtYTdmNDZiZGVjNTk0L2ltYWdlXkEyXkFqcGdeQXVyNTAyODkwOQ@@._V1_SX4000.jpg",
     "year": 2006,
     "runtime": 126,
-    "imdbRating": 7.7
+    "imdbRating": 7.7,
+    "synopsis": "A battle between the world's two greatest minds begins when Light Yagami finds the Death Note, a notebook with the power to kill, and decides to rid the world of criminals.",
+    "cast": [
+      "Tatsuya Fujiwara",
+      "Ken'ichi Matsuyama",
+      "Asaka Seto",
+      "Yû Kashii"
+    ]
   },
   {
     "movieId": "this-is-england-2006",
@@ -8316,7 +13657,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMmE3OWZhZDYtOTBjMi00NDIwLTg1NWMtMjg0NjJmZWM4MjliL2ltYWdlXkEyXkFqcGdeQXVyNTAyODkwOQ@@._V1_SX4000.jpg",
     "year": 2006,
     "runtime": 101,
-    "imdbRating": 7.7
+    "imdbRating": 7.7,
+    "synopsis": "A young boy becomes friends with a gang of skinheads. Friends soon become like family, and relationships will be pushed to the very limit.",
+    "cast": [
+      "Thomas Turgoose",
+      "Stephen Graham",
+      "Jo Hartley",
+      "Andrew Shim"
+    ]
   },
   {
     "movieId": "ex-machina-2014",
@@ -8327,7 +13675,14 @@
     "year": 2014,
     "runtime": 108,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A young programmer is selected to participate in a ground-breaking experiment in synthetic intelligence by evaluating the human qualities of a highly advanced humanoid A.I.",
+    "cast": [
+      "Alicia Vikander",
+      "Domhnall Gleeson",
+      "Oscar Isaac",
+      "Sonoya Mizuno"
+    ]
   },
   {
     "movieId": "efter-brylluppet-2006",
@@ -8338,7 +13693,14 @@
     "year": 2006,
     "runtime": 120,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A manager of an orphanage in India is sent to Copenhagen, Denmark, where he discovers a life-altering family secret.",
+    "cast": [
+      "Mads Mikkelsen",
+      "Sidse Babett Knudsen",
+      "Rolf Lassgård",
+      "Neeral Mulchandani"
+    ]
   },
   {
     "movieId": "the-last-king-of-scotland-2006",
@@ -8349,7 +13711,14 @@
     "year": 2006,
     "runtime": 123,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Based on the events of the brutal Ugandan dictator Idi Amin's regime as seen by his personal physician during the 1970s.",
+    "cast": [
+      "James McAvoy",
+      "Forest Whitaker",
+      "Gillian Anderson",
+      "Kerry Washington"
+    ]
   },
   {
     "movieId": "zodiac-2007",
@@ -8360,7 +13729,14 @@
     "year": 2007,
     "runtime": 157,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "In the late 1960s/early 1970s, a San Francisco cartoonist becomes an amateur detective obsessed with tracking down the Zodiac Killer, an unidentified individual who terrorizes Northern California with a killing spree.",
+    "cast": [
+      "Jake Gyllenhaal",
+      "Robert Downey Jr.",
+      "Mark Ruffalo",
+      "Anthony Edwards"
+    ]
   },
   {
     "movieId": "lucky-number-slevin-2006",
@@ -8371,7 +13747,14 @@
     "year": 2006,
     "runtime": 110,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A case of mistaken identity lands Slevin into the middle of a war being plotted by two of the city's most rival crime bosses. Under constant surveillance by Detective Brikowski and assassin Goodkat, he must get them before they get him.",
+    "cast": [
+      "Josh Hartnett",
+      "Ben Kingsley",
+      "Morgan Freeman",
+      "Lucy Liu"
+    ]
   },
   {
     "movieId": "joyeux-no-l-2005",
@@ -8382,7 +13765,14 @@
     "year": 2005,
     "runtime": 116,
     "imdbRating": 7.7,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "In December 1914, an unofficial Christmas truce on the Western Front allows soldiers from opposing sides of the First World War to gain insight into each other's way of life.",
+    "cast": [
+      "Diane Kruger",
+      "Benno Fürmann",
+      "Guillaume Canet",
+      "Natalie Dessay"
+    ]
   },
   {
     "movieId": "control-2007",
@@ -8393,7 +13783,14 @@
     "year": 2007,
     "runtime": 122,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A profile of Ian Curtis, the enigmatic singer of Joy Division whose personal, professional, and romantic troubles led him to commit suicide at the age of 23.",
+    "cast": [
+      "Sam Riley",
+      "Samantha Morton",
+      "Craig Parkinson",
+      "Alexandra Maria Lara"
+    ]
   },
   {
     "movieId": "tangled-2010",
@@ -8404,7 +13801,14 @@
     "year": 2010,
     "runtime": 100,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The magically long-haired Rapunzel has spent her entire life in a tower, but now that a runaway thief has stumbled upon her, she is about to discover the world for the first time, and who she really is.",
+    "cast": [
+      "Byron Howard",
+      "Mandy Moore",
+      "Zachary Levi",
+      "Donna Murphy"
+    ]
   },
   {
     "movieId": "zwartboek-2006",
@@ -8415,7 +13819,14 @@
     "year": 2006,
     "runtime": 145,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "In the Nazi-occupied Netherlands during World War II, a Jewish singer infiltrates the regional Gestapo headquarters for the Dutch resistance.",
+    "cast": [
+      "Carice van Houten",
+      "Sebastian Koch",
+      "Thom Hoffman",
+      "Halina Reijn"
+    ]
   },
   {
     "movieId": "brokeback-mountain-2005",
@@ -8426,7 +13837,14 @@
     "year": 2005,
     "runtime": 134,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The story of a forbidden and secretive relationship between two cowboys, and their lives over the years.",
+    "cast": [
+      "Jake Gyllenhaal",
+      "Heath Ledger",
+      "Michelle Williams",
+      "Randy Quaid"
+    ]
   },
   {
     "movieId": "3-10-to-yuma-2007",
@@ -8437,7 +13855,14 @@
     "year": 2007,
     "runtime": 122,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A small-time rancher agrees to hold a captured outlaw who's awaiting a train to go to court in Yuma. A battle of wills ensues as the outlaw tries to psych out the rancher.",
+    "cast": [
+      "Russell Crowe",
+      "Christian Bale",
+      "Ben Foster",
+      "Logan Lerman"
+    ]
   },
   {
     "movieId": "crash-2004",
@@ -8448,7 +13873,14 @@
     "year": 2004,
     "runtime": 112,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Los Angeles citizens with vastly separate lives collide in interweaving stories of race, loss and redemption.",
+    "cast": [
+      "Don Cheadle",
+      "Sandra Bullock",
+      "Thandie Newton",
+      "Karina Arroyave"
+    ]
   },
   {
     "movieId": "kung-fu-2004",
@@ -8459,7 +13891,14 @@
     "year": 2004,
     "runtime": 99,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "In Shanghai, China in the 1940s, a wannabe gangster aspires to join the notorious \"Axe Gang\" while residents of a housing complex exhibit extraordinary powers in defending their turf.",
+    "cast": [
+      "Stephen Chow",
+      "Wah Yuen",
+      "Qiu Yuen",
+      "Siu-Lung Leung"
+    ]
   },
   {
     "movieId": "the-bourne-supremacy-2004",
@@ -8470,7 +13909,14 @@
     "year": 2004,
     "runtime": 108,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "When Jason Bourne is framed for a CIA operation gone awry, he is forced to resume his former life as a trained assassin to survive.",
+    "cast": [
+      "Matt Damon",
+      "Franka Potente",
+      "Joan Allen",
+      "Brian Cox"
+    ]
   },
   {
     "movieId": "the-machinist-2004",
@@ -8481,7 +13927,14 @@
     "year": 2004,
     "runtime": 101,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "An industrial worker who hasn't slept in a year begins to doubt his own sanity.",
+    "cast": [
+      "Christian Bale",
+      "Jennifer Jason Leigh",
+      "Aitana Sánchez-Gijón",
+      "John Sharian"
+    ]
   },
   {
     "movieId": "ray-2004",
@@ -8492,7 +13945,14 @@
     "year": 2004,
     "runtime": 152,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The story of the life and career of the legendary rhythm and blues musician Ray Charles, from his humble beginnings in the South, where he went blind at age seven, to his meteoric rise to stardom during the 1950s and 1960s.",
+    "cast": [
+      "Jamie Foxx",
+      "Regina King",
+      "Kerry Washington",
+      "Clifton Powell"
+    ]
   },
   {
     "movieId": "lost-in-translation-2003",
@@ -8503,7 +13963,14 @@
     "year": 2003,
     "runtime": 102,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A faded movie star and a neglected young woman form an unlikely bond after crossing paths in Tokyo.",
+    "cast": [
+      "Bill Murray",
+      "Scarlett Johansson",
+      "Giovanni Ribisi",
+      "Anna Faris"
+    ]
   },
   {
     "movieId": "harry-potter-and-the-goblet-of-fire-2005",
@@ -8514,7 +13981,14 @@
     "year": 2005,
     "runtime": 157,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Harry Potter finds himself competing in a hazardous tournament between rival schools of magic, but he is distracted by recurring nightmares.",
+    "cast": [
+      "Daniel Radcliffe",
+      "Emma Watson",
+      "Rupert Grint",
+      "Eric Sykes"
+    ]
   },
   {
     "movieId": "man-on-fire-2004",
@@ -8525,7 +13999,14 @@
     "year": 2004,
     "runtime": 146,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "In Mexico City, a former CIA operative swears vengeance on those who committed an unspeakable act against the family he was hired to protect.",
+    "cast": [
+      "Denzel Washington",
+      "Christopher Walken",
+      "Dakota Fanning",
+      "Radha Mitchell"
+    ]
   },
   {
     "movieId": "coraline-2009",
@@ -8536,7 +14017,14 @@
     "year": 2009,
     "runtime": 100,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "An adventurous 11-year-old girl finds another world that is a strangely idealized version of her frustrating home, but it has sinister secrets.",
+    "cast": [
+      "Dakota Fanning",
+      "Teri Hatcher",
+      "John Hodgman",
+      "Jennifer Saunders"
+    ]
   },
   {
     "movieId": "the-last-samurai-2003",
@@ -8547,7 +14035,14 @@
     "year": 2003,
     "runtime": 154,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "An American military advisor embraces the Samurai culture he was hired to destroy after he is captured in battle.",
+    "cast": [
+      "Tom Cruise",
+      "Ken Watanabe",
+      "Billy Connolly",
+      "William Atherton"
+    ]
   },
   {
     "movieId": "the-magdalene-sisters-2002",
@@ -8558,7 +14053,14 @@
     "year": 2002,
     "runtime": 114,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Three young Irish women struggle to maintain their spirits while they endure dehumanizing abuse as inmates of a Magdalene Sisters Asylum.",
+    "cast": [
+      "Eileen Walsh",
+      "Dorothy Duffy",
+      "Nora-Jane Noone",
+      "Anne-Marie Duff"
+    ]
   },
   {
     "movieId": "good-bye-lenin-2003",
@@ -8569,7 +14071,14 @@
     "year": 2003,
     "runtime": 121,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "In 1990, to protect his fragile mother from a fatal shock after a long coma, a young man must keep her from learning that her beloved nation of East Germany as she knew it has disappeared.",
+    "cast": [
+      "Daniel Brühl",
+      "Katrin Saß",
+      "Chulpan Khamatova",
+      "Florian Lukas"
+    ]
   },
   {
     "movieId": "in-america-2002",
@@ -8580,7 +14089,14 @@
     "year": 2002,
     "runtime": 105,
     "imdbRating": 7.7,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A family of Irish immigrants adjust to life on the mean streets of Hell's Kitchen while also grieving the death of a child.",
+    "cast": [
+      "Paddy Considine",
+      "Samantha Morton",
+      "Djimon Hounsou",
+      "Sarah Bolger"
+    ]
   },
   {
     "movieId": "i-am-sam-2001",
@@ -8591,7 +14107,14 @@
     "year": 2001,
     "runtime": 132,
     "imdbRating": 7.7,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A mentally handicapped man fights for custody of his 7-year-old daughter and in the process teaches his cold-hearted lawyer the value of love and family.",
+    "cast": [
+      "Sean Penn",
+      "Michelle Pfeiffer",
+      "Dakota Fanning",
+      "Dianne Wiest"
+    ]
   },
   {
     "movieId": "adaptation-2002",
@@ -8602,7 +14125,14 @@
     "year": 2002,
     "runtime": 115,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A lovelorn screenwriter becomes desperate as he tries and fails to adapt 'The Orchid Thief' by Susan Orlean for the screen.",
+    "cast": [
+      "Nicolas Cage",
+      "Meryl Streep",
+      "Chris Cooper",
+      "Tilda Swinton"
+    ]
   },
   {
     "movieId": "black-hawk-down-2001",
@@ -8613,7 +14143,14 @@
     "year": 2001,
     "runtime": 144,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "160 elite U.S. soldiers drop into Somalia to capture two top lieutenants of a renegade warlord and find themselves in a desperate battle with a large force of heavily-armed Somalis.",
+    "cast": [
+      "Josh Hartnett",
+      "Ewan McGregor",
+      "Tom Sizemore",
+      "Eric Bana"
+    ]
   },
   {
     "movieId": "road-to-perdition-2002",
@@ -8624,7 +14161,14 @@
     "year": 2002,
     "runtime": 117,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A mob enforcer's son witnesses a murder, forcing him and his father to take to the road, and his father down a path of redemption and revenge.",
+    "cast": [
+      "Tom Hanks",
+      "Tyler Hoechlin",
+      "Rob Maxey",
+      "Liam Aiken"
+    ]
   },
   {
     "movieId": "das-experiment-2001",
@@ -8635,7 +14179,14 @@
     "year": 2001,
     "runtime": 120,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "For two weeks, 20 male participants are hired to play prisoners and guards in a prison. The \"prisoners\" have to follow seemingly mild rules, and the \"guards\" are told to retain order without using physical violence.",
+    "cast": [
+      "Moritz Bleibtreu",
+      "Christian Berkel",
+      "Oliver Stokowski",
+      "Wotan Wilke Möhring"
+    ]
   },
   {
     "movieId": "billy-elliot-2000",
@@ -8646,7 +14197,14 @@
     "year": 2000,
     "runtime": 110,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A talented young boy becomes torn between his unexpected love of dance and the disintegration of his family.",
+    "cast": [
+      "Jamie Bell",
+      "Julie Walters",
+      "Jean Heywood",
+      "Jamie Draven"
+    ]
   },
   {
     "movieId": "hedwig-and-the-angry-inch-2001",
@@ -8657,7 +14215,14 @@
     "year": 2001,
     "runtime": 95,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A gender-queer punk-rock singer from East Berlin tours the U.S. with her band as she tells her life story and follows the former lover/band-mate who stole her songs.",
+    "cast": [
+      "John Cameron Mitchell",
+      "Miriam Shor",
+      "Stephen Trask",
+      "Theodore Liscinski"
+    ]
   },
   {
     "movieId": "ocean-s-eleven-2001",
@@ -8668,7 +14233,14 @@
     "year": 2001,
     "runtime": 116,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Danny Ocean and his ten accomplices plan to rob three Las Vegas casinos simultaneously.",
+    "cast": [
+      "George Clooney",
+      "Brad Pitt",
+      "Julia Roberts",
+      "Matt Damon"
+    ]
   },
   {
     "movieId": "vampire-hunter-d-bloodlust-2000",
@@ -8679,7 +14251,14 @@
     "year": 2000,
     "runtime": 103,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "When a girl is abducted by a vampire, a legendary bounty hunter is hired to bring her back.",
+    "cast": [
+      "Andrew Philpot",
+      "John Rafter Lee",
+      "Pamela Adlon",
+      "Wendee Lee"
+    ]
   },
   {
     "movieId": "o-brother-where-art-thou-2000",
@@ -8690,7 +14269,14 @@
     "year": 2000,
     "runtime": 107,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In the deep south during the 1930s, three escaped convicts search for hidden treasure while a relentless lawman pursues them.",
+    "cast": [
+      "Ethan Coen",
+      "George Clooney",
+      "John Turturro",
+      "Tim Blake Nelson"
+    ]
   },
   {
     "movieId": "interstate-60-episodes-of-the-road-2002",
@@ -8701,7 +14287,14 @@
     "year": 2002,
     "runtime": 116,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Neal Oliver, a very confused young man and an artist, takes a journey of a lifetime on a highway I60 that doesn't exist on any of the maps, going to the places he never even heard of, searching for an answer and his dreamgirl.",
+    "cast": [
+      "James Marsden",
+      "Gary Oldman",
+      "Kurt Russell",
+      "Matthew Edison"
+    ]
   },
   {
     "movieId": "south-park-bigger-longer-uncut-1999",
@@ -8712,7 +14305,14 @@
     "year": 1999,
     "runtime": 81,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "When Stan Marsh and his friends go see an R-rated movie, they start cursing and their parents think that Canada is to blame.",
+    "cast": [
+      "Trey Parker",
+      "Matt Stone",
+      "Mary Kay Bergman",
+      "Isaac Hayes"
+    ]
   },
   {
     "movieId": "office-space-1999",
@@ -8723,7 +14323,14 @@
     "year": 1999,
     "runtime": 89,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Three company workers who hate their jobs decide to rebel against their greedy boss.",
+    "cast": [
+      "Ron Livingston",
+      "Jennifer Aniston",
+      "David Herman",
+      "Ajay Naidu"
+    ]
   },
   {
     "movieId": "happiness-1998",
@@ -8733,7 +14340,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BM2FlNzE0ZmUtMmVkZS00MWQ3LWE4OWQtYjQwZjdhNzRmNWE2XkEyXkFqcGdeQXVyMTAwMzUyOTc@._V1_SX4000.jpg",
     "year": 1998,
     "runtime": 134,
-    "imdbRating": 7.7
+    "imdbRating": 7.7,
+    "synopsis": "The lives of several individuals intertwine as they go about their lives in their own unique ways, engaging in acts society as a whole might find disturbing in a desperate search for human connection.",
+    "cast": [
+      "Jane Adams",
+      "Jon Lovitz",
+      "Philip Seymour Hoffman",
+      "Dylan Baker"
+    ]
   },
   {
     "movieId": "training-day-2001",
@@ -8744,7 +14358,14 @@
     "year": 2001,
     "runtime": 122,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A rookie cop spends his first day as a Los Angeles narcotics officer with a rogue detective who isn't what he appears to be.",
+    "cast": [
+      "Denzel Washington",
+      "Ethan Hawke",
+      "Scott Glenn",
+      "Tom Berenger"
+    ]
   },
   {
     "movieId": "rushmore-1998",
@@ -8755,7 +14376,14 @@
     "year": 1998,
     "runtime": 93,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The extracurricular king of Rushmore Preparatory School is put on academic probation.",
+    "cast": [
+      "Jason Schwartzman",
+      "Bill Murray",
+      "Olivia Williams",
+      "Seymour Cassel"
+    ]
   },
   {
     "movieId": "abre-los-ojos-1997",
@@ -8766,7 +14394,14 @@
     "year": 1997,
     "runtime": 119,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A very handsome man finds the love of his life, but he suffers an accident and needs to have his face rebuilt by surgery after it is severely disfigured.",
+    "cast": [
+      "Eduardo Noriega",
+      "Penélope Cruz",
+      "Chete Lera",
+      "Fele Martínez"
+    ]
   },
   {
     "movieId": "being-john-malkovich-1999",
@@ -8777,7 +14412,14 @@
     "year": 1999,
     "runtime": 113,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A puppeteer discovers a portal that leads literally into the head of movie star John Malkovich.",
+    "cast": [
+      "John Cusack",
+      "Cameron Diaz",
+      "Catherine Keener",
+      "John Malkovich"
+    ]
   },
   {
     "movieId": "as-good-as-it-gets-1997",
@@ -8788,7 +14430,14 @@
     "year": 1997,
     "runtime": 139,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A single mother and waitress, a misanthropic author, and a gay artist form an unlikely friendship after the artist is assaulted in a robbery.",
+    "cast": [
+      "Jack Nicholson",
+      "Helen Hunt",
+      "Greg Kinnear",
+      "Cuba Gooding Jr."
+    ]
   },
   {
     "movieId": "the-fifth-element-1997",
@@ -8799,7 +14448,14 @@
     "year": 1997,
     "runtime": 126,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "In the colorful future, a cab driver unwittingly becomes the central figure in the search for a legendary cosmic weapon to keep Evil and Mr. Zorg at bay.",
+    "cast": [
+      "Bruce Willis",
+      "Milla Jovovich",
+      "Gary Oldman",
+      "Ian Holm"
+    ]
   },
   {
     "movieId": "le-d-ner-de-cons-1998",
@@ -8810,7 +14466,14 @@
     "year": 1998,
     "runtime": 80,
     "imdbRating": 7.7,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A few friends have a weekly fools' dinner, where each brings a fool along. Pierre finds a champion fool for next dinner. Surprise.",
+    "cast": [
+      "Thierry Lhermitte",
+      "Jacques Villeret",
+      "Francis Huster",
+      "Daniel Prévost"
+    ]
   },
   {
     "movieId": "donnie-brasco-1997",
@@ -8821,7 +14484,14 @@
     "year": 1997,
     "runtime": 127,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An FBI undercover agent infiltrates the mob and finds himself identifying more with the mafia life, at the expense of his regular one.",
+    "cast": [
+      "Al Pacino",
+      "Johnny Depp",
+      "Michael Madsen",
+      "Bruno Kirby"
+    ]
   },
   {
     "movieId": "shine-1996",
@@ -8832,7 +14502,14 @@
     "year": 1996,
     "runtime": 105,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Pianist David Helfgott, driven by his father and teachers, has a breakdown. Years later he returns to the piano, to popular if not critical acclaim.",
+    "cast": [
+      "Geoffrey Rush",
+      "Armin Mueller-Stahl",
+      "Justin Braine",
+      "Sonia Todd"
+    ]
   },
   {
     "movieId": "primal-fear-1996",
@@ -8843,7 +14520,14 @@
     "year": 1996,
     "runtime": 129,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An altar boy is accused of murdering a priest, and the truth is buried several layers deep.",
+    "cast": [
+      "Richard Gere",
+      "Laura Linney",
+      "Edward Norton",
+      "John Mahoney"
+    ]
   },
   {
     "movieId": "hamlet-1996",
@@ -8854,7 +14538,14 @@
     "year": 1996,
     "runtime": 242,
     "imdbRating": 7.7,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "Hamlet, Prince of Denmark, returns home to find his father murdered and his mother remarrying the murderer, his uncle. Meanwhile, war is brewing.",
+    "cast": [
+      "Kenneth Branagh",
+      "Julie Christie",
+      "Derek Jacobi",
+      "Kate Winslet"
+    ]
   },
   {
     "movieId": "a-little-princess-1995",
@@ -8865,7 +14556,14 @@
     "year": 1995,
     "runtime": 97,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A young girl is relegated to servitude at a boarding school when her father goes missing and is presumed dead.",
+    "cast": [
+      "Liesel Matthews",
+      "Eleanor Bron",
+      "Liam Cunningham",
+      "Rusty Schwimmer"
+    ]
   },
   {
     "movieId": "do-lok-tin-si-1995",
@@ -8876,7 +14574,14 @@
     "year": 1995,
     "runtime": 99,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "This Hong Kong-set crime drama follows the lives of a hitman, hoping to get out of the business, and his elusive female partner.",
+    "cast": [
+      "Leon Lai",
+      "Michelle Reis",
+      "Takeshi Kaneshiro",
+      "Charlie Yeung"
+    ]
   },
   {
     "movieId": "il-postino-1994",
@@ -8887,7 +14592,14 @@
     "year": 1994,
     "runtime": 108,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A simple Italian postman learns to love poetry while delivering mail to a famous poet, and then uses this to woo local beauty Beatrice.",
+    "cast": [
+      "Massimo Troisi",
+      "Massimo Troisi",
+      "Philippe Noiret",
+      "Maria Grazia Cucinotta"
+    ]
   },
   {
     "movieId": "clerks-1994",
@@ -8898,7 +14610,14 @@
     "year": 1994,
     "runtime": 92,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A day in the lives of two convenience clerks named Dante and Randal as they annoy customers, discuss movies, and play hockey on the store roof.",
+    "cast": [
+      "Brian O'Halloran",
+      "Jeff Anderson",
+      "Marilyn Ghigliotti",
+      "Lisa Spoonauer"
+    ]
   },
   {
     "movieId": "short-cuts-1993",
@@ -8909,7 +14628,14 @@
     "year": 1993,
     "runtime": 188,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "The day-to-day lives of several suburban Los Angeles residents.",
+    "cast": [
+      "Andie MacDowell",
+      "Julianne Moore",
+      "Tim Robbins",
+      "Bruce Davison"
+    ]
   },
   {
     "movieId": "philadelphia-1993",
@@ -8920,7 +14646,14 @@
     "year": 1993,
     "runtime": 125,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "When a man with HIV is fired by his law firm because of his condition, he hires a homophobic small time lawyer as the only willing advocate for a wrongful dismissal suit.",
+    "cast": [
+      "Tom Hanks",
+      "Denzel Washington",
+      "Roberta Maxwell",
+      "Buzz Kilman"
+    ]
   },
   {
     "movieId": "the-muppet-christmas-carol-1992",
@@ -8931,7 +14664,14 @@
     "year": 1992,
     "runtime": 85,
     "imdbRating": 7.7,
-    "rated": "G"
+    "rated": "G",
+    "synopsis": "The Muppet characters tell their version of the classic tale of an old and bitter miser's redemption on Christmas Eve.",
+    "cast": [
+      "Michael Caine",
+      "Kermit the Frog",
+      "Dave Goelz",
+      "Miss Piggy"
+    ]
   },
   {
     "movieId": "malcolm-x-1992",
@@ -8942,7 +14682,14 @@
     "year": 1992,
     "runtime": 202,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Biographical epic of the controversial and influential Black Nationalist leader, from his early life and career as a small-time gangster, to his ministry as a member of the Nation of Islam.",
+    "cast": [
+      "Denzel Washington",
+      "Angela Bassett",
+      "Delroy Lindo",
+      "Spike Lee"
+    ]
   },
   {
     "movieId": "the-last-of-the-mohicans-1992",
@@ -8953,7 +14700,14 @@
     "year": 1992,
     "runtime": 112,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Three trappers protect the daughters of a British Colonel in the midst of the French and Indian War.",
+    "cast": [
+      "Daniel Day-Lewis",
+      "Madeleine Stowe",
+      "Russell Means",
+      "Eric Schweig"
+    ]
   },
   {
     "movieId": "kurenai-no-buta-1992",
@@ -8964,7 +14718,14 @@
     "year": 1992,
     "runtime": 94,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In 1930s Italy, a veteran World War I pilot is cursed to look like an anthropomorphic pig.",
+    "cast": [
+      "Shûichirô Moriyama",
+      "Tokiko Katô",
+      "Bunshi Katsura Vi",
+      "Tsunehiko Kamijô"
+    ]
   },
   {
     "movieId": "glengarry-glen-ross-1992",
@@ -8975,7 +14736,14 @@
     "year": 1992,
     "runtime": 100,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "An examination of the machinations behind the scenes at a real estate office.",
+    "cast": [
+      "Al Pacino",
+      "Jack Lemmon",
+      "Alec Baldwin",
+      "Alan Arkin"
+    ]
   },
   {
     "movieId": "a-few-good-men-1992",
@@ -8986,7 +14754,14 @@
     "year": 1992,
     "runtime": 138,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Military lawyer Lieutenant Daniel Kaffee defends Marines accused of murder. They contend they were acting under orders.",
+    "cast": [
+      "Tom Cruise",
+      "Jack Nicholson",
+      "Demi Moore",
+      "Kevin Bacon"
+    ]
   },
   {
     "movieId": "fried-green-tomatoes-1991",
@@ -8997,7 +14772,14 @@
     "year": 1991,
     "runtime": 130,
     "imdbRating": 7.7,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A housewife who is unhappy with her life befriends an old lady in a nursing home and is enthralled by the tales she tells of people she used to know.",
+    "cast": [
+      "Kathy Bates",
+      "Jessica Tandy",
+      "Mary Stuart Masterson",
+      "Mary-Louise Parker"
+    ]
   },
   {
     "movieId": "barton-fink-1991",
@@ -9008,7 +14790,14 @@
     "year": 1991,
     "runtime": 116,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A renowned New York playwright is enticed to California to write for the movies and discovers the hellish truth of Hollywood.",
+    "cast": [
+      "Ethan Coen",
+      "John Turturro",
+      "John Goodman",
+      "Judy Davis"
+    ]
   },
   {
     "movieId": "miller-s-crossing-1990",
@@ -9019,7 +14808,14 @@
     "year": 1990,
     "runtime": 115,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Tom Reagan, an advisor to a Prohibition-era crime boss, tries to keep the peace between warring mobs but gets caught in divided loyalties.",
+    "cast": [
+      "Ethan Coen",
+      "Gabriel Byrne",
+      "Albert Finney",
+      "John Turturro"
+    ]
   },
   {
     "movieId": "who-framed-roger-rabbit-1988",
@@ -9030,7 +14826,14 @@
     "year": 1988,
     "runtime": 104,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A toon-hating detective is a cartoon rabbit's only hope to prove his innocence when he is accused of murder.",
+    "cast": [
+      "Bob Hoskins",
+      "Christopher Lloyd",
+      "Joanna Cassidy",
+      "Charles Fleischer"
+    ]
   },
   {
     "movieId": "spoorloos-1988",
@@ -9040,7 +14843,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNDcwMTYzMjctN2M2Yy00ZDcxLWJhNTEtMGNhYzEwYzc2NDE4XkEyXkFqcGdeQXVyNTI4MjkwNjA@._V1_SX4000.jpg",
     "year": 1988,
     "runtime": 107,
-    "imdbRating": 7.7
+    "imdbRating": 7.7,
+    "synopsis": "Rex and Saskia, a young couple in love, are on vacation. They stop at a busy service station and Saskia is abducted. After three years and no sign of Saskia, Rex begins receiving letters from the abductor.",
+    "cast": [
+      "Bernard-Pierre Donnadieu",
+      "Gene Bervoets",
+      "Johanna ter Steege",
+      "Gwen Eckhaus"
+    ]
   },
   {
     "movieId": "withnail-i-1987",
@@ -9051,7 +14861,14 @@
     "year": 1987,
     "runtime": 107,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "In 1969, two substance-abusing, unemployed actors retreat to the countryside for a holiday that proves disastrous.",
+    "cast": [
+      "Richard E. Grant",
+      "Paul McGann",
+      "Richard Griffiths",
+      "Ralph Brown"
+    ]
   },
   {
     "movieId": "the-last-emperor-1987",
@@ -9062,7 +14879,14 @@
     "year": 1987,
     "runtime": 163,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The story of the final Emperor of China.",
+    "cast": [
+      "John Lone",
+      "Joan Chen",
+      "Peter O'Toole",
+      "Ruocheng Ying"
+    ]
   },
   {
     "movieId": "empire-of-the-sun-1987",
@@ -9073,7 +14897,14 @@
     "year": 1987,
     "runtime": 153,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A young English boy struggles to survive under Japanese occupation during World War II.",
+    "cast": [
+      "Christian Bale",
+      "John Malkovich",
+      "Miranda Richardson",
+      "Nigel Havers"
+    ]
   },
   {
     "movieId": "der-name-der-rose-1986",
@@ -9084,7 +14915,14 @@
     "year": 1986,
     "runtime": 130,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "An intellectually nonconformist friar investigates a series of mysterious deaths in an isolated abbey.",
+    "cast": [
+      "Sean Connery",
+      "Christian Slater",
+      "Helmut Qualtinger",
+      "Elya Baskin"
+    ]
   },
   {
     "movieId": "blue-velvet-1986",
@@ -9095,7 +14933,14 @@
     "year": 1986,
     "runtime": 120,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The discovery of a severed human ear found in a field leads a young man on an investigation related to a beautiful, mysterious nightclub singer and a group of psychopathic criminals who have kidnapped her child.",
+    "cast": [
+      "Isabella Rossellini",
+      "Kyle MacLachlan",
+      "Dennis Hopper",
+      "Laura Dern"
+    ]
   },
   {
     "movieId": "the-purple-rose-of-cairo-1985",
@@ -9106,7 +14951,14 @@
     "year": 1985,
     "runtime": 82,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In New Jersey in 1935, a movie character walks off the screen and into the real world.",
+    "cast": [
+      "Mia Farrow",
+      "Jeff Daniels",
+      "Danny Aiello",
+      "Irving Metzman"
+    ]
   },
   {
     "movieId": "after-hours-1985",
@@ -9117,7 +14969,14 @@
     "year": 1985,
     "runtime": 97,
     "imdbRating": 7.7,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "An ordinary word processor has the worst night of his life after he agrees to visit a girl in Soho who he met that evening at a coffee shop.",
+    "cast": [
+      "Griffin Dunne",
+      "Rosanna Arquette",
+      "Verna Bloom",
+      "Tommy Chong"
+    ]
   },
   {
     "movieId": "zelig-1983",
@@ -9128,7 +14987,14 @@
     "year": 1983,
     "runtime": 79,
     "imdbRating": 7.7,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "\"Documentary\" about a man who can look and act like whoever he's around, and meets various famous people.",
+    "cast": [
+      "Woody Allen",
+      "Mia Farrow",
+      "Patrick Horgan",
+      "John Buckwalter"
+    ]
   },
   {
     "movieId": "the-verdict-1982",
@@ -9139,7 +15005,14 @@
     "year": 1982,
     "runtime": 129,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A lawyer sees the chance to salvage his career and self-respect by taking a medical malpractice case to trial rather than settling.",
+    "cast": [
+      "Paul Newman",
+      "Charlotte Rampling",
+      "Jack Warden",
+      "James Mason"
+    ]
   },
   {
     "movieId": "star-trek-ii-the-wrath-of-khan-1982",
@@ -9150,7 +15023,14 @@
     "year": 1982,
     "runtime": 113,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "With the assistance of the Enterprise crew, Admiral Kirk must stop an old nemesis, Khan Noonien Singh, from using the life-generating Genesis Device as the ultimate weapon.",
+    "cast": [
+      "William Shatner",
+      "Leonard Nimoy",
+      "DeForest Kelley",
+      "James Doohan"
+    ]
   },
   {
     "movieId": "first-blood-1982",
@@ -9161,7 +15041,14 @@
     "year": 1982,
     "runtime": 93,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A veteran Green Beret is forced by a cruel Sheriff and his deputies to flee into the mountains and wage an escalating one-man war against his pursuers.",
+    "cast": [
+      "Sylvester Stallone",
+      "Brian Dennehy",
+      "Richard Crenna",
+      "Bill McKinney"
+    ]
   },
   {
     "movieId": "ordinary-people-1980",
@@ -9172,7 +15059,14 @@
     "year": 1980,
     "runtime": 124,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The accidental death of the older son of an affluent family deeply strains the relationships among the bitter mother, the good-natured father, and the guilt-ridden younger son.",
+    "cast": [
+      "Donald Sutherland",
+      "Mary Tyler Moore",
+      "Judd Hirsch",
+      "Timothy Hutton"
+    ]
   },
   {
     "movieId": "airplane-1980",
@@ -9183,7 +15077,14 @@
     "year": 1980,
     "runtime": 88,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A man afraid to fly must ensure that a plane lands safely after the pilots become sick.",
+    "cast": [
+      "David Zucker",
+      "Jerry Zucker",
+      "Robert Hays",
+      "Julie Hagerty"
+    ]
   },
   {
     "movieId": "rupan-sansei-kariosutoro-no-shiro-1979",
@@ -9194,7 +15095,14 @@
     "year": 1979,
     "runtime": 100,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A dashing thief, his gang of desperadoes and an intrepid policeman struggle to free a princess from an evil count's clutches, and learn the hidden secret to a fabulous treasure that she holds part of a key to.",
+    "cast": [
+      "Yasuo Yamada",
+      "Eiko Masuyama",
+      "Kiyoshi Kobayashi",
+      "Makio Inoue"
+    ]
   },
   {
     "movieId": "halloween-1978",
@@ -9205,7 +15113,14 @@
     "year": 1978,
     "runtime": 91,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Fifteen years after murdering his sister on Halloween night 1963, Michael Myers escapes from a mental hospital and returns to the small town of Haddonfield, Illinois to kill again.",
+    "cast": [
+      "Donald Pleasence",
+      "Jamie Lee Curtis",
+      "Tony Moran",
+      "Nancy Kyes"
+    ]
   },
   {
     "movieId": "le-locataire-1976",
@@ -9216,7 +15131,14 @@
     "year": 1976,
     "runtime": 126,
     "imdbRating": 7.7,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A bureaucrat rents a Paris apartment where he finds himself drawn into a rabbit hole of dangerous paranoia.",
+    "cast": [
+      "Roman Polanski",
+      "Isabelle Adjani",
+      "Melvyn Douglas",
+      "Jo Van Fleet"
+    ]
   },
   {
     "movieId": "love-and-death-1975",
@@ -9227,7 +15149,14 @@
     "year": 1975,
     "runtime": 85,
     "imdbRating": 7.7,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "In czarist Russia, a neurotic soldier and his distant cousin formulate a plot to assassinate Napoleon.",
+    "cast": [
+      "Woody Allen",
+      "Diane Keaton",
+      "Georges Adet",
+      "Frank Adu"
+    ]
   },
   {
     "movieId": "the-taking-of-pelham-one-two-three-1974",
@@ -9238,7 +15167,14 @@
     "year": 1974,
     "runtime": 104,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In New York, armed men hijack a subway car and demand a ransom for the passengers. Even if it's paid, how could they get away?",
+    "cast": [
+      "Walter Matthau",
+      "Robert Shaw",
+      "Martin Balsam",
+      "Hector Elizondo"
+    ]
   },
   {
     "movieId": "blazing-saddles-1974",
@@ -9249,7 +15185,14 @@
     "year": 1974,
     "runtime": 93,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In order to ruin a western town, a corrupt politician appoints a black Sheriff, who promptly becomes his most formidable adversary.",
+    "cast": [
+      "Cleavon Little",
+      "Gene Wilder",
+      "Slim Pickens",
+      "Harvey Korman"
+    ]
   },
   {
     "movieId": "serpico-1973",
@@ -9260,7 +15203,14 @@
     "year": 1973,
     "runtime": 130,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An honest New York cop named Frank Serpico blows the whistle on rampant corruption in the force only to have his comrades turn against him.",
+    "cast": [
+      "Al Pacino",
+      "John Randolph",
+      "Jack Kehoe",
+      "Biff McGuire"
+    ]
   },
   {
     "movieId": "enter-the-dragon-1973",
@@ -9271,7 +15221,14 @@
     "year": 1973,
     "runtime": 102,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A secret agent comes to an opium lord's island fortress with other fighters for a martial-arts tournament.",
+    "cast": [
+      "Bruce Lee",
+      "John Saxon",
+      "Jim Kelly",
+      "Ahna Capri"
+    ]
   },
   {
     "movieId": "deliverance-1972",
@@ -9282,7 +15239,14 @@
     "year": 1972,
     "runtime": 109,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Intent on seeing the Cahulawassee River before it's dammed and turned into a lake, outdoor fanatic Lewis Medlock takes his friends on a canoeing trip they'll never forget into the dangerous American back-country.",
+    "cast": [
+      "Jon Voight",
+      "Burt Reynolds",
+      "Ned Beatty",
+      "Ronny Cox"
+    ]
   },
   {
     "movieId": "the-french-connection-1971",
@@ -9293,7 +15257,14 @@
     "year": 1971,
     "runtime": 104,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A pair of NYC cops in the Narcotics Bureau stumble onto a drug smuggling job with a French connection.",
+    "cast": [
+      "Gene Hackman",
+      "Roy Scheider",
+      "Fernando Rey",
+      "Tony Lo Bianco"
+    ]
   },
   {
     "movieId": "dirty-harry-1971",
@@ -9304,7 +15275,14 @@
     "year": 1971,
     "runtime": 102,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "When a madman calling himself \"the Scorpio Killer\" menaces the city, tough-as-nails San Francisco Police Inspector \"Dirty\" Harry Callahan is assigned to track down and ferret out the crazed psychopath.",
+    "cast": [
+      "Clint Eastwood",
+      "Andrew Robinson",
+      "Harry Guardino",
+      "Reni Santoni"
+    ]
   },
   {
     "movieId": "where-eagles-dare-1968",
@@ -9315,7 +15293,14 @@
     "year": 1968,
     "runtime": 158,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Allied agents stage a daring raid on a castle where the Nazis are holding American brigadier general George Carnaby prisoner, but that's not all that's really going on.",
+    "cast": [
+      "Richard Burton",
+      "Clint Eastwood",
+      "Mary Ure",
+      "Patrick Wymark"
+    ]
   },
   {
     "movieId": "the-odd-couple-1968",
@@ -9326,7 +15311,14 @@
     "year": 1968,
     "runtime": 105,
     "imdbRating": 7.7,
-    "rated": "G"
+    "rated": "G",
+    "synopsis": "Two friends try sharing an apartment, but their ideas of housekeeping and lifestyles are as different as night and day.",
+    "cast": [
+      "Jack Lemmon",
+      "Walter Matthau",
+      "John Fiedler",
+      "Herb Edelman"
+    ]
   },
   {
     "movieId": "the-dirty-dozen-1967",
@@ -9336,7 +15328,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BM2Y1ZTI0NzktYzU3MS00YmE1LThkY2EtMDc0NGYxNTNlZDA5XkEyXkFqcGdeQXVyNTAyODkwOQ@@._V1_SX4000.jpg",
     "year": 1967,
     "runtime": 150,
-    "imdbRating": 7.7
+    "imdbRating": 7.7,
+    "synopsis": "During World War II, a rebellious U.S. Army Major is assigned a dozen convicted murderers to train and lead them into a mass assassination mission of German officers.",
+    "cast": [
+      "Lee Marvin",
+      "Ernest Borgnine",
+      "Charles Bronson",
+      "John Cassavetes"
+    ]
   },
   {
     "movieId": "belle-de-jour-1967",
@@ -9347,7 +15346,14 @@
     "year": 1967,
     "runtime": 100,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A frigid young housewife decides to spend her midweek afternoons as a prostitute.",
+    "cast": [
+      "Catherine Deneuve",
+      "Jean Sorel",
+      "Michel Piccoli",
+      "Geneviève Page"
+    ]
   },
   {
     "movieId": "a-man-for-all-seasons-1966",
@@ -9358,7 +15364,14 @@
     "year": 1966,
     "runtime": 120,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The story of Sir Thomas More, who stood up to King Henry VIII when the King rejected the Roman Catholic Church to obtain a divorce and remarry.",
+    "cast": [
+      "Paul Scofield",
+      "Wendy Hiller",
+      "Robert Shaw",
+      "Leo McKern"
+    ]
   },
   {
     "movieId": "repulsion-1965",
@@ -9368,7 +15381,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BZTU5ZThjNzAtNjc4NC00OTViLWIxYTYtODFmMTk5Y2NjZjZiL2ltYWdlL2ltYWdlXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_SX4000.jpg",
     "year": 1965,
     "runtime": 105,
-    "imdbRating": 7.7
+    "imdbRating": 7.7,
+    "synopsis": "A sex-repulsed woman who disapproves of her sister's boyfriend sinks into depression and has horrific visions of rape and violence.",
+    "cast": [
+      "Catherine Deneuve",
+      "Ian Hendry",
+      "John Fraser",
+      "Yvonne Furneaux"
+    ]
   },
   {
     "movieId": "zulu-1964",
@@ -9379,7 +15399,14 @@
     "year": 1964,
     "runtime": 138,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Outnumbered British soldiers do battle with Zulu warriors at Rorke's Drift.",
+    "cast": [
+      "Stanley Baker",
+      "Jack Hawkins",
+      "Ulla Jacobsson",
+      "James Booth"
+    ]
   },
   {
     "movieId": "goldfinger-1964",
@@ -9390,7 +15417,14 @@
     "year": 1964,
     "runtime": 110,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "While investigating a gold magnate's smuggling, James Bond uncovers a plot to contaminate the Fort Knox gold reserve.",
+    "cast": [
+      "Sean Connery",
+      "Gert Fröbe",
+      "Honor Blackman",
+      "Shirley Eaton"
+    ]
   },
   {
     "movieId": "the-birds-1963",
@@ -9401,7 +15435,14 @@
     "year": 1963,
     "runtime": 119,
     "imdbRating": 7.7,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A wealthy San Francisco socialite pursues a potential boyfriend to a small Northern California town that slowly takes a turn for the bizarre when birds of all kinds suddenly begin to attack people.",
+    "cast": [
+      "Rod Taylor",
+      "Tippi Hedren",
+      "Jessica Tandy",
+      "Suzanne Pleshette"
+    ]
   },
   {
     "movieId": "cape-fear-1962",
@@ -9412,7 +15453,14 @@
     "year": 1962,
     "runtime": 106,
     "imdbRating": 7.7,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A lawyer's family is stalked by a man he once helped put in jail.",
+    "cast": [
+      "Gregory Peck",
+      "Robert Mitchum",
+      "Polly Bergen",
+      "Lori Martin"
+    ]
   },
   {
     "movieId": "peeping-tom-1960",
@@ -9422,7 +15470,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BZjM3ZTAzZDYtZmFjZS00YmQ1LWJlOWEtN2I4MDRmYzY5YmRlL2ltYWdlXkEyXkFqcGdeQXVyMjgyNjk3MzE@._V1_SX4000.jpg",
     "year": 1960,
     "runtime": 101,
-    "imdbRating": 7.7
+    "imdbRating": 7.7,
+    "synopsis": "A young man murders women, using a movie camera to film their dying expressions of terror.",
+    "cast": [
+      "Karlheinz Böhm",
+      "Anna Massey",
+      "Moira Shearer",
+      "Maxine Audley"
+    ]
   },
   {
     "movieId": "the-magnificent-seven-1960",
@@ -9433,7 +15488,14 @@
     "year": 1960,
     "runtime": 128,
     "imdbRating": 7.7,
-    "rated": "Approved"
+    "rated": "Approved",
+    "synopsis": "Seven gunfighters are hired by Mexican peasants to liberate their village from oppressive bandits.",
+    "cast": [
+      "Yul Brynner",
+      "Steve McQueen",
+      "Charles Bronson",
+      "Eli Wallach"
+    ]
   },
   {
     "movieId": "les-yeux-sans-visage-1960",
@@ -9443,7 +15505,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNzBiMWRhNzQtMjZhZS00NzFmLWE5YWMtOWY4NzIxMjYzZTEyXkEyXkFqcGdeQXVyMzg2MzE2OTE@._V1_SX4000.jpg",
     "year": 1960,
     "runtime": 90,
-    "imdbRating": 7.7
+    "imdbRating": 7.7,
+    "synopsis": "A surgeon causes an accident which leaves his daughter disfigured, and goes to extremes to give her a new face.",
+    "cast": [
+      "Pierre Brasseur",
+      "Alida Valli",
+      "Juliette Mayniel",
+      "Alexandre Rignault"
+    ]
   },
   {
     "movieId": "invasion-of-the-body-snatchers-1956",
@@ -9454,7 +15523,14 @@
     "year": 1956,
     "runtime": 80,
     "imdbRating": 7.7,
-    "rated": "Approved"
+    "rated": "Approved",
+    "synopsis": "A small-town doctor learns that the population of his community is being replaced by emotionless alien duplicates.",
+    "cast": [
+      "Kevin McCarthy",
+      "Dana Wynter",
+      "Larry Gates",
+      "King Donovan"
+    ]
   },
   {
     "movieId": "rebel-without-a-cause-1955",
@@ -9465,7 +15541,14 @@
     "year": 1955,
     "runtime": 111,
     "imdbRating": 7.7,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A rebellious young man with a troubled past comes to a new town, finding friends and enemies.",
+    "cast": [
+      "James Dean",
+      "Natalie Wood",
+      "Sal Mineo",
+      "Jim Backus"
+    ]
   },
   {
     "movieId": "the-ladykillers-1955",
@@ -9475,7 +15558,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BYTVlM2JmOGQtNWEwYy00NDQzLWIyZmEtOGZhMzgxZGRjZDA0XkEyXkFqcGdeQXVyMDI2NDg0NQ@@._V1_SX4000.jpg",
     "year": 1955,
     "runtime": 91,
-    "imdbRating": 7.7
+    "imdbRating": 7.7,
+    "synopsis": "Five oddball criminals planning a bank robbery rent rooms on a cul-de-sac from an octogenarian widow under the pretext that they are classical musicians.",
+    "cast": [
+      "Alec Guinness",
+      "Peter Sellers",
+      "Cecil Parker",
+      "Herbert Lom"
+    ]
   },
   {
     "movieId": "sabrina-1954",
@@ -9486,7 +15576,14 @@
     "year": 1954,
     "runtime": 113,
     "imdbRating": 7.7,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A playboy becomes interested in the daughter of his family's chauffeur, but it's his more serious brother who would be the better man for her.",
+    "cast": [
+      "Humphrey Bogart",
+      "Audrey Hepburn",
+      "William Holden",
+      "Walter Hampden"
+    ]
   },
   {
     "movieId": "the-quiet-man-1952",
@@ -9497,7 +15594,14 @@
     "year": 1952,
     "runtime": 129,
     "imdbRating": 7.7,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "A retired American boxer returns to the village of his birth in Ireland, where he falls for a spirited redhead whose brother is contemptuous of their union.",
+    "cast": [
+      "John Wayne",
+      "Maureen O'Hara",
+      "Barry Fitzgerald",
+      "Ward Bond"
+    ]
   },
   {
     "movieId": "the-day-the-earth-stood-still-1951",
@@ -9508,7 +15612,14 @@
     "year": 1951,
     "runtime": 92,
     "imdbRating": 7.7,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "An alien lands and tells the people of Earth that they must live peacefully or be destroyed as a danger to other planets.",
+    "cast": [
+      "Michael Rennie",
+      "Patricia Neal",
+      "Hugh Marlowe",
+      "Sam Jaffe"
+    ]
   },
   {
     "movieId": "the-african-queen-1951",
@@ -9519,7 +15630,14 @@
     "year": 1951,
     "runtime": 105,
     "imdbRating": 7.7,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "In WWI Africa, a gin-swilling riverboat captain is persuaded by a strait-laced missionary to use his boat to attack an enemy warship.",
+    "cast": [
+      "Humphrey Bogart",
+      "Katharine Hepburn",
+      "Robert Morley",
+      "Peter Bull"
+    ]
   },
   {
     "movieId": "gilda-1946",
@@ -9530,7 +15648,14 @@
     "year": 1946,
     "runtime": 110,
     "imdbRating": 7.7,
-    "rated": "Approved"
+    "rated": "Approved",
+    "synopsis": "A small-time gambler hired to work in a Buenos Aires casino discovers his employer's new wife is his former lover.",
+    "cast": [
+      "Rita Hayworth",
+      "Glenn Ford",
+      "George Macready",
+      "Joseph Calleia"
+    ]
   },
   {
     "movieId": "fantasia-1940",
@@ -9541,7 +15666,14 @@
     "year": 1940,
     "runtime": 125,
     "imdbRating": 7.7,
-    "rated": "G"
+    "rated": "G",
+    "synopsis": "A collection of animated interpretations of great works of Western classical music.",
+    "cast": [
+      "Samuel Armstrong",
+      "Ford Beebe Jr.",
+      "Norman Ferguson",
+      "David Hand"
+    ]
   },
   {
     "movieId": "the-invisible-man-1933",
@@ -9552,7 +15684,14 @@
     "year": 1933,
     "runtime": 71,
     "imdbRating": 7.7,
-    "rated": "TV-PG"
+    "rated": "TV-PG",
+    "synopsis": "A scientist finds a way of becoming invisible, but in doing so, he becomes murderously insane.",
+    "cast": [
+      "Claude Rains",
+      "Gloria Stuart",
+      "William Harrigan",
+      "Henry Travers"
+    ]
   },
   {
     "movieId": "dark-waters-2019",
@@ -9563,7 +15702,14 @@
     "year": 2019,
     "runtime": 126,
     "imdbRating": 7.6,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A corporate defense attorney takes on an environmental lawsuit against a chemical company that exposes a lengthy history of pollution.",
+    "cast": [
+      "Mark Ruffalo",
+      "Anne Hathaway",
+      "Tim Robbins",
+      "Bill Pullman"
+    ]
   },
   {
     "movieId": "searching-2018",
@@ -9574,7 +15720,14 @@
     "year": 2018,
     "runtime": 102,
     "imdbRating": 7.6,
-    "rated": "U/A"
+    "rated": "U/A",
+    "synopsis": "After his teenage daughter goes missing, a desperate father tries to find clues on her laptop.",
+    "cast": [
+      "John Cho",
+      "Debra Messing",
+      "Joseph Lee",
+      "Michelle La"
+    ]
   },
   {
     "movieId": "once-upon-a-time-in-hollywood-2019",
@@ -9585,7 +15738,14 @@
     "year": 2019,
     "runtime": 161,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A faded television actor and his stunt double strive to achieve fame and success in the final years of Hollywood's Golden Age in 1969 Los Angeles.",
+    "cast": [
+      "Leonardo DiCaprio",
+      "Brad Pitt",
+      "Margot Robbie",
+      "Emile Hirsch"
+    ]
   },
   {
     "movieId": "nelyubov-2017",
@@ -9596,7 +15756,14 @@
     "year": 2017,
     "runtime": 127,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A couple going through a divorce must team up to find their son who has disappeared during one of their bitter arguments.",
+    "cast": [
+      "Maryana Spivak",
+      "Aleksey Rozin",
+      "Matvey Novikov",
+      "Marina Vasileva"
+    ]
   },
   {
     "movieId": "the-florida-project-2017",
@@ -9607,7 +15774,14 @@
     "year": 2017,
     "runtime": 111,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Set over one summer, the film follows precocious six-year-old Moonee as she courts mischief and adventure with her ragtag playmates and bonds with her rebellious but caring mother, all while living in the shadows of Walt Disney World.",
+    "cast": [
+      "Brooklynn Prince",
+      "Bria Vinaite",
+      "Willem Dafoe",
+      "Christopher Rivera"
+    ]
   },
   {
     "movieId": "just-mercy-2019",
@@ -9618,7 +15792,14 @@
     "year": 2019,
     "runtime": 137,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "World-renowned civil rights defense attorney Bryan Stevenson works to free a wrongly condemned death row prisoner.",
+    "cast": [
+      "Michael B. Jordan",
+      "Jamie Foxx",
+      "Brie Larson",
+      "Charlie Pye Jr."
+    ]
   },
   {
     "movieId": "gifted-2017",
@@ -9629,7 +15810,14 @@
     "year": 2017,
     "runtime": 101,
     "imdbRating": 7.6,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "Frank, a single man raising his child prodigy niece Mary, is drawn into a custody battle with his mother.",
+    "cast": [
+      "Chris Evans",
+      "Mckenna Grace",
+      "Lindsay Duncan",
+      "Octavia Spencer"
+    ]
   },
   {
     "movieId": "the-peanut-butter-falcon-2019",
@@ -9640,7 +15828,14 @@
     "year": 2019,
     "runtime": 97,
     "imdbRating": 7.6,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "Zak runs away from his care home to make his dream of becoming a wrestler come true.",
+    "cast": [
+      "Michael Schwartz",
+      "Zack Gottsagen",
+      "Ann Owens",
+      "Dakota Johnson"
+    ]
   },
   {
     "movieId": "victoria-2015",
@@ -9650,7 +15845,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTc5NzQzNjk2NF5BMl5BanBnXkFtZTgwODU0MjI5NjE@._V1_SX4000.jpg",
     "year": 2015,
     "runtime": 138,
-    "imdbRating": 7.6
+    "imdbRating": 7.6,
+    "synopsis": "A young Spanish woman who has recently moved to Berlin finds her flirtation with a local guy turn potentially deadly as their night out with his friends reveals a dangerous secret.",
+    "cast": [
+      "Laia Costa",
+      "Frederick Lau",
+      "Franz Rogowski",
+      "Burak Yigit"
+    ]
   },
   {
     "movieId": "mustang-2015",
@@ -9661,7 +15863,14 @@
     "year": 2015,
     "runtime": 97,
     "imdbRating": 7.6,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "When five orphan girls are seen innocently playing with boys on a beach, their scandalized conservative guardians confine them while forced marriages are arranged.",
+    "cast": [
+      "Günes Sensoy",
+      "Doga Zeynep Doguslu",
+      "Tugba Sunguroglu",
+      "Elit Iscan"
+    ]
   },
   {
     "movieId": "guardians-of-the-galaxy-vol-2-2017",
@@ -9672,7 +15881,14 @@
     "year": 2017,
     "runtime": 136,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The Guardians struggle to keep together as a team while dealing with their personal family issues, notably Star-Lord's encounter with his father the ambitious celestial being Ego.",
+    "cast": [
+      "Chris Pratt",
+      "Zoe Saldana",
+      "Dave Bautista",
+      "Vin Diesel"
+    ]
   },
   {
     "movieId": "baby-driver-2017",
@@ -9683,7 +15899,14 @@
     "year": 2017,
     "runtime": 113,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "After being coerced into working for a crime boss, a young getaway driver finds himself taking part in a heist doomed to fail.",
+    "cast": [
+      "Ansel Elgort",
+      "Jon Bernthal",
+      "Jon Hamm",
+      "Eiza González"
+    ]
   },
   {
     "movieId": "only-the-brave-2017",
@@ -9694,7 +15917,14 @@
     "year": 2017,
     "runtime": 134,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Based on the true story of the Granite Mountain Hotshots, a group of elite firefighters who risk everything to protect a town from a historic wildfire.",
+    "cast": [
+      "Josh Brolin",
+      "Miles Teller",
+      "Jeff Bridges",
+      "Jennifer Connelly"
+    ]
   },
   {
     "movieId": "bridge-of-spies-2015",
@@ -9705,7 +15935,14 @@
     "year": 2015,
     "runtime": 142,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "During the Cold War, an American lawyer is recruited to defend an arrested Soviet spy in court, and then help the CIA facilitate an exchange of the spy for the Soviet captured American U2 spy plane pilot, Francis Gary Powers.",
+    "cast": [
+      "Tom Hanks",
+      "Mark Rylance",
+      "Alan Alda",
+      "Amy Ryan"
+    ]
   },
   {
     "movieId": "incredibles-2-2018",
@@ -9716,7 +15953,14 @@
     "year": 2018,
     "runtime": 118,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The Incredibles family takes on a new mission which involves a change in family roles: Bob Parr (Mr. Incredible) must manage the house while his wife Helen (Elastigirl) goes out to save the world.",
+    "cast": [
+      "Craig T. Nelson",
+      "Holly Hunter",
+      "Sarah Vowell",
+      "Huck Milner"
+    ]
   },
   {
     "movieId": "moana-2016",
@@ -9727,7 +15971,14 @@
     "year": 2016,
     "runtime": 107,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In Ancient Polynesia, when a terrible curse incurred by the Demigod Maui reaches Moana's island, she answers the Ocean's call to seek out the Demigod to set things right.",
+    "cast": [
+      "John Musker",
+      "Don Hall",
+      "Chris Williams",
+      "Auli'i Cravalho"
+    ]
   },
   {
     "movieId": "sicario-2015",
@@ -9738,7 +15989,14 @@
     "year": 2015,
     "runtime": 121,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "An idealistic FBI agent is enlisted by a government task force to aid in the escalating war against drugs at the border area between the U.S. and Mexico.",
+    "cast": [
+      "Emily Blunt",
+      "Josh Brolin",
+      "Benicio Del Toro",
+      "Jon Bernthal"
+    ]
   },
   {
     "movieId": "creed-2015",
@@ -9749,7 +16007,14 @@
     "year": 2015,
     "runtime": 133,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The former World Heavyweight Champion Rocky Balboa serves as a trainer and mentor to Adonis Johnson, the son of his late friend and former rival Apollo Creed.",
+    "cast": [
+      "Michael B. Jordan",
+      "Sylvester Stallone",
+      "Tessa Thompson",
+      "Phylicia Rashad"
+    ]
   },
   {
     "movieId": "leviafan-2014",
@@ -9760,7 +16025,14 @@
     "year": 2014,
     "runtime": 140,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "In a Russian coastal town, Kolya is forced to fight the corrupt mayor when he is told that his house will be demolished. He recruits a lawyer friend to help, but the man's arrival brings further misfortune for Kolya and his family.",
+    "cast": [
+      "Aleksey Serebryakov",
+      "Elena Lyadova",
+      "Roman Madyanov",
+      "Vladimir Vdovichenkov"
+    ]
   },
   {
     "movieId": "hell-or-high-water-2016",
@@ -9771,7 +16043,14 @@
     "year": 2016,
     "runtime": 102,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A divorced father and his ex-con older brother resort to a desperate scheme in order to save their family's ranch in West Texas.",
+    "cast": [
+      "Chris Pine",
+      "Ben Foster",
+      "Jeff Bridges",
+      "Gil Birmingham"
+    ]
   },
   {
     "movieId": "philomena-2013",
@@ -9782,7 +16061,14 @@
     "year": 2013,
     "runtime": 98,
     "imdbRating": 7.6,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A world-weary political journalist picks up the story of a woman's search for her son, who was taken away from her decades ago after she became pregnant and was forced to live in a convent.",
+    "cast": [
+      "Judi Dench",
+      "Steve Coogan",
+      "Sophie Kennedy Clark",
+      "Mare Winningham"
+    ]
   },
   {
     "movieId": "dawn-of-the-planet-of-the-apes-2014",
@@ -9793,7 +16079,14 @@
     "year": 2014,
     "runtime": 130,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A growing nation of genetically evolved apes led by Caesar is threatened by a band of human survivors of the devastating virus unleashed a decade earlier.",
+    "cast": [
+      "Gary Oldman",
+      "Keri Russell",
+      "Andy Serkis",
+      "Kodi Smit-McPhee"
+    ]
   },
   {
     "movieId": "el-cuerpo-2012",
@@ -9803,7 +16096,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNGMxZjFkN2EtMDRiMS00ZTBjLWI0M2MtZWUyYjFhZGViZDJlXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_SX4000.jpg",
     "year": 2012,
     "runtime": 112,
-    "imdbRating": 7.6
+    "imdbRating": 7.6,
+    "synopsis": "A detective searches for the body of a femme fatale which has gone missing from a morgue.",
+    "cast": [
+      "Jose Coronado",
+      "Hugo Silva",
+      "Belén Rueda",
+      "Aura Garrido"
+    ]
   },
   {
     "movieId": "serbuan-maut-2011",
@@ -9814,7 +16114,14 @@
     "year": 2011,
     "runtime": 101,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A S.W.A.T. team becomes trapped in a tenement run by a ruthless mobster and his army of killers and thugs.",
+    "cast": [
+      "Iko Uwais",
+      "Ananda George",
+      "Ray Sahetapy",
+      "Donny Alamsyah"
+    ]
   },
   {
     "movieId": "end-of-watch-2012",
@@ -9825,7 +16132,14 @@
     "year": 2012,
     "runtime": 109,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Shot documentary-style, this film follows the daily grind of two young police officers in LA who are partners and friends, and what happens when they meet criminal forces greater than themselves.",
+    "cast": [
+      "Jake Gyllenhaal",
+      "Michael Peña",
+      "Anna Kendrick",
+      "America Ferrera"
+    ]
   },
   {
     "movieId": "kari-gurashi-no-arietti-2010",
@@ -9836,7 +16150,14 @@
     "year": 2010,
     "runtime": 94,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The Clock family are four-inch-tall people who live anonymously in another family's residence, borrowing simple items to make their home. Life changes for the Clocks when their teenage daughter, Arrietty, is discovered.",
+    "cast": [
+      "Amy Poehler",
+      "Mirai Shida",
+      "Ryûnosuke Kamiki",
+      "Tatsuya Fujiwara"
+    ]
   },
   {
     "movieId": "a-star-is-born-2018",
@@ -9847,7 +16168,14 @@
     "year": 2018,
     "runtime": 136,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A musician helps a young singer find fame as age and alcoholism send his own career into a downward spiral.",
+    "cast": [
+      "Lady Gaga",
+      "Bradley Cooper",
+      "Sam Elliott",
+      "Greg Grunberg"
+    ]
   },
   {
     "movieId": "true-grit-2010",
@@ -9858,7 +16186,14 @@
     "year": 2010,
     "runtime": 110,
     "imdbRating": 7.6,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A stubborn teenager enlists the help of a tough U.S. Marshal to track down her father's murderer.",
+    "cast": [
+      "Joel Coen",
+      "Jeff Bridges",
+      "Matt Damon",
+      "Hailee Steinfeld"
+    ]
   },
   {
     "movieId": "h-vnen-2010",
@@ -9869,7 +16204,14 @@
     "year": 2010,
     "runtime": 118,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "The lives of two Danish families cross each other, and an extraordinary but risky friendship comes into bud. But loneliness, frailty and sorrow lie in wait.",
+    "cast": [
+      "Mikael Persbrandt",
+      "Trine Dyrholm",
+      "Markus Rygaard",
+      "Wil Johnson"
+    ]
   },
   {
     "movieId": "despicable-me-2010",
@@ -9880,7 +16222,14 @@
     "year": 2010,
     "runtime": 95,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "When a criminal mastermind uses a trio of orphan girls as pawns for a grand scheme, he finds their love is profoundly changing him for the better.",
+    "cast": [
+      "Chris Renaud",
+      "Steve Carell",
+      "Jason Segel",
+      "Russell Brand"
+    ]
   },
   {
     "movieId": "50-50-2011",
@@ -9891,7 +16240,14 @@
     "year": 2011,
     "runtime": 100,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Inspired by a true story, a comedy centered on a 27-year-old guy who learns of his cancer diagnosis and his subsequent struggle to beat the disease.",
+    "cast": [
+      "Joseph Gordon-Levitt",
+      "Seth Rogen",
+      "Anna Kendrick",
+      "Bryce Dallas Howard"
+    ]
   },
   {
     "movieId": "kick-ass-2010",
@@ -9902,7 +16258,14 @@
     "year": 2010,
     "runtime": 117,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Dave Lizewski is an unnoticed high school student and comic book fan who one day decides to become a superhero, even though he has no powers, training or meaningful reason to do so.",
+    "cast": [
+      "Aaron Taylor-Johnson",
+      "Nicolas Cage",
+      "Chloë Grace Moretz",
+      "Garrett M. Brown"
+    ]
   },
   {
     "movieId": "celda-211-2009",
@@ -9912,7 +16275,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMjI2ODE4ODAtMDA3MS00ODNkLTg4N2EtOGU0YjZmNGY4NjZlXkEyXkFqcGdeQXVyMTY5MDE5NA@@._V1_SX4000.jpg",
     "year": 2009,
     "runtime": 113,
-    "imdbRating": 7.6
+    "imdbRating": 7.6,
+    "synopsis": "The story of two men on different sides of a prison riot -- the inmate leading the rebellion and the young guard trapped in the revolt, who poses as a prisoner in a desperate attempt to survive the ordeal.",
+    "cast": [
+      "Luis Tosar",
+      "Alberto Ammann",
+      "Antonio Resines",
+      "Manuel Morón"
+    ]
   },
   {
     "movieId": "moneyball-2011",
@@ -9923,7 +16293,14 @@
     "year": 2011,
     "runtime": 133,
     "imdbRating": 7.6,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "Oakland A's general manager Billy Beane's successful attempt to assemble a baseball team on a lean budget by employing computer-generated analysis to acquire new players.",
+    "cast": [
+      "Brad Pitt",
+      "Robin Wright",
+      "Jonah Hill",
+      "Philip Seymour Hoffman"
+    ]
   },
   {
     "movieId": "la-piel-que-habito-2011",
@@ -9934,7 +16311,14 @@
     "year": 2011,
     "runtime": 120,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A brilliant plastic surgeon, haunted by past tragedies, creates a type of synthetic skin that withstands any kind of damage. His guinea pig: a mysterious and volatile woman who holds the key to his obsession.",
+    "cast": [
+      "Antonio Banderas",
+      "Elena Anaya",
+      "Jan Cornet",
+      "Marisa Paredes"
+    ]
   },
   {
     "movieId": "zombieland-2009",
@@ -9945,7 +16329,14 @@
     "year": 2009,
     "runtime": 88,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A shy student trying to reach his family in Ohio, a gun-toting tough guy trying to find the last Twinkie, and a pair of sisters trying to get to an amusement park join forces to travel across a zombie-filled America.",
+    "cast": [
+      "Jesse Eisenberg",
+      "Emma Stone",
+      "Woody Harrelson",
+      "Abigail Breslin"
+    ]
   },
   {
     "movieId": "die-welle-2008",
@@ -9955,7 +16346,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMzc0ZmUyZjAtZThkMi00ZDY5LTg5YjctYmUwM2FiYjMyMDI5XkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_SX4000.jpg",
     "year": 2008,
     "runtime": 107,
-    "imdbRating": 7.6
+    "imdbRating": 7.6,
+    "synopsis": "A high school teacher's experiment to demonstrate to his students what life is like under a dictatorship spins horribly out of control when he forms a social unit with a life of its own.",
+    "cast": [
+      "Jürgen Vogel",
+      "Frederick Lau",
+      "Max Riemelt",
+      "Jennifer Ulrich"
+    ]
   },
   {
     "movieId": "sherlock-holmes-2009",
@@ -9966,7 +16364,14 @@
     "year": 2009,
     "runtime": 128,
     "imdbRating": 7.6,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "Detective Sherlock Holmes and his stalwart partner Watson engage in a battle of wits and brawn with a nemesis whose plot is a threat to all of England.",
+    "cast": [
+      "Robert Downey Jr.",
+      "Jude Law",
+      "Rachel McAdams",
+      "Mark Strong"
+    ]
   },
   {
     "movieId": "the-blind-side-2009",
@@ -9977,7 +16382,14 @@
     "year": 2009,
     "runtime": 129,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "The story of Michael Oher, a homeless and traumatized boy who became an All-American football player and first-round NFL draft pick with the help of a caring woman and her family.",
+    "cast": [
+      "Quinton Aaron",
+      "Sandra Bullock",
+      "Tim McGraw",
+      "Jae Head"
+    ]
   },
   {
     "movieId": "the-visitor-2007",
@@ -9988,7 +16400,14 @@
     "year": 2007,
     "runtime": 104,
     "imdbRating": 7.6,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A college professor travels to New York City to attend a conference and finds a young couple living in his apartment.",
+    "cast": [
+      "Richard Jenkins",
+      "Haaz Sleiman",
+      "Danai Gurira",
+      "Hiam Abbass"
+    ]
   },
   {
     "movieId": "seven-pounds-2008",
@@ -9999,7 +16418,14 @@
     "year": 2008,
     "runtime": 123,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A man with a fateful secret embarks on an extraordinary journey of redemption by forever changing the lives of seven strangers.",
+    "cast": [
+      "Will Smith",
+      "Rosario Dawson",
+      "Woody Harrelson",
+      "Michael Ealy"
+    ]
   },
   {
     "movieId": "eastern-promises-2007",
@@ -10010,7 +16436,14 @@
     "year": 2007,
     "runtime": 100,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A teenager who dies during childbirth leaves clues in her journal that could tie her child to a rape involving a violent Russian mob family.",
+    "cast": [
+      "Naomi Watts",
+      "Viggo Mortensen",
+      "Armin Mueller-Stahl",
+      "Josef Altin"
+    ]
   },
   {
     "movieId": "stardust-2007",
@@ -10021,7 +16454,14 @@
     "year": 2007,
     "runtime": 127,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In a countryside town bordering on a magical land, a young man makes a promise to his beloved that he'll retrieve a fallen star by venturing into the magical realm.",
+    "cast": [
+      "Charlie Cox",
+      "Claire Danes",
+      "Sienna Miller",
+      "Ian McKellen"
+    ]
   },
   {
     "movieId": "the-secret-of-kells-2009",
@@ -10031,7 +16471,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMjEzMjEzNTIzOF5BMl5BanBnXkFtZTcwMTg2MjAyMw@@._V1_SX4000.jpg",
     "year": 2009,
     "runtime": 71,
-    "imdbRating": 7.6
+    "imdbRating": 7.6,
+    "synopsis": "A young boy in a remote medieval outpost under siege from barbarian raids is beckoned to adventure when a celebrated master illuminator arrives with an ancient book, brimming with secret wisdom and powers.",
+    "cast": [
+      "Nora Twomey",
+      "Evan McGuire",
+      "Brendan Gleeson",
+      "Mick Lally"
+    ]
   },
   {
     "movieId": "inside-man-2006",
@@ -10042,7 +16489,14 @@
     "year": 2006,
     "runtime": 129,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A police detective, a bank robber, and a high-power broker enter high-stakes negotiations after the criminal's brilliant heist spirals into a hostage situation.",
+    "cast": [
+      "Denzel Washington",
+      "Clive Owen",
+      "Jodie Foster",
+      "Christopher Plummer"
+    ]
   },
   {
     "movieId": "gone-baby-gone-2007",
@@ -10053,7 +16507,14 @@
     "year": 2007,
     "runtime": 114,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Two Boston area detectives investigate a little girl's kidnapping, which ultimately turns into a crisis both professionally and personally.",
+    "cast": [
+      "Morgan Freeman",
+      "Ed Harris",
+      "Casey Affleck",
+      "Michelle Monaghan"
+    ]
   },
   {
     "movieId": "la-vie-en-rose-2007",
@@ -10064,7 +16525,14 @@
     "year": 2007,
     "runtime": 140,
     "imdbRating": 7.6,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "Biopic of the iconic French singer Édith Piaf. Raised by her grandmother in a brothel, she was discovered while singing on a street corner at the age of 19. Despite her success, Piaf's life was filled with tragedy.",
+    "cast": [
+      "Marion Cotillard",
+      "Sylvie Testud",
+      "Pascal Greggory",
+      "Emmanuelle Seigner"
+    ]
   },
   {
     "movieId": "huo-yuan-jia-2006",
@@ -10075,7 +16543,14 @@
     "year": 2006,
     "runtime": 104,
     "imdbRating": 7.6,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A biography of Chinese Martial Arts Master Huo Yuanjia, who is the founder and spiritual guru of the Jin Wu Sports Federation.",
+    "cast": [
+      "Jet Li",
+      "Li Sun",
+      "Yong Dong",
+      "Yun Qu"
+    ]
   },
   {
     "movieId": "the-illusionist-2006",
@@ -10086,7 +16561,14 @@
     "year": 2006,
     "runtime": 110,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "In turn-of-the-century Vienna, a magician uses his abilities to secure the love of a woman far above his social standing.",
+    "cast": [
+      "Edward Norton",
+      "Jessica Biel",
+      "Paul Giamatti",
+      "Rufus Sewell"
+    ]
   },
   {
     "movieId": "dead-man-s-shoes-2004",
@@ -10096,7 +16578,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTI5Mzk1MDc2M15BMl5BanBnXkFtZTcwMjIzMDA0MQ@@._V1_SX4000.jpg",
     "year": 2004,
     "runtime": 90,
-    "imdbRating": 7.6
+    "imdbRating": 7.6,
+    "synopsis": "A disaffected soldier returns to his hometown to get even with the thugs who brutalized his mentally-challenged brother years ago.",
+    "cast": [
+      "Paddy Considine",
+      "Gary Stretch",
+      "Toby Kebbell",
+      "Stuart Wolfenden"
+    ]
   },
   {
     "movieId": "harry-potter-and-the-half-blood-prince-2009",
@@ -10107,7 +16596,14 @@
     "year": 2009,
     "runtime": 153,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "As Harry Potter begins his sixth year at Hogwarts, he discovers an old book marked as \"the property of the Half-Blood Prince\" and begins to learn more about Lord Voldemort's dark past.",
+    "cast": [
+      "Daniel Radcliffe",
+      "Emma Watson",
+      "Rupert Grint",
+      "Michael Gambon"
+    ]
   },
   {
     "movieId": "300-2006",
@@ -10118,7 +16614,14 @@
     "year": 2006,
     "runtime": 117,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "King Leonidas of Sparta and a force of 300 men fight the Persians at Thermopylae in 480 B.C.",
+    "cast": [
+      "Gerard Butler",
+      "Lena Headey",
+      "David Wenham",
+      "Dominic West"
+    ]
   },
   {
     "movieId": "match-point-2005",
@@ -10129,7 +16632,14 @@
     "year": 2005,
     "runtime": 124,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "At a turning point in his life, a former tennis pro falls for an actress who happens to be dating his friend and soon-to-be brother-in-law.",
+    "cast": [
+      "Scarlett Johansson",
+      "Jonathan Rhys Meyers",
+      "Emily Mortimer",
+      "Matthew Goode"
+    ]
   },
   {
     "movieId": "watchmen-2009",
@@ -10140,7 +16650,14 @@
     "year": 2009,
     "runtime": 162,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In 1985 where former superheroes exist, the murder of a colleague sends active vigilante Rorschach into his own sprawling investigation, uncovering something that could completely change the course of history as we know it.",
+    "cast": [
+      "Jackie Earle Haley",
+      "Patrick Wilson",
+      "Carla Gugino",
+      "Malin Akerman"
+    ]
   },
   {
     "movieId": "lord-of-war-2005",
@@ -10151,7 +16668,14 @@
     "year": 2005,
     "runtime": 122,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "An arms dealer confronts the morality of his work as he is being chased by an INTERPOL Agent.",
+    "cast": [
+      "Nicolas Cage",
+      "Ethan Hawke",
+      "Jared Leto",
+      "Bridget Moynahan"
+    ]
   },
   {
     "movieId": "saw-2004",
@@ -10162,7 +16686,14 @@
     "year": 2004,
     "runtime": 103,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Two strangers awaken in a room with no recollection of how they got there, and soon discover they're pawns in a deadly game perpetrated by a notorious serial killer.",
+    "cast": [
+      "Cary Elwes",
+      "Leigh Whannell",
+      "Danny Glover",
+      "Ken Leung"
+    ]
   },
   {
     "movieId": "synecdoche-new-york-2008",
@@ -10173,7 +16704,14 @@
     "year": 2008,
     "runtime": 124,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A theatre director struggles with his work, and the women in his life, as he creates a life-size replica of New York City inside a warehouse as part of his new play.",
+    "cast": [
+      "Philip Seymour Hoffman",
+      "Samantha Morton",
+      "Michelle Williams",
+      "Catherine Keener"
+    ]
   },
   {
     "movieId": "mysterious-skin-2004",
@@ -10184,7 +16722,14 @@
     "year": 2004,
     "runtime": 105,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A teenage hustler and a young man obsessed with alien abductions cross paths, together discovering a horrible, liberating truth.",
+    "cast": [
+      "Brady Corbet",
+      "Joseph Gordon-Levitt",
+      "Elisabeth Shue",
+      "Chase Ellison"
+    ]
   },
   {
     "movieId": "jeux-d-enfants-2003",
@@ -10195,7 +16740,14 @@
     "year": 2003,
     "runtime": 93,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "As adults, best friends Julien and Sophie continue the odd game they started as children -- a fearless competition to outdo one another with daring and outrageous stunts. While they often act out to relieve one another's pain, their game might be a way to avoid the fact that they are truly meant for one another.",
+    "cast": [
+      "Guillaume Canet",
+      "Marion Cotillard",
+      "Thibault Verhaeghe",
+      "Joséphine Lebas-Joly"
+    ]
   },
   {
     "movieId": "un-long-dimanche-de-fian-ailles-2004",
@@ -10206,7 +16758,14 @@
     "year": 2004,
     "runtime": 133,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Tells the story of a young woman's relentless search for her fiancé, who has disappeared from the trenches of the Somme during World War One.",
+    "cast": [
+      "Audrey Tautou",
+      "Gaspard Ulliel",
+      "Jodie Foster",
+      "Dominique Pinon"
+    ]
   },
   {
     "movieId": "the-station-agent-2003",
@@ -10217,7 +16776,14 @@
     "year": 2003,
     "runtime": 89,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "When his only friend dies, a man born with dwarfism moves to rural New Jersey to live a life of solitude, only to meet a chatty hot dog vendor and a woman dealing with her own personal loss.",
+    "cast": [
+      "Peter Dinklage",
+      "Patricia Clarkson",
+      "Bobby Cannavale",
+      "Paul Benjamin"
+    ]
   },
   {
     "movieId": "21-grams-2003",
@@ -10228,7 +16794,14 @@
     "year": 2003,
     "runtime": 124,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "A freak accident brings together a critically ill mathematician, a grieving mother, and a born-again ex-con.",
+    "cast": [
+      "Sean Penn",
+      "Benicio Del Toro",
+      "Naomi Watts",
+      "Danny Huston"
+    ]
   },
   {
     "movieId": "boksuneun-naui-geot-2002",
@@ -10239,7 +16812,14 @@
     "year": 2002,
     "runtime": 129,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "A recently laid off factory worker kidnaps his former boss' friend's daughter, hoping to use the ransom money to pay for his sister's kidney transplant.",
+    "cast": [
+      "Kang-ho Song",
+      "Shin Ha-kyun",
+      "Bae Doona",
+      "Ji-Eun Lim"
+    ]
   },
   {
     "movieId": "finding-neverland-2004",
@@ -10250,7 +16830,14 @@
     "year": 2004,
     "runtime": 106,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The story of Sir J.M. Barrie's friendship with a family who inspired him to create Peter Pan.",
+    "cast": [
+      "Johnny Depp",
+      "Kate Winslet",
+      "Julie Christie",
+      "Radha Mitchell"
+    ]
   },
   {
     "movieId": "25th-hour-2002",
@@ -10261,7 +16848,14 @@
     "year": 2002,
     "runtime": 135,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Cornered by the DEA, convicted New York drug dealer Montgomery Brogan reevaluates his life in the 24 remaining hours before facing a seven-year jail term.",
+    "cast": [
+      "Edward Norton",
+      "Barry Pepper",
+      "Philip Seymour Hoffman",
+      "Rosario Dawson"
+    ]
   },
   {
     "movieId": "the-butterfly-effect-2004",
@@ -10272,7 +16866,14 @@
     "year": 2004,
     "runtime": 113,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Evan Treborn suffers blackouts during significant events of his life. As he grows up, he finds a way to remember these lost memories and a supernatural way to alter his life by reading his journal.",
+    "cast": [
+      "J. Mackye Gruber",
+      "Ashton Kutcher",
+      "Amy Smart",
+      "Melora Walters"
+    ]
   },
   {
     "movieId": "28-days-later-2002",
@@ -10283,7 +16884,14 @@
     "year": 2002,
     "runtime": 113,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Four weeks after a mysterious, incurable virus spreads throughout the UK, a handful of survivors try to find sanctuary.",
+    "cast": [
+      "Cillian Murphy",
+      "Naomie Harris",
+      "Christopher Eccleston",
+      "Alex Palmer"
+    ]
   },
   {
     "movieId": "batoru-rowaiaru-2000",
@@ -10293,7 +16901,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMDc2MGYwYzAtNzE2Yi00YmU3LTkxMDUtODk2YjhiNDM5NDIyXkEyXkFqcGdeQXVyMTEwNDU1MzEy._V1_SX4000.jpg",
     "year": 2000,
     "runtime": 114,
-    "imdbRating": 7.6
+    "imdbRating": 7.6,
+    "synopsis": "In the future, the Japanese government captures a class of ninth-grade students and forces them to kill each other under the revolutionary \"Battle Royale\" act.",
+    "cast": [
+      "Tatsuya Fujiwara",
+      "Aki Maeda",
+      "Tarô Yamamoto",
+      "Takeshi Kitano"
+    ]
   },
   {
     "movieId": "the-royal-tenenbaums-2001",
@@ -10304,7 +16919,14 @@
     "year": 2001,
     "runtime": 110,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The eccentric members of a dysfunctional family reluctantly gather under the same roof for various reasons.",
+    "cast": [
+      "Gene Hackman",
+      "Gwyneth Paltrow",
+      "Anjelica Huston",
+      "Ben Stiller"
+    ]
   },
   {
     "movieId": "y-tu-mam-tambi-n-2001",
@@ -10315,7 +16937,14 @@
     "year": 2001,
     "runtime": 106,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In Mexico, two teenage boys and an attractive older woman embark on a road trip and learn a thing or two about life, friendship, sex, and each other.",
+    "cast": [
+      "Maribel Verdú",
+      "Gael García Bernal",
+      "Daniel Giménez Cacho",
+      "Ana López Mercado"
+    ]
   },
   {
     "movieId": "harry-potter-and-the-sorcerer-s-stone-2001",
@@ -10326,7 +16955,14 @@
     "year": 2001,
     "runtime": 152,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "An orphaned boy enrolls in a school of wizardry, where he learns the truth about himself, his family and the terrible evil that haunts the magical world.",
+    "cast": [
+      "Daniel Radcliffe",
+      "Rupert Grint",
+      "Richard Harris",
+      "Maggie Smith"
+    ]
   },
   {
     "movieId": "the-others-2001",
@@ -10337,7 +16973,14 @@
     "year": 2001,
     "runtime": 101,
     "imdbRating": 7.6,
-    "rated": "PG-13"
+    "rated": "PG-13",
+    "synopsis": "A woman who lives in her darkened old family house with her two photosensitive children becomes convinced that the home is haunted.",
+    "cast": [
+      "Nicole Kidman",
+      "Christopher Eccleston",
+      "Fionnula Flanagan",
+      "Alakina Mann"
+    ]
   },
   {
     "movieId": "blow-2001",
@@ -10348,7 +16991,14 @@
     "year": 2001,
     "runtime": 124,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "The story of how George Jung, along with the Medellín Cartel headed by Pablo Escobar, established the American cocaine market in the 1970s in the United States.",
+    "cast": [
+      "Johnny Depp",
+      "Penélope Cruz",
+      "Franka Potente",
+      "Rachel Griffiths"
+    ]
   },
   {
     "movieId": "enemy-at-the-gates-2001",
@@ -10359,7 +17009,14 @@
     "year": 2001,
     "runtime": 131,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A Russian and a German sniper play a game of cat-and-mouse during the Battle of Stalingrad.",
+    "cast": [
+      "Jude Law",
+      "Ed Harris",
+      "Joseph Fiennes",
+      "Rachel Weisz"
+    ]
   },
   {
     "movieId": "minority-report-2002",
@@ -10370,7 +17027,14 @@
     "year": 2002,
     "runtime": 145,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In a future where a special police unit is able to arrest murderers before they commit their crimes, an officer from that unit is himself accused of a future murder.",
+    "cast": [
+      "Tom Cruise",
+      "Colin Farrell",
+      "Samantha Morton",
+      "Max von Sydow"
+    ]
   },
   {
     "movieId": "the-hurricane-1999",
@@ -10381,7 +17045,14 @@
     "year": 1999,
     "runtime": 146,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "The story of Rubin 'Hurricane' Carter, a boxer wrongly imprisoned for murder, and the people who aided in his fight to prove his innocence.",
+    "cast": [
+      "Denzel Washington",
+      "Vicellous Shannon",
+      "Deborah Kara Unger",
+      "Liev Schreiber"
+    ]
   },
   {
     "movieId": "american-psycho-2000",
@@ -10392,7 +17063,14 @@
     "year": 2000,
     "runtime": 101,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A wealthy New York City investment banking executive, Patrick Bateman, hides his alternate psychopathic ego from his co-workers and friends as he delves deeper into his violent, hedonistic fantasies.",
+    "cast": [
+      "Christian Bale",
+      "Justin Theroux",
+      "Josh Lucas",
+      "Bill Sage"
+    ]
   },
   {
     "movieId": "lola-rennt-1998",
@@ -10403,7 +17081,14 @@
     "year": 1998,
     "runtime": 81,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "After a botched money delivery, Lola has 20 minutes to come up with 100,000 Deutschmarks.",
+    "cast": [
+      "Franka Potente",
+      "Moritz Bleibtreu",
+      "Herbert Knaup",
+      "Nina Petri"
+    ]
   },
   {
     "movieId": "the-thin-red-line-1998",
@@ -10414,7 +17099,14 @@
     "year": 1998,
     "runtime": 170,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Adaptation of James Jones' autobiographical 1962 novel, focusing on the conflict at Guadalcanal during the second World War.",
+    "cast": [
+      "Jim Caviezel",
+      "Sean Penn",
+      "Nick Nolte",
+      "Kirk Acevedo"
+    ]
   },
   {
     "movieId": "mulan-1998",
@@ -10425,7 +17117,14 @@
     "year": 1998,
     "runtime": 88,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "To save her father from death in the army, a young maiden secretly goes in his place and becomes one of China's greatest heroines in the process.",
+    "cast": [
+      "Barry Cook",
+      "Ming-Na Wen",
+      "Eddie Murphy",
+      "BD Wong"
+    ]
   },
   {
     "movieId": "fear-and-loathing-in-las-vegas-1998",
@@ -10436,7 +17135,14 @@
     "year": 1998,
     "runtime": 118,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "An oddball journalist and his psychopathic lawyer travel to Las Vegas for a series of psychedelic escapades.",
+    "cast": [
+      "Johnny Depp",
+      "Benicio Del Toro",
+      "Tobey Maguire",
+      "Michael Lee Gogin"
+    ]
   },
   {
     "movieId": "funny-games-1997",
@@ -10447,7 +17153,14 @@
     "year": 1997,
     "runtime": 108,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Two violent young men take a mother, father, and son hostage in their vacation cabin and force them to play sadistic \"games\" with one another for their own amusement.",
+    "cast": [
+      "Susanne Lothar",
+      "Ulrich Mühe",
+      "Arno Frisch",
+      "Frank Giering"
+    ]
   },
   {
     "movieId": "dark-city-1998",
@@ -10458,7 +17171,14 @@
     "year": 1998,
     "runtime": 100,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A man struggles with memories of his past, which include a wife he cannot remember and a nightmarish world no one else ever seems to wake up from.",
+    "cast": [
+      "Rufus Sewell",
+      "Kiefer Sutherland",
+      "Jennifer Connelly",
+      "William Hurt"
+    ]
   },
   {
     "movieId": "sleepers-1996",
@@ -10469,7 +17189,14 @@
     "year": 1996,
     "runtime": 147,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "After a prank goes disastrously wrong, a group of boys are sent to a detention center where they are brutalized. Thirteen years later, an unexpected random encounter with a former guard gives them a chance for revenge.",
+    "cast": [
+      "Robert De Niro",
+      "Kevin Bacon",
+      "Brad Pitt",
+      "Jason Patric"
+    ]
   },
   {
     "movieId": "lost-highway-1997",
@@ -10480,7 +17207,14 @@
     "year": 1997,
     "runtime": 134,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Anonymous videotapes presage a musician's murder conviction, and a gangster's girlfriend leads a mechanic astray.",
+    "cast": [
+      "Bill Pullman",
+      "Patricia Arquette",
+      "John Roselius",
+      "Louis Eppolito"
+    ]
   },
   {
     "movieId": "sense-and-sensibility-1995",
@@ -10491,7 +17225,14 @@
     "year": 1995,
     "runtime": 136,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Rich Mr. Dashwood dies, leaving his second wife and her three daughters poor by the rules of inheritance. The two eldest daughters are the title opposites.",
+    "cast": [
+      "Emma Thompson",
+      "Kate Winslet",
+      "James Fleet",
+      "Tom Wilkinson"
+    ]
   },
   {
     "movieId": "die-hard-with-a-vengeance-1995",
@@ -10502,7 +17243,14 @@
     "year": 1995,
     "runtime": 128,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "John McClane and a Harlem store owner are targeted by German terrorist Simon in New York City, where he plans to rob the Federal Reserve Building.",
+    "cast": [
+      "Bruce Willis",
+      "Jeremy Irons",
+      "Samuel L. Jackson",
+      "Graham Greene"
+    ]
   },
   {
     "movieId": "dead-man-1995",
@@ -10513,7 +17261,14 @@
     "year": 1995,
     "runtime": 121,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "On the run after murdering a man, accountant William Blake encounters a strange aboriginal American man named Nobody who prepares him for his journey into the spiritual world.",
+    "cast": [
+      "Johnny Depp",
+      "Gary Farmer",
+      "Crispin Glover",
+      "Lance Henriksen"
+    ]
   },
   {
     "movieId": "the-bridges-of-madison-county-1995",
@@ -10524,7 +17279,14 @@
     "year": 1995,
     "runtime": 135,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Photographer Robert Kincaid wanders into the life of housewife Francesca Johnson for four days in the 1960s.",
+    "cast": [
+      "Clint Eastwood",
+      "Meryl Streep",
+      "Annie Corley",
+      "Victor Slezak"
+    ]
   },
   {
     "movieId": "apollo-13",
@@ -10534,7 +17296,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BNjEzYjJmNzgtNDkwNy00MTQ4LTlmMWMtNzA4YjE2NjI0ZDg4XkEyXkFqcGdeQXVyNjU0OTQ0OTY@._V1_SX4000.jpg",
     "runtime": 140,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "NASA must devise a strategy to return Apollo 13 to Earth safely after the spacecraft undergoes massive internal damage putting the lives of the three astronauts on board in jeopardy.",
+    "cast": [
+      "Tom Hanks",
+      "Bill Paxton",
+      "Kevin Bacon",
+      "Gary Sinise"
+    ]
   },
   {
     "movieId": "trois-couleurs-blanc-1994",
@@ -10545,7 +17314,14 @@
     "year": 1994,
     "runtime": 92,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "After his wife divorces him, a Polish immigrant plots to get even with her.",
+    "cast": [
+      "Zbigniew Zamachowski",
+      "Julie Delpy",
+      "Janusz Gajos",
+      "Jerzy Stuhr"
+    ]
   },
   {
     "movieId": "falling-down-1993",
@@ -10556,7 +17332,14 @@
     "year": 1993,
     "runtime": 113,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "An ordinary man frustrated with the various flaws he sees in society begins to psychotically and violently lash out against them.",
+    "cast": [
+      "Michael Douglas",
+      "Robert Duvall",
+      "Barbara Hershey",
+      "Rachel Ticotin"
+    ]
   },
   {
     "movieId": "dazed-and-confused-1993",
@@ -10567,7 +17350,14 @@
     "year": 1993,
     "runtime": 102,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "The adventures of high school and junior high students on the last day of school in May 1976.",
+    "cast": [
+      "Jason London",
+      "Wiley Wiggins",
+      "Matthew McConaughey",
+      "Rory Cochrane"
+    ]
   },
   {
     "movieId": "my-cousin-vinny-1992",
@@ -10578,7 +17368,14 @@
     "year": 1992,
     "runtime": 120,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Two New Yorkers accused of murder in rural Alabama while on their way back to college call in the help of one of their cousins, a loudmouth lawyer with no trial experience.",
+    "cast": [
+      "Joe Pesci",
+      "Marisa Tomei",
+      "Ralph Macchio",
+      "Mitchell Whitfield"
+    ]
   },
   {
     "movieId": "omohide-poro-poro-1991",
@@ -10589,7 +17386,14 @@
     "year": 1991,
     "runtime": 118,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A twenty-seven-year-old office worker travels to the countryside while reminiscing about her childhood in Tokyo.",
+    "cast": [
+      "Miki Imai",
+      "Toshirô Yanagiba",
+      "Yoko Honna",
+      "Mayumi Izuka"
+    ]
   },
   {
     "movieId": "delicatessen-1991",
@@ -10600,7 +17404,14 @@
     "year": 1991,
     "runtime": 99,
     "imdbRating": 7.6,
-    "rated": "R"
+    "rated": "R",
+    "synopsis": "Post-apocalyptic surrealist black comedy about the landlord of an apartment building who occasionally prepares a delicacy for his odd tenants.",
+    "cast": [
+      "Jean-Pierre Jeunet",
+      "Marie-Laure Dougnac",
+      "Dominique Pinon",
+      "Pascal Benezech"
+    ]
   },
   {
     "movieId": "home-alone-1990",
@@ -10611,7 +17422,14 @@
     "year": 1990,
     "runtime": 103,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "An eight-year-old troublemaker must protect his house from a pair of burglars when he is accidentally left home alone by his family during Christmas vacation.",
+    "cast": [
+      "Macaulay Culkin",
+      "Joe Pesci",
+      "Daniel Stern",
+      "John Heard"
+    ]
   },
   {
     "movieId": "the-godfather-part-iii-1990",
@@ -10622,7 +17440,14 @@
     "year": 1990,
     "runtime": 162,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Follows Michael Corleone, now in his 60s, as he seeks to free his family from crime and find a suitable successor to his empire.",
+    "cast": [
+      "Al Pacino",
+      "Diane Keaton",
+      "Andy Garcia",
+      "Talia Shire"
+    ]
   },
   {
     "movieId": "when-harry-met-sally-1989",
@@ -10633,7 +17458,14 @@
     "year": 1989,
     "runtime": 95,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Harry and Sally have known each other for years, and are very good friends, but they fear sex would ruin the friendship.",
+    "cast": [
+      "Billy Crystal",
+      "Meg Ryan",
+      "Carrie Fisher",
+      "Bruno Kirby"
+    ]
   },
   {
     "movieId": "the-little-mermaid-1989",
@@ -10644,7 +17476,14 @@
     "year": 1989,
     "runtime": 83,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A mermaid princess makes a Faustian bargain in an attempt to become human and win a prince's love.",
+    "cast": [
+      "John Musker",
+      "Jodi Benson",
+      "Samuel E. Wright",
+      "Rene Auberjonois"
+    ]
   },
   {
     "movieId": "the-naked-gun-from-the-files-of-police-squad-1988",
@@ -10655,7 +17494,14 @@
     "year": 1988,
     "runtime": 85,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Incompetent police Detective Frank Drebin must foil an attempt to assassinate Queen Elizabeth II.",
+    "cast": [
+      "Leslie Nielsen",
+      "Priscilla Presley",
+      "O.J. Simpson",
+      "Ricardo Montalban"
+    ]
   },
   {
     "movieId": "planes-trains-automobiles-1987",
@@ -10666,7 +17512,14 @@
     "year": 1987,
     "runtime": 93,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "A man must struggle to travel home for Thanksgiving with a lovable oaf of a shower curtain ring salesman as his only companion.",
+    "cast": [
+      "Steve Martin",
+      "John Candy",
+      "Laila Robins",
+      "Michael McKean"
+    ]
   },
   {
     "movieId": "lethal-weapon-1987",
@@ -10677,7 +17530,14 @@
     "year": 1987,
     "runtime": 109,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Two newly paired cops who are complete opposites must put aside their differences in order to catch a gang of drug smugglers.",
+    "cast": [
+      "Mel Gibson",
+      "Danny Glover",
+      "Gary Busey",
+      "Mitchell Ryan"
+    ]
   },
   {
     "movieId": "blood-simple-1984",
@@ -10688,7 +17548,14 @@
     "year": 1984,
     "runtime": 99,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "The owner of a seedy small-town Texas bar discovers that one of his employees is having an affair with his wife. A chaotic chain of misunderstandings, lies and mischief ensues after he devises a plot to have them murdered.",
+    "cast": [
+      "Ethan Coen",
+      "John Getz",
+      "Frances McDormand",
+      "Dan Hedaya"
+    ]
   },
   {
     "movieId": "on-golden-pond-1981",
@@ -10699,7 +17566,14 @@
     "year": 1981,
     "runtime": 109,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "Norman is a curmudgeon with an estranged relationship with his daughter Chelsea. At Golden Pond, he and his wife nevertheless agree to care for Billy, the son of Chelsea's new boyfriend, and a most unexpected relationship blooms.",
+    "cast": [
+      "Katharine Hepburn",
+      "Henry Fonda",
+      "Jane Fonda",
+      "Doug McKeon"
+    ]
   },
   {
     "movieId": "mad-max-2-1981",
@@ -10710,7 +17584,14 @@
     "year": 1981,
     "runtime": 96,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "In the post-apocalyptic Australian wasteland, a cynical drifter agrees to help a small, gasoline-rich community escape a horde of bandits.",
+    "cast": [
+      "Mel Gibson",
+      "Bruce Spence",
+      "Michael Preston",
+      "Max Phipps"
+    ]
   },
   {
     "movieId": "the-warriors-1979",
@@ -10721,7 +17602,14 @@
     "year": 1979,
     "runtime": 92,
     "imdbRating": 7.6,
-    "rated": "UA"
+    "rated": "UA",
+    "synopsis": "In the near future, a charismatic leader summons the street gangs of New York City in a bid to take it over. When he is killed, The Warriors are falsely blamed and now must fight their way home while every other gang is hunting them down.",
+    "cast": [
+      "Michael Beck",
+      "James Remar",
+      "Dorsey Wright",
+      "Brian Tyler"
+    ]
   },
   {
     "movieId": "the-muppet-movie-1979",
@@ -10732,7 +17620,14 @@
     "year": 1979,
     "runtime": 95,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Kermit and his newfound friends trek across America to find success in Hollywood, but a frog legs merchant is after Kermit.",
+    "cast": [
+      "Jim Henson",
+      "Frank Oz",
+      "Jerry Nelson",
+      "Richard Hunt"
+    ]
   },
   {
     "movieId": "escape-from-alcatraz-1979",
@@ -10743,7 +17638,14 @@
     "year": 1979,
     "runtime": 112,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Alcatraz is the most secure prison of its time. It is believed that no one can ever escape from it, until three daring men make a possible successful attempt at escaping from one of the most infamous prisons in the world.",
+    "cast": [
+      "Clint Eastwood",
+      "Patrick McGoohan",
+      "Roberts Blossom",
+      "Jack Thibeau"
+    ]
   },
   {
     "movieId": "watership-down-1978",
@@ -10754,7 +17656,14 @@
     "year": 1978,
     "runtime": 91,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Hoping to escape destruction by human developers and save their community, a colony of rabbits, led by Hazel and Fiver, seek out a safe place to set up a new warren.",
+    "cast": [
+      "John Hubley",
+      "John Hurt",
+      "Richard Briers",
+      "Ralph Richardson"
+    ]
   },
   {
     "movieId": "midnight-express-1978",
@@ -10765,7 +17674,14 @@
     "year": 1978,
     "runtime": 121,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Billy Hayes, an American college student, is caught smuggling drugs out of Turkey and thrown into prison.",
+    "cast": [
+      "Brad Davis",
+      "Irene Miracle",
+      "Bo Hopkins",
+      "Paolo Bonacelli"
+    ]
   },
   {
     "movieId": "close-encounters-of-the-third-kind-1977",
@@ -10776,7 +17692,14 @@
     "year": 1977,
     "runtime": 138,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Roy Neary, an electric lineman, watches how his quiet and ordinary daily life turns upside down after a close encounter with a UFO.",
+    "cast": [
+      "Richard Dreyfuss",
+      "François Truffaut",
+      "Teri Garr",
+      "Melinda Dillon"
+    ]
   },
   {
     "movieId": "the-long-goodbye-1973",
@@ -10787,7 +17710,14 @@
     "year": 1973,
     "runtime": 112,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "Private investigator Philip Marlowe helps a friend out of a jam, but in doing so gets implicated in his wife's murder.",
+    "cast": [
+      "Elliott Gould",
+      "Nina van Pallandt",
+      "Sterling Hayden",
+      "Mark Rydell"
+    ]
   },
   {
     "movieId": "gi-la-testa-1971",
@@ -10798,7 +17728,14 @@
     "year": 1971,
     "runtime": 157,
     "imdbRating": 7.6,
-    "rated": "PG"
+    "rated": "PG",
+    "synopsis": "A low-life bandit and an I.R.A. explosives expert rebel against the government and become heroes of the Mexican Revolution.",
+    "cast": [
+      "Rod Steiger",
+      "James Coburn",
+      "Romolo Valli",
+      "Maria Monti"
+    ]
   },
   {
     "movieId": "kelly-s-heroes-1970",
@@ -10809,7 +17746,14 @@
     "year": 1970,
     "runtime": 144,
     "imdbRating": 7.6,
-    "rated": "GP"
+    "rated": "GP",
+    "synopsis": "A group of U.S. soldiers sneaks across enemy lines to get their hands on a secret stash of Nazi treasure.",
+    "cast": [
+      "Clint Eastwood",
+      "Telly Savalas",
+      "Don Rickles",
+      "Carroll O'Connor"
+    ]
   },
   {
     "movieId": "the-jungle-book-1967",
@@ -10820,7 +17764,14 @@
     "year": 1967,
     "runtime": 78,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Bagheera the Panther and Baloo the Bear have a difficult time trying to convince a boy to leave the jungle for human civilization.",
+    "cast": [
+      "Phil Harris",
+      "Sebastian Cabot",
+      "Louis Prima",
+      "Bruce Reitherman"
+    ]
   },
   {
     "movieId": "blowup-1966",
@@ -10831,7 +17782,14 @@
     "year": 1966,
     "runtime": 111,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A fashion photographer unknowingly captures a death on film after following two lovers in a park.",
+    "cast": [
+      "David Hemmings",
+      "Vanessa Redgrave",
+      "Sarah Miles",
+      "John Castle"
+    ]
   },
   {
     "movieId": "a-hard-day-s-night-1964",
@@ -10842,7 +17800,14 @@
     "year": 1964,
     "runtime": 87,
     "imdbRating": 7.6,
-    "rated": "U"
+    "rated": "U",
+    "synopsis": "Over two \"typical\" days in the life of The Beatles, the boys struggle to keep themselves and Sir Paul McCartney's mischievous grandfather in check while preparing for a live television performance.",
+    "cast": [
+      "John Lennon",
+      "Paul McCartney",
+      "George Harrison",
+      "Ringo Starr"
+    ]
   },
   {
     "movieId": "breakfast-at-tiffany-s-1961",
@@ -10853,7 +17818,14 @@
     "year": 1961,
     "runtime": 115,
     "imdbRating": 7.6,
-    "rated": "A"
+    "rated": "A",
+    "synopsis": "A young New York socialite becomes interested in a young man who has moved into her apartment building, but her past threatens to get in the way.",
+    "cast": [
+      "Audrey Hepburn",
+      "George Peppard",
+      "Patricia Neal",
+      "Buddy Ebsen"
+    ]
   },
   {
     "movieId": "giant-1956",
@@ -10864,7 +17836,14 @@
     "year": 1956,
     "runtime": 201,
     "imdbRating": 7.6,
-    "rated": "G"
+    "rated": "G",
+    "synopsis": "Sprawling epic covering the life of a Texas cattle rancher and his family and associates.",
+    "cast": [
+      "Elizabeth Taylor",
+      "Rock Hudson",
+      "James Dean",
+      "Carroll Baker"
+    ]
   },
   {
     "movieId": "from-here-to-eternity-1953",
@@ -10875,7 +17854,14 @@
     "year": 1953,
     "runtime": 118,
     "imdbRating": 7.6,
-    "rated": "Passed"
+    "rated": "Passed",
+    "synopsis": "In Hawaii in 1941, a private is cruelly punished for not boxing on his unit's team, while his captain's wife and second-in-command are falling in love.",
+    "cast": [
+      "Burt Lancaster",
+      "Montgomery Clift",
+      "Deborah Kerr",
+      "Donna Reed"
+    ]
   },
   {
     "movieId": "lifeboat-1944",
@@ -10885,7 +17871,14 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BZTBmMjUyMjItYTM4ZS00MjAwLWEyOGYtYjMyZTUxN2I3OTMxXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_SX4000.jpg",
     "year": 1944,
     "runtime": 97,
-    "imdbRating": 7.6
+    "imdbRating": 7.6,
+    "synopsis": "Several survivors of a torpedoed merchant ship in World War II find themselves in the same lifeboat with one of the crew members of the U-boat that sank their ship.",
+    "cast": [
+      "Tallulah Bankhead",
+      "John Hodiak",
+      "Walter Slezak",
+      "William Bendix"
+    ]
   },
   {
     "movieId": "the-39-steps-1935",
@@ -10895,6 +17888,13 @@
     "poster": "https://m.media-amazon.com/images/M/MV5BMTY5ODAzMTcwOF5BMl5BanBnXkFtZTcwMzYxNDYyNA@@._V1_SX4000.jpg",
     "year": 1935,
     "runtime": 86,
-    "imdbRating": 7.6
+    "imdbRating": 7.6,
+    "synopsis": "A man in London tries to help a counter-espionage Agent. But when the Agent is killed, and the man stands accused, he must go on the run to save himself and stop a spy ring which is trying to steal top secret information.",
+    "cast": [
+      "Robert Donat",
+      "Madeleine Carroll",
+      "Lucie Mannheim",
+      "Godfrey Tearle"
+    ]
   }
 ]

--- a/scripts/enrich_catalogue.py
+++ b/scripts/enrich_catalogue.py
@@ -1,0 +1,96 @@
+"""Enrich functions/shared/movies_catalogue.json with `synopsis` and `cast`.
+
+The Lambda catalogue (movies_catalogue.json) was generated without plot text or
+cast — those two fields only exist in the raw dataset (datasets/imdb_top_1000.csv,
+columns `Overview` and `Star1`..`Star4`). This script does a one-time, idempotent
+merge so the recommend Lambda can return them.
+
+Join strategy: title-only, case-insensitive. Verified 1000/1000 match against the
+current catalogue (title+year matches 999/1000 — only "Apollo 13" differs on year —
+so title-only is the reliable key here).
+
+Idempotent: re-running overwrites `synopsis`/`cast` with the same values; it never
+duplicates records or reorders the catalogue. Safe to run repeatedly.
+
+Usage:
+    python scripts/enrich_catalogue.py            # writes in place
+    python scripts/enrich_catalogue.py --check    # dry-run; prints coverage, no write
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+CATALOGUE = ROOT / "functions" / "shared" / "movies_catalogue.json"
+CSV_PATH = ROOT / "datasets" / "imdb_top_1000.csv"
+
+
+def _norm(title: str) -> str:
+    return title.strip().lower()
+
+
+def build_csv_index() -> dict[str, dict]:
+    with open(CSV_PATH, encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    # Last-wins on duplicate titles (none expected in this dataset).
+    return {_norm(r["Series_Title"]): r for r in rows}
+
+
+def cast_from_row(row: dict) -> list[str]:
+    stars = [row.get(f"Star{i}", "").strip() for i in range(1, 5)]
+    return [s for s in stars if s]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="dry-run: report coverage without writing",
+    )
+    args = parser.parse_args()
+
+    catalogue = json.loads(CATALOGUE.read_text(encoding="utf-8"))
+    csv_index = build_csv_index()
+
+    matched = 0
+    missing: list[str] = []
+    for movie in catalogue:
+        row = csv_index.get(_norm(movie["title"]))
+        if row is None:
+            missing.append(movie["title"])
+            continue
+        matched += 1
+        synopsis = (row.get("Overview") or "").strip()
+        cast = cast_from_row(row)
+        if not args.check:
+            # Insert synopsis right after genre and cast right after director for
+            # readable diffs; dict order in Python is insertion order, but since
+            # these keys may already exist we just assign — JSON output below is
+            # sorted by our explicit key order writer, not dict order.
+            movie["synopsis"] = synopsis
+            movie["cast"] = cast
+
+    print(f"catalogue records : {len(catalogue)}")
+    print(f"matched in CSV    : {matched}/{len(catalogue)}")
+    if missing:
+        print(f"UNMATCHED ({len(missing)}): {missing}")
+
+    if args.check:
+        print("\n--check: no file written.")
+        return 0 if not missing else 1
+
+    CATALOGUE.write_text(
+        json.dumps(catalogue, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"\nwrote {CATALOGUE.relative_to(ROOT)}")
+    return 0 if not missing else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Brings the recommendation screen back to a rich layout (the "first version" had more on it) using the 1000-movie catalogue, and redesigns it poster-first.

**Visual:** sharp full poster in a sticky right column (portrait posters were being cropped to a forehead in the old backdrop layout), blurred ambient copy behind the hero, and a restored **"Filmes parecidos"** horizontal rail.

## ⚠️ Coordinate — this touches the shared backend (CLAUDE.md rule #1)

`functions/` is normally read-only this milestone. This PR intentionally changes it, so **classmates should be aware of two things**:

1. **`/recommend` + `/recommend_anon` response shape changes** (additive only — no fields removed). New keys: `synopsis`, `cast`, `similar[]`. The frontend adapter treats them all as optional, so an older client won't break.
2. **`movies_catalogue.json` grows 368KB → 665KB** (added synopsis + cast for all 1000 movies). It ships in the **shared Lambda Layer**, so it slightly raises cold-start memory for **every** function, not just recommend. Modest, but it affects everyone's lambdas.

## How

- **Data** (`scripts/enrich_catalogue.py`): idempotent merge of the IMDb CSV's `Overview` → `synopsis` and `Star1..4` → `cast` into the catalogue (1000/1000 matched; core fields unchanged — verified). The 9k-line diff is re-serialization + the two new fields, not data churn.
- **Lambda** (`recommend.py`): returns `synopsis`/`cast` + a lightweight `similar[]`. Similar = genre **superset** (contains ALL the movie's genres, may have more), fallback to "shares ≥1 genre" when empty (~62/1000), up to 12 random. Existing preference-filter / history-write / auth logic untouched.
- **Frontend** (`recommend.real.ts` + `page.tsx`): adapter maps the new fields (kebab→camel); page restyled to the poster-led layout. Tokens-only (DSGN-06 verified: no hex in className, no inline `style=`). Dropped the fabricated `match%` (no longer produced).

## Tests

- Recommend adapter + page tests: **10/10 pass**.
- Full frontend suite: 47/48 pass. The 1 failure is a **pre-existing**, time-dependent `time.test.ts > sameDay` case unrelated to this change (not a file touched here).
- `_pick_similar` verified against the real catalogue: Godfather (crime, drama) → 12 similar, all containing both crime AND drama; the 62 zero-strict-match movies fall back correctly (never an empty rail).

## Notes / follow-ups

- Synopsis + titles are **English** (dataset language). For a PT-BR app this is a known wart (same as the existing English titles); translating 1000 synopses is a separate task.
- `streaming-services` is still null end-to-end — no streaming data exists in the catalogue. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
