### PR TITLE
feat(recommendation): right-size posters, blur-up loading, fallback +…

### DIFF
--- a/frontend/web/app/(app)/recommendation/page.tsx
+++ b/frontend/web/app/(app)/recommendation/page.tsx
@@ -41,6 +41,8 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Bookmark, BookmarkCheck, Play, RefreshCw } from "lucide-react";
 import { useAuth } from "@/lib/auth/AuthContext";
 import { ServiceBadge } from "@/components/ServiceBadge";
+import { PosterImage } from "@/components/PosterImage";
+import { posterAt } from "@/lib/posters";
 import { SnackRecipeModal } from "@/components/SnackRecipeModal";
 import {
   getRecommendationReal,
@@ -250,9 +252,12 @@ export default function RecommendationPage() {
           /* non-tokenized: h-170 ambient region height primitive */
           className="absolute top-0 left-0 right-0 h-170 overflow-hidden animate-fade-in"
         >
-          {/* non-tokenized: blur-[48px] + brightness-[.45] + scale-110 ambient recipe (no token) */}
+          {/* non-tokenized: blur-[48px] + brightness-[.45] + scale-110 ambient recipe (no token).
+              Uses the tiny (~1KB) variant — it's blurred to oblivion anyway, no point
+              downloading the full poster twice. */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src={movie.poster}
+            src={posterAt(movie.poster, "tiny")}
             alt=""
             className="absolute inset-0 w-full h-full object-cover blur-[48px] brightness-[.45] scale-110"
           />
@@ -387,19 +392,19 @@ export default function RecommendationPage() {
             )}
           </div>
 
-          {/* RIGHT: full poster — never cropped (object-contain). Sticky on md+. */}
-          {movie.poster && (
-            <div className="order-1 md:order-2 md:sticky md:top-22 animate-fade-up [animation-delay:120ms]">
-              {/* non-tokenized: max-w-[320px] poster width + aspect-2/3 portrait ratio primitives */}
-              <div className="mx-auto w-full max-w-[320px] aspect-2/3 overflow-hidden rounded-lg bg-surface-2 border border-border-strong shadow-lg">
-                <img
-                  src={movie.poster}
-                  alt={`Pôster: ${movie.title}`}
-                  className="w-full h-full object-contain bg-black"
-                />
-              </div>
-            </div>
-          )}
+          {/* RIGHT: full poster — never cropped (object-contain). Sticky on md+.
+              PosterImage blur-ups from a 1KB placeholder and falls back to a film
+              icon if the (sometimes-404) poster fails. */}
+          <div className="order-1 md:order-2 md:sticky md:top-22 animate-fade-up [animation-delay:120ms]">
+            {/* non-tokenized: max-w-[320px] poster width + aspect-2/3 portrait ratio primitives */}
+            <PosterImage
+              src={movie.poster}
+              alt={`Pôster: ${movie.title}`}
+              width="hero"
+              fit="contain"
+              className="mx-auto w-full max-w-[320px] aspect-2/3 rounded-lg border border-border-strong shadow-lg"
+            />
+          </div>
         </div>
 
         {/* Similar films rail */}
@@ -436,16 +441,13 @@ function SimilarRail({ items }: { items: ReadonlyArray<SimilarMovie> }) {
         {items.map((m) => (
           <article key={m.movieId} className="shrink-0 w-37.5">
             {/* non-tokenized: aspect-2/3 portrait poster ratio primitive */}
-            <div className="w-37.5 aspect-2/3 overflow-hidden rounded-md bg-surface-2 border border-border">
-              {m.poster && (
-                <img
-                  src={m.poster}
-                  alt={`Pôster: ${m.title}`}
-                  loading="lazy"
-                  className="w-full h-full object-cover block"
-                />
-              )}
-            </div>
+            <PosterImage
+              src={m.poster}
+              alt={`Pôster: ${m.title}`}
+              width="card"
+              fit="cover"
+              className="w-37.5 aspect-2/3 rounded-md border border-border"
+            />
             <p className="mt-2 text-13 font-semibold text-text-primary line-clamp-2 leading-tight">
               {m.title}
             </p>
@@ -464,9 +466,9 @@ function SimilarRail({ items }: { items: ReadonlyArray<SimilarMovie> }) {
 }
 
 /**
- * Richer loading skeleton — mirrors the recommendation hero layout so the
- * page doesn't feel empty while the snack-recipe modal is up. Tokens-only;
- * uses the same pt/px/max-w primitives as the live hero above.
+ * Loading skeleton — mirrors the live poster-led layout (text column + poster
+ * column inside the max-w-300 shell) so the skeleton→content swap doesn't shift.
+ * Tokens-only; reuses the same shell / grid / poster primitives as the hero.
  */
 function SkeletonHero() {
   return (
@@ -474,35 +476,35 @@ function SkeletonHero() {
       className="relative isolate w-full min-h-screen overflow-hidden bg-bg"
       aria-busy="true"
     >
-      {/* non-tokenized: backdrop height + scrim recipe mirrors the live hero */}
-      <div
-        aria-hidden
-        className="absolute top-0 left-0 right-0 h-[360px] md:h-[560px] overflow-hidden"
-      >
-        <div className="absolute inset-0 bg-surface animate-pulse" />
-        <div className="absolute inset-0 bg-[linear-gradient(to_bottom,rgba(10,10,11,0.30)_0%,rgba(10,10,11,0.10)_30%,rgba(10,10,11,0.70)_70%,var(--color-bg)_100%)]" />
-      </div>
-      <div className="relative z-10">
-        {/* non-tokenized: pt-[220px] / pt-[280px] / max-w-[880px] match live hero */}
-        <div className="pt-[220px] md:pt-[280px] px-6 md:px-14 max-w-[880px]">
-          <div className="h-4 w-48 rounded-sm bg-surface-2 animate-pulse mb-4" />
-          <div className="h-10 md:h-14 w-3/4 rounded-md bg-surface-2 animate-pulse mb-3" />
-          <div className="h-10 md:h-14 w-1/2 rounded-md bg-surface-2 animate-pulse mb-6" />
-          <div className="flex gap-3 mb-7">
-            <div className="h-5 w-20 rounded-sm bg-surface-2 animate-pulse" />
-            <div className="h-5 w-12 rounded-sm bg-surface-2 animate-pulse" />
-            <div className="h-5 w-16 rounded-sm bg-surface-2 animate-pulse" />
+      {/* non-tokenized: max-w-300 shell + md:pt-22 / pt-12 match the live hero */}
+      <div className="relative z-10 mx-auto max-w-300 px-6 md:px-10">
+        <div className="grid grid-cols-1 gap-7 pt-12 md:grid-cols-[1fr_minmax(300px,360px)] md:gap-12 md:pt-22 md:items-start">
+          {/* LEFT: text skeleton */}
+          <div className="order-2 md:order-1">
+            <div className="h-4 w-56 rounded-sm bg-surface-2 animate-pulse mb-4" />
+            <div className="h-10 md:h-12 w-3/4 rounded-md bg-surface-2 animate-pulse mb-3" />
+            <div className="h-10 md:h-12 w-1/2 rounded-md bg-surface-2 animate-pulse mb-5" />
+            <div className="flex gap-3 mb-6">
+              <div className="h-5 w-24 rounded-sm bg-surface-2 animate-pulse" />
+              <div className="h-5 w-12 rounded-sm bg-surface-2 animate-pulse" />
+              <div className="h-5 w-16 rounded-sm bg-surface-2 animate-pulse" />
+            </div>
+            {/* non-tokenized: max-w-150 body width matches live synopsis */}
+            <div className="space-y-2.5 mb-6 max-w-150">
+              <div className="h-4 w-full rounded-sm bg-surface-2 animate-pulse" />
+              <div className="h-4 w-11/12 rounded-sm bg-surface-2 animate-pulse" />
+              <div className="h-4 w-3/4 rounded-sm bg-surface-2 animate-pulse" />
+            </div>
+            <div className="flex flex-wrap gap-2.5">
+              <div className="h-12 w-44 rounded-md bg-surface-2 animate-pulse" />
+              <div className="h-12 w-56 rounded-md bg-surface-2 animate-pulse" />
+            </div>
           </div>
-          {/* non-tokenized: max-w-[640px] body width primitive matches live hero */}
-          <div className="space-y-2.5 mb-8 max-w-[640px]">
-            <div className="h-4 w-full rounded-sm bg-surface-2 animate-pulse" />
-            <div className="h-4 w-11/12 rounded-sm bg-surface-2 animate-pulse" />
-            <div className="h-4 w-3/4 rounded-sm bg-surface-2 animate-pulse" />
-          </div>
-          <div className="flex flex-wrap gap-2.5">
-            <div className="h-12 w-44 rounded-md bg-surface-2 animate-pulse" />
-            <div className="h-12 w-56 rounded-md bg-surface-2 animate-pulse" />
-            <div className="h-12 w-44 rounded-md bg-surface-2 animate-pulse" />
+
+          {/* RIGHT: poster skeleton — same dimensions as the live poster */}
+          <div className="order-1 md:order-2">
+            {/* non-tokenized: max-w-[320px] aspect-2/3 poster primitives */}
+            <div className="mx-auto w-full max-w-[320px] aspect-2/3 rounded-lg bg-surface-2 animate-pulse" />
           </div>
         </div>
       </div>

--- a/frontend/web/components/PosterImage.tsx
+++ b/frontend/web/components/PosterImage.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+/**
+ * Movie poster with blur-up loading and a graceful error fallback.
+ *
+ * Loading: a tiny (48px, ~1KB) variant is shown immediately, blurred and
+ * scaled up, while the sharp target width loads on top. When the sharp image
+ * decodes it cross-fades in over the blur. This kills the "blank box then pop"
+ * lag for the right-sized (640px) posters.
+ *
+ * Error: if the sharp image fails (some catalogue posters 404), we render a
+ * film-icon placeholder on a surface tile instead of a broken-image glyph.
+ *
+ * Consumers pass the *original* catalogue URL; this component derives the tiny
+ * and target widths via `posterAt`. `fit` controls object-fit ("contain" for
+ * the main hero poster so nothing crops; "cover" for fixed-ratio rail cards).
+ *
+ * DSGN-06: tokens only (bg-surface-2, text-text-muted). The blur amount and the
+ * scale are non-tokenized visual primitives, marked inline.
+ */
+
+import { useState } from "react";
+import { Film } from "lucide-react";
+import { posterAt, type PosterWidth } from "@/lib/posters";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  /** Original catalogue poster URL (may be undefined / empty). */
+  src?: string;
+  alt: string;
+  /** Target render width. Defaults to "hero". */
+  width?: PosterWidth;
+  /** object-fit for the sharp image. Defaults to "cover". */
+  fit?: "cover" | "contain";
+  className?: string;
+};
+
+export function PosterImage({
+  src,
+  alt,
+  width = "hero",
+  fit = "cover",
+  className,
+}: Props) {
+  const [loaded, setLoaded] = useState(false);
+  const [errored, setErrored] = useState(false);
+  // Reset blur-up / error state when the source changes, using the
+  // adjust-state-while-rendering pattern (React docs) rather than an effect, so
+  // a new poster re-runs the load animation without a synchronous setState in
+  // an effect (react-hooks/set-state-in-effect).
+  const [prevSrc, setPrevSrc] = useState(src);
+  if (prevSrc !== src) {
+    setPrevSrc(src);
+    setLoaded(false);
+    setErrored(false);
+  }
+
+  // No usable source, or the sharp image failed → icon placeholder.
+  if (!src || errored) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center bg-surface-2 text-text-muted",
+          className,
+        )}
+        aria-label={alt}
+        role="img"
+      >
+        <Film size={32} aria-hidden />
+      </div>
+    );
+  }
+
+  const tiny = posterAt(src, "tiny");
+  const sharp = posterAt(src, width);
+  const objectFit = fit === "contain" ? "object-contain" : "object-cover";
+
+  return (
+    <div className={cn("relative overflow-hidden bg-surface-2", className)}>
+      {/* Tiny blurred placeholder — fades out once the sharp image is in. */}
+      {!loaded && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={tiny}
+          alt=""
+          aria-hidden
+          /* non-tokenized: blur-[14px] + scale-110 blur-up placeholder recipe */
+          className="absolute inset-0 w-full h-full object-cover blur-[14px] scale-110"
+        />
+      )}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={sharp}
+        alt={alt}
+        loading="lazy"
+        decoding="async"
+        onLoad={() => setLoaded(true)}
+        onError={() => setErrored(true)}
+        className={cn(
+          "relative w-full h-full transition-opacity duration-500 ease-out",
+          objectFit,
+          loaded ? "opacity-100" : "opacity-0",
+        )}
+      />
+    </div>
+  );
+}

--- a/frontend/web/components/SnackRecipeModal.tsx
+++ b/frontend/web/components/SnackRecipeModal.tsx
@@ -1,17 +1,29 @@
 "use client";
 
 /**
- * A two-state floating card shown while the recommendation fetch is in
- * flight: a centered recipe modal during loading, a small popcorn bubble
- * in the top-right when minimized. The two states are separate elements
- * cross-faded via opacity — no morphing layout, just fade-out / fade-in.
+ * A two-state floating card shown around the recommendation fetch: a recipe
+ * card anchored TOP-RIGHT while loading (and for a short linger after), then a
+ * small popcorn bubble in the same corner once it auto-collapses.
  *
- * `isLoading` from the consumer forces the open state. `userOpen` is the
- * self-managed re-open after a load completes. When loading kicks in again
- * (next /recommend fetch), userOpen resets so the modal re-opens centered.
+ * Why top-right (not centered): the /recommend fetch is very fast, so a centered
+ * modal used to flash in and out jarringly. Anchoring the card where the bubble
+ * lives means the open→mini transition is an in-place shrink, not a fly-across,
+ * and a brief post-fetch linger keeps the recipe readable even on a sub-second
+ * fetch.
+ *
+ * Timing:
+ *   - isLoading true            → card open (forced).
+ *   - isLoading true → false    → keep the card open for LINGER_MS, then
+ *                                 auto-collapse to the bubble.
+ *   - user clicks minimize      → collapse immediately (cancels the linger).
+ *   - user clicks the bubble    → re-open the card (stays until minimized).
+ *   - next fetch (isLoading true) → re-opens.
+ *
+ * The two visual states are separate elements cross-faded via opacity — no
+ * layout morphing.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ExternalLink, Minimize2, Popcorn } from "lucide-react";
 import type { SnackRecipe } from "@/lib/data/snack-recipes";
 import { cn } from "@/lib/utils";
@@ -21,23 +33,63 @@ type Props = {
   isLoading: boolean;
 };
 
+// How long the card lingers after a fetch completes before auto-collapsing.
+const LINGER_MS = 2500;
+
 export function SnackRecipeModal({ recipe, isLoading }: Props) {
-  const [userOpen, setUserOpen] = useState(false);
+  // The card is open when any of these hold:
+  //   - isLoading (derived from props — no state needed)
+  //   - lingering: the brief post-fetch hold before auto-collapse
+  //   - reopened: the user re-opened it from the bubble
+  // Minimizing clears lingering+reopened.
+  const [lingering, setLingering] = useState(false);
+  const [reopened, setReopened] = useState(false);
+  // Tracks the previous isLoading to detect the true→false edge during render
+  // (the React-recommended "adjust state while rendering" pattern — avoids
+  // synchronous setState inside an effect, i.e. react-hooks/set-state-in-effect).
+  const [prevLoading, setPrevLoading] = useState(isLoading);
+  const lingerTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  function clearLinger() {
+    if (lingerTimer.current) {
+      clearTimeout(lingerTimer.current);
+      lingerTimer.current = null;
+    }
+  }
+
+  // Edge-detect during render: when a fetch just finished, start lingering.
+  if (prevLoading !== isLoading) {
+    setPrevLoading(isLoading);
+    if (!isLoading) setLingering(true); // fetch settled → hold briefly
+  }
+
+  // The effect only SCHEDULES the collapse timer (and cleans it up). The
+  // setState happens in the timer callback, outside the render pass.
   useEffect(() => {
-    if (isLoading) setUserOpen(false);
-  }, [isLoading]);
+    if (!lingering) return;
+    lingerTimer.current = setTimeout(() => {
+      lingerTimer.current = null;
+      setLingering(false);
+    }, LINGER_MS);
+    return clearLinger;
+  }, [lingering]);
 
-  const open = isLoading || userOpen;
+  const open = isLoading || lingering || reopened;
+
+  function minimizeNow() {
+    clearLinger();
+    setLingering(false);
+    setReopened(false);
+  }
 
   return (
     <>
-      {/* Open state — centered recipe card */}
+      {/* Open state — recipe card, anchored top-right (in-place with the bubble). */}
       <div
         aria-hidden={!open}
         className={cn(
-          // non-tokenized: top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 centering recipe; w-[min(420px,92vw)] modal width primitive.
-          "fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[min(420px,92vw)] rounded-lg bg-surface-elevated border border-border-strong shadow-lg transition-opacity duration-300 ease-out",
+          // non-tokenized: top-6 right-6 anchor; w-[min(380px,92vw)] modal width primitive.
+          "fixed top-6 right-6 z-50 w-[min(380px,92vw)] rounded-lg bg-surface-elevated border border-border-strong shadow-lg transition-opacity duration-300 ease-out",
           open ? "opacity-100" : "opacity-0 pointer-events-none",
         )}
       >
@@ -50,10 +102,9 @@ export function SnackRecipeModal({ recipe, isLoading }: Props) {
             </p>
             <button
               type="button"
-              onClick={() => setUserOpen(false)}
-              disabled={isLoading}
+              onClick={minimizeNow}
               aria-label="Minimizar"
-              className="text-text-muted hover:text-text-primary transition-colors duration-150 disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2 rounded-sm"
+              className="text-text-muted hover:text-text-primary transition-colors duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2 rounded-sm"
             >
               <Minimize2 size={16} aria-hidden />
             </button>
@@ -87,15 +138,15 @@ export function SnackRecipeModal({ recipe, isLoading }: Props) {
         </div>
       </div>
 
-      {/* Mini state — top-right popcorn bubble */}
+      {/* Mini state — top-right popcorn bubble (same corner as the card). */}
       <button
         type="button"
         aria-hidden={open}
         aria-label="Ver receita"
         tabIndex={open ? -1 : 0}
-        onClick={() => setUserOpen(true)}
+        onClick={() => setReopened(true)}
         className={cn(
-          // non-tokenized: top-20 right-6 mini bubble position; w-14 h-14 mini bubble size primitive.
+          // non-tokenized: top-6 right-6 mini bubble position; w-14 h-14 mini bubble size primitive.
           "fixed top-6 right-6 z-50 w-14 h-14 rounded-full bg-surface-elevated border border-border-strong shadow-lg flex items-center justify-center text-accent hover:border-accent transition-opacity duration-300 ease-out focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2",
           open ? "opacity-0 pointer-events-none" : "opacity-100",
         )}

--- a/frontend/web/lib/posters.ts
+++ b/frontend/web/lib/posters.ts
@@ -1,0 +1,36 @@
+/**
+ * IMDb / Amazon media poster URL helpers.
+ *
+ * The catalogue stores every poster at `._V1_SX4000.jpg` — a ~4000px-wide image
+ * (~200KB+) for a thumbnail that renders at ~320px. That's the source of the
+ * "posters take a moment to load" lag. Amazon's media CDN lets us request a
+ * specific width by rewriting the `._V1_<spec>.jpg` segment, so we downscale to
+ * what we actually display.
+ *
+ * Widths we use:
+ *   - tiny  (48px)  : 1KB blur-up placeholder (instant)
+ *   - card  (300px) : similar-rail cards (~150px @2x)
+ *   - hero  (640px) : main recommendation poster (~320px @2x)
+ *
+ * If a URL doesn't match the rewritable pattern (defensive — not expected for
+ * the current catalogue) it's returned unchanged.
+ */
+
+const V1_RE = /\._V1_[A-Za-z0-9_,]+\.jpg$/i;
+
+export type PosterWidth = "tiny" | "card" | "hero";
+
+const SPEC: Record<PosterWidth, string> = {
+  tiny: "SX48",
+  card: "SX300",
+  hero: "SX640",
+};
+
+/**
+ * Rewrite an Amazon media poster URL to a target render width. No-op for URLs
+ * that don't carry the `._V1_…​.jpg` size segment.
+ */
+export function posterAt(url: string, width: PosterWidth): string {
+  if (!V1_RE.test(url)) return url;
+  return url.replace(V1_RE, `._V1_${SPEC[width]}.jpg`);
+}


### PR DESCRIPTION
… snack popup rework

Three UX fixes on the new recommendation screen:

1. Posters were served at _SX4000 (~4000px, ~214KB) for a ~320px slot — the source of the load lag. Add lib/posters.ts to rewrite the Amazon `._V1_` width segment to what we actually render (hero 640px ~58KB, card 300px ~19KB, tiny 48px ~1KB). The ambient blurred backdrop now uses the 1KB tiny variant.

2. New PosterImage component: blur-ups from the 1KB tiny variant to the sharp image (cross-fade on decode), and falls back to a film-icon tile when a poster 404s (some catalogue entries do). Wired into the hero poster (object-contain) and the similar-rail cards (object-cover).

3. SnackRecipeModal: the fast /recommend fetch made the centered modal flash in and out. It now anchors TOP-RIGHT (in-place with the bubble), stays through the fetch, lingers ~2.5s after it settles, then auto-collapses to the bubble. Edge-detection uses the adjust-state-while-rendering pattern (no synchronous setState in effects). Skeleton reworked to mirror the two-column poster-led layout so the skeleton→content swap doesn't shift.

Tokens-only (DSGN-06). Recommend tests still 10/10.